### PR TITLE
[AV-64976] User refresh state for users deleted from UI

### DIFF
--- a/docs/data-sources/certificate.md
+++ b/docs/data-sources/certificate.md
@@ -23,4 +23,11 @@ description: |-
 
 ### Read-Only
 
+- `data` (Attributes List) (see [below for nested schema](#nestedatt--data))
+
+<a id="nestedatt--data"></a>
+### Nested Schema for `data`
+
+Read-Only:
+
 - `certificate` (String)

--- a/docs/resources/allowlist.md
+++ b/docs/resources/allowlist.md
@@ -26,7 +26,6 @@ description: |-
 
 - `comment` (String)
 - `expires_at` (String)
-- `if_match` (String)
 
 ### Read-Only
 

--- a/docs/resources/bucket.md
+++ b/docs/resources/bucket.md
@@ -24,14 +24,14 @@ description: |-
 
 ### Optional
 
-- `conflict_resolution` (String)
+- `bucket_conflict_resolution` (String)
 - `durability_level` (String)
 - `eviction_policy` (String)
 - `flush` (Boolean)
-- `memory_allocationinmb` (Number)
+- `memory_allocation_in_mb` (Number)
 - `replicas` (Number)
 - `storage_backend` (String)
-- `ttl` (Number)
+- `time_to_live_in_seconds` (Number)
 - `type` (String)
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/google/uuid v1.3.1
-	github.com/hashicorp/terraform-plugin-framework v1.4.0
+	github.com/hashicorp/terraform-plugin-framework v1.4.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/stretchr/testify v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/hashicorp/terraform-plugin-docs v0.16.0 h1:UmxFr3AScl6Wged84jndJIfFcc
 github.com/hashicorp/terraform-plugin-docs v0.16.0/go.mod h1:M3ZrlKBJAbPMtNOPwHicGi1c+hZUh7/g0ifT/z7TVfA=
 github.com/hashicorp/terraform-plugin-framework v1.4.0 h1:WKbtCRtNrjsh10eA7NZvC/Qyr7zp77j+D21aDO5th9c=
 github.com/hashicorp/terraform-plugin-framework v1.4.0/go.mod h1:XC0hPcQbBvlbxwmjxuV/8sn8SbZRg4XwGMs22f+kqV0=
+github.com/hashicorp/terraform-plugin-framework v1.4.1 h1:ZC29MoB3Nbov6axHdgPbMz7799pT5H8kIrM8YAsaVrs=
+github.com/hashicorp/terraform-plugin-framework v1.4.1/go.mod h1:XC0hPcQbBvlbxwmjxuV/8sn8SbZRg4XwGMs22f+kqV0=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.19.0 h1:BuZx/6Cp+lkmiG0cOBk6Zps0Cb2tmqQpDM3iAtnhDQU=

--- a/internal/datasources/users.go
+++ b/internal/datasources/users.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -113,6 +114,8 @@ func (d *Users) Read(ctx context.Context, req datasource.ReadRequest, resp *data
 			)
 			return
 		}
+		tflog.Info(ctx, "resource doesn't exist in remote server removing resource from state file")
+		resp.State.RemoveResource(ctx)
 		return
 	default:
 		resp.Diagnostics.AddError(

--- a/internal/resources/user.go
+++ b/internal/resources/user.go
@@ -285,7 +285,7 @@ func (r *User) getUser(ctx context.Context, organizationId, userId string) (*api
 		nil,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %v", errors.ErrExecutingRequest, err)
+		return nil, err
 	}
 
 	userResp := api.GetUserResponse{}
@@ -299,7 +299,7 @@ func (r *User) getUser(ctx context.Context, organizationId, userId string) (*api
 func (r *User) refreshUser(ctx context.Context, organizationId, userId string, plan providerschema.User) (*providerschema.User, error) {
 	userResp, err := r.getUser(ctx, organizationId, userId)
 	if err != nil {
-		return nil, handleCapellaUserError(err)
+		return nil, err
 	}
 
 	audit := providerschema.NewCouchbaseAuditData(userResp.Audit)


### PR DESCRIPTION
https://couchbasecloud.atlassian.net/browse/AV-64976

1. Remove the resource from state when the user is deleted from UI. 
2. Upgrades `terraform-plugin-framework` to 1.4.1
3. Updated generated docs files. 


```
terraform plan 
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp.com/couchabasecloud/capella in /Users/nidhi.kumar/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
data.capella_users.existing_users: Reading...
capella_user.new_user: Refreshing state... [id=165233df-c490-4212-b9ca-a030551b8d70]
data.capella_users.existing_users: Read complete after 2s

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have affected this plan:

  # capella_user.new_user has been deleted
  - resource "capella_user" "new_user" {
      - audit                = {
          - created_at  = "2023-10-13 10:54:22.723953525 +0000 UTC" -> null
          - created_by  = "165233df-c490-4212-b9ca-a030551b8d70" -> null
          - modified_at = "2023-10-13 10:54:22.723953525 +0000 UTC" -> null
          - modified_by = "165233df-c490-4212-b9ca-a030551b8d70" -> null
          - version     = 1 -> null
        } -> null
      - email                = "johndoe@couchbase.com" -> null
      - enable_notifications = false -> null
      - expires_at           = "2024-01-11T10:54:22.723954493Z" -> null
      - id                   = "165233df-c490-4212-b9ca-a030551b8d70" -> null
      - inactive             = true -> null
      - name                 = "John Doe" -> null
      - organization_id      = "6af08c0a-8cab-4c1c-b257-b521575c16d0" -> null
      - organization_roles   = [
          - "organizationMember",
        ] -> null
      - resources            = [
          - {
              - id    = "f14134f2-7943-4e7b-b2c5-fc2071728b6e" -> null
              - roles = [
                  - "projectViewer",
                ] -> null
              - type  = "project" -> null
            },
          - {
              - id    = "f14134f2-7943-4e7b-b2c5-fc2071728b6e" -> null
              - roles = [
                  - "projectDataReaderWriter",
                ] -> null
              - type  = "project" -> null
            },
        ] -> null
      - status               = "not-verified" -> null
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to
undo or respond to these changes.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # capella_user.new_user will be created
  + resource "capella_user" "new_user" {
      + audit                = (known after apply)
      + email                = "johndoe@couchbase.com"
      + enable_notifications = (known after apply)
      + expires_at           = (known after apply)
      + id                   = (known after apply)
      + inactive             = (known after apply)
      + last_login           = (known after apply)
      + name                 = "John Doe"
      + organization_id      = "6af08c0a-8cab-4c1c-b257-b521575c16d0"
      + organization_roles   = [
          + "organizationMember",
        ]
      + region               = (known after apply)
      + resources            = [
          + {
              + id    = "f14134f2-7943-4e7b-b2c5-fc2071728b6e"
              + roles = [
                  + "projectViewer",
                ]
              + type  = "project"
            },
          + {
              + id    = "f14134f2-7943-4e7b-b2c5-fc2071728b6e"
              + roles = [
                  + "projectDataReaderWriter",
                ]
              + type  = "project"
            },
        ]
      + status               = (known after apply)
      + time_zone            = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```


