### PR TITLE
[AV-62833] Improvements to provider readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Ordinarily, terraform will downloaded the requested providers on running the com
 ```bash
 $ terraform init
 ```
-As we are working with a local install of `Terraform-Provider-Capella` this command is not needed and considered optional. 
+If you are working with a local install of `Terraform-Provider-Capella` provider, this step is not needed and considered optional. 
 However if you plan to use any other providers at the same time it may need to be ran. 
 
 **1\. Review the Terraform plan**


### PR DESCRIPTION
Updates to the README according to feedback from https://couchbasecloud.atlassian.net/browse/AV-62833

I have renamed all terraform.template.tfvars files to terraform.tfvars. Using .template meant that the -var-file flag had to be used to run terraform plan and terraform apply.

Have manually verified that the variables are now retrieved without the var flag