### PR TITLE
[AV-65771] List APIs - Projects pagination

### DIFF
--- a/internal/api/project.go
+++ b/internal/api/project.go
@@ -66,18 +66,3 @@ type PutProjectRequest struct {
 	// Name is the name of the project.
 	Name string `json:"name"`
 }
-
-// GetProjectsResponse is the response received from the Capella V4 Public API when asked to list all projects in an organization.
-//
-// In order to access this endpoint, the provided API key must have at least one of the following roles:
-//
-// Organization Owner
-// Project Owner
-// Project Manager
-// Project Viewer
-// Database Data Reader/Writer
-// Database Data Reader
-// To learn more, see https://docs.couchbase.com/cloud/organizations/organization-projects-overview.html
-type GetProjectsResponse struct {
-	Data []GetProjectResponse `json:"data"`
-}


### PR DESCRIPTION
This PR handles pagination for the projects datasource. 

Manual testing: 

```
  + projects_list = {
      + data            = [
          + {
              + audit           = {
                  + created_at  = "2023-10-31 08:48:08.774881592 +0000 UTC"
                  + created_by  = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + modified_at = "2023-10-31 08:48:08.774900717 +0000 UTC"
                  + modified_by = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + version     = 1
                }
              + description     = ""
              + etag            = null
              + id              = "01d4b111-d568-48b3-9d2a-9cf02c3bd27c"
              + if_match        = null
              + name            = "9"
              + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
            },
          + {
              + audit           = {
                  + created_at  = "2023-10-31 08:48:11.779971969 +0000 UTC"
                  + created_by  = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + modified_at = "2023-10-31 08:48:11.780006219 +0000 UTC"
                  + modified_by = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + version     = 1
                }
              + description     = ""
              + etag            = null
              + id              = "1863270d-088f-4c47-bbb9-4f2c1f6b2bdb"
              + if_match        = null
              + name            = "10"
              + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
            },
          + {
              + audit           = {
                  + created_at  = "2023-10-31 08:47:51.956241376 +0000 UTC"
                  + created_by  = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + modified_at = "2023-10-31 08:47:51.956265667 +0000 UTC"
                  + modified_by = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + version     = 1
                }
              + description     = ""
              + etag            = null
              + id              = "3e4e093d-05d4-4c43-90b0-e88178a17217"
              + if_match        = null
              + name            = "3"
              + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
            },
          + {
              + audit           = {
                  + created_at  = "2023-10-31 08:47:39.299391176 +0000 UTC"
                  + created_by  = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + modified_at = "2023-10-31 08:47:39.299401134 +0000 UTC"
                  + modified_by = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + version     = 1
                }
              + description     = ""
              + etag            = null
              + id              = "5429af02-1c40-4485-af9a-4e5e45ae7c9b"
              + if_match        = null
              + name            = "1"
              + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
            },
          + {
              + audit           = {
                  + created_at  = "2023-10-31 08:47:48.880902597 +0000 UTC"
                  + created_by  = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + modified_at = "2023-10-31 08:47:48.880917222 +0000 UTC"
                  + modified_by = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + version     = 1
                }
              + description     = ""
              + etag            = null
              + id              = "5a1aef50-0422-4c93-a7e0-2596b23ef1b1"
              + if_match        = null
              + name            = "2"
              + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
            },
          + {
              + audit           = {
                  + created_at  = "2023-10-31 08:48:00.308062338 +0000 UTC"
                  + created_by  = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + modified_at = "2023-10-31 08:48:00.308081255 +0000 UTC"
                  + modified_by = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + version     = 1
                }
              + description     = ""
              + etag            = null
              + id              = "5e8384c0-4205-4c04-8b8a-f2237043783a"
              + if_match        = null
              + name            = "6"
              + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
            },
          + {
              + audit           = {
                  + created_at  = "2023-10-31 08:47:57.613893253 +0000 UTC"
                  + created_by  = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + modified_at = "2023-10-31 08:47:57.613907045 +0000 UTC"
                  + modified_by = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + version     = 1
                }
              + description     = ""
              + etag            = null
              + id              = "9dded765-4621-4210-a4e7-e5fe12024ada"
              + if_match        = null
              + name            = "5"
              + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
            },
          + {
              + audit           = {
                  + created_at  = "2023-10-31 08:48:06.097276882 +0000 UTC"
                  + created_by  = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + modified_at = "2023-10-31 08:48:06.097289882 +0000 UTC"
                  + modified_by = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + version     = 1
                }
              + description     = ""
              + etag            = null
              + id              = "b929d3f8-9ef3-4146-b3ab-0876afc92308"
              + if_match        = null
              + name            = "8"
              + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
            },
          + {
              + audit           = {
                  + created_at  = "2023-10-31 08:47:54.671516294 +0000 UTC"
                  + created_by  = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + modified_at = "2023-10-31 08:47:54.671531877 +0000 UTC"
                  + modified_by = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + version     = 1
                }
              + description     = ""
              + etag            = null
              + id              = "daeb0a3a-1a8f-4e83-a96c-286684fe29c4"
              + if_match        = null
              + name            = "4"
              + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
            },
          + {
              + audit           = {
                  + created_at  = "2023-10-31 08:48:03.42895184 +0000 UTC"
                  + created_by  = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + modified_at = "2023-10-31 08:48:03.428966131 +0000 UTC"
                  + modified_by = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + version     = 1
                }
              + description     = ""
              + etag            = null
              + id              = "e4173568-127e-427d-b6fd-8f97491690af"
              + if_match        = null
              + name            = "7"
              + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
            },
          + {
              + audit           = {
                  + created_at  = "2023-10-31 08:48:14.638252095 +0000 UTC"
                  + created_by  = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + modified_at = "2023-10-31 08:48:14.638272637 +0000 UTC"
                  + modified_by = "be8ee852-55ce-4283-babe-998f5f0afa92"
                  + version     = 1
                }
              + description     = ""
              + etag            = null
              + id              = "eda42c5e-4e6b-4c91-b796-c08d28752ec8"
              + if_match        = null
              + name            = "11"
              + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
            },
        ]
      + organization_id = "ce0d4684-34f2-4c84-8ae2-6ee863085024"
    }

───────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take
exactly these actions if you run "terraform apply" now.
```