### PR TITLE
[AV-62050] Remove duplicate env variable set

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"os"
 	"terraform-provider-capella/internal/datasources"
 	"time"
 
@@ -106,19 +105,10 @@ func (p *capellaProvider) Configure(ctx context.Context, req provider.ConfigureR
 		return
 	}
 
-	// Default values to environment variables, but override
-	// with Terraform configuration value if set.
+	// Set the host and authentication token to be used
 
-	host := os.Getenv("CAPELLA_HOST")
-	authenticationToken := os.Getenv("CAPELLA_AUTHENTICATION_TOKEN")
-
-	if !config.Host.IsNull() {
-		host = config.Host.ValueString()
-	}
-
-	if !config.AuthenticationToken.IsNull() {
-		authenticationToken = config.AuthenticationToken.ValueString()
-	}
+	host := config.Host.ValueString()
+	authenticationToken := config.AuthenticationToken.ValueString()
 
 	// If any of the expected configurations are missing, return
 	// error with provider-specific guidance.
@@ -127,7 +117,7 @@ func (p *capellaProvider) Configure(ctx context.Context, req provider.ConfigureR
 			path.Root(capellaPublicAPIHostField),
 			"Missing Capella Public API Host",
 			"The provider cannot create the Capella API client as there is a missing or empty value for the Capella API host. "+
-				"Set the host value in the configuration or use the CAPELLA_HOST environment variable. "+
+				"Set the host value in the configuration or use the TF_VAR_host environment variable. "+
 				"If either is already set, ensure the value is not empty.",
 		)
 	}
@@ -137,7 +127,7 @@ func (p *capellaProvider) Configure(ctx context.Context, req provider.ConfigureR
 			path.Root(capellaAuthenticationTokenField),
 			"Missing Capella Authentication Token",
 			"The provider cannot create the Capella API client as there is a missing or empty value for the capella authentication token. "+
-				"Set the password value in the configuration or use the CAPELLA_AUTHENTICATION_TOKEN environment variable. "+
+				"Set the password value in the configuration or use the TF_VAR_auth_token environment variable. "+
 				"If either is already set, ensure the value is not empty.",
 		)
 	}


### PR DESCRIPTION
https://couchbasecloud.atlassian.net/browse/AV-62050

There are currently two ways that environment variables are being set. 

We should deprecate auth token and host being retrieved directly from os and only adhere to the best practice method. Please read the ticket description for more details. 

Manual testing evidence: 

Successful error when variables are not set
```
│ Error: Missing Capella Public API Host
│ 
│   with provider["hashicorp.com/couchabasecloud/capella"],
│   on main.tf line 10, in provider "capella":
│   10:   host                 = var.host
│ 
│ The provider cannot create the Capella API client as there is a missing or empty value for the Capella API host. Set the host value in the configuration or use the
│ TF_VAR_host environment variable. If either is already set, ensure the value is not empty.
╵
╷
│ Error: Missing Capella Authentication Token
│ 
│   with provider["hashicorp.com/couchabasecloud/capella"],
│   on main.tf line 11, in provider "capella":
│   11:   authentication_token = var.auth_token
│ 
│ The provider cannot create the Capella API client as there is a missing or empty value for the capella authentication token. Set the password value in the configuration or
│ use the TF_VAR_auth_token environment variable. If either is already set, ensure the value is not empty.
```