### PR TITLE
[AV-65076] Fixed template.tfvars files for examples

### DIFF
--- a/examples/cluster/terraform.template.tfvars
+++ b/examples/cluster/terraform.template.tfvars
@@ -1,6 +1,7 @@
 auth_token      = "<v4-api-key-secret>"
 organization_id = "<organization_id>"
 host            = "https://cloudapi.cloud.couchbase.com"
+project_id      = "<project_id>"
 
 cloud_provider = {
   name   = "aws",

--- a/examples/database_credential/terraform.template.tfvars
+++ b/examples/database_credential/terraform.template.tfvars
@@ -3,5 +3,8 @@ organization_id          = "<organization_id>"
 project_id               = "<project_id>"
 host                     = "https://cloudapi.cloud.couchbase.com"
 database_credential_name = "test_db_user"
-cluster_id               = "546caf5b-f495-45fc-93e5-7a40e0ee2a17"
+cluster_id               = "<cluster_id>"
 password                 = "Secret12$#"
+access = [{
+  privileges = ["data_reader", "data_writer"]
+}]

--- a/internal/resources/bucket.go
+++ b/internal/resources/bucket.go
@@ -100,11 +100,11 @@ func (c *Bucket) Create(ctx context.Context, req resource.CreateRequest, resp *r
 		c.Token,
 		nil,
 	)
-	_, err = handleClusterError(err)
+	_, err = handleBucketError(err)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating bucket",
-			"Could not create bucket, unexpected error: "+string(response.Body),
+			"Could not create bucket, unexpected error: "+err.Error(),
 		)
 		return
 	}


### PR DESCRIPTION
https://couchbasecloud.atlassian.net/browse/AV-65076

1. Updated template.tfvars files for examples. 
2. Fixed invalid bucket payload errors. 

```
capella_bucket.new_bucket: Creating...
╷
│ Error: Error creating bucket
│ 
│   with capella_bucket.new_bucket,
│   on create_bucket.tf line 5, in resource "capella_bucket" "new_bucket":
│    5: resource "capella_bucket" "new_bucket" {
│ 
│ Could not create bucket, unexpected error: {"code":6021,"hint":"The provided evictionPolicy is an invalid configuration option for Couchbase (Memory and Disk)
│ buckets. Please specify 'fullEviction', or remove the evictionPolicy payload from the request to use the default
│ ('fullEviction').","httpStatusCode":422,"message":"The provided evictionPolicy of 'noEviction' is invalid for Couchbase buckets. evictionPolicy must be
│ 'fullEviction' or left empty to use default (fullEviction)."}
╵
```