### PR TITLE
[AV-65073] Terraform Bugs - Change min terraform version in readme to 1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the repository for Couchbase's Terraform-Provider-Capella which forms a 
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) >= 1.0
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.5.2
 - [Go](https://golang.org/doc/install) >= 1.20
 
 ## Using the provider


### PR DESCRIPTION
The minimum terraform version to be supported as per the PRD is 1.5.2. This change updates the readme to reflect this. 