### PR TITLE
[AV-66360] PP Bugs - Make resource object optional

### DIFF
--- a/internal/datasources/users.go
+++ b/internal/datasources/users.go
@@ -57,7 +57,7 @@ func (d *Users) Schema(_ context.Context, _ datasource.SchemaRequest, resp *data
 						"enable_notifications": computedBoolAttribute,
 						"expires_at":           computedStringAttribute,
 						"resources": schema.ListNestedAttribute{
-							Required: true,
+							Computed: true,
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"type":  computedStringAttribute,

--- a/internal/resources/user_schema.go
+++ b/internal/resources/user_schema.go
@@ -20,7 +20,7 @@ func UserSchema() schema.Schema {
 			"enable_notifications": boolAttribute(computed, requiresReplace),
 			"expires_at":           stringAttribute(computed, requiresReplace),
 			"resources": schema.ListNestedAttribute{
-				Required: true,
+				Optional: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"type":  stringAttribute(optional, requiresReplace),


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-66360](https://couchbasecloud.atlassian.net/browse/AV-66360)

## Description

<!-- What does this change do? Why is it needed? -->

CP-Open-API states that “When performing a GET request for a user with an organization owner role, the response will exclude project-level permissions for that user. This is because organization owners have access to all resources at the organization level, rendering project-level permissions unnecessary for them.”

Prior to this change, designating a user as an organizationOwner and not adding a resource object would cause an error. This changes makes resources optional (as per the API)

## Maturity Assessment

- [ ] 0. Prototype
- [ ] 1. Make it work
- [x] 2. Make it right
- [ ] 3. Make it delightful
- [ ] N/A

## Area impacted

- [x] Resource
- [ ] Data source
- [ ] Documentation
- [ ] Other (Please comment)

<!-- Tick this box if this PR introduces a breaking change -->
- [ ] Breaking change

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] E2E tested
- [ ] Unable to test / will not test (Please provide comments in section below)


### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

```
output "new_user" {
  value = capella_user.new_user
}

resource "capella_user" "new_user" {
  organization_id = var.organization_id

  name  = var.user_name
  email = var.email

  organization_roles = [
    "organizationOwner"
  ]
}
```

```
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

new_user = {
  "audit" = {
    "created_at" = "2023-11-01 09:15:51.550976248 +0000 UTC"
    "created_by" = "7106d5c9-da50-4ce8-8c5b-be37df75986b"
    "modified_at" = "2023-11-01 09:15:51.550976248 +0000 UTC"
    "modified_by" = "7106d5c9-da50-4ce8-8c5b-be37df75986b"
    "version" = 1
  }
  "email" = "matty.maclean+100@couchbase.com"
  "enable_notifications" = false
  "expires_at" = "2024-01-30T09:15:51.550976717Z"
  "id" = "7106d5c9-da50-4ce8-8c5b-be37df75986b"
  "inactive" = true
  "last_login" = ""
  "name" = "Matty"
  "organization_id" = "1a3c4544-772e-449e-9996-1203e7020b96"
  "organization_roles" = tolist([
    "organizationOwner",
  ])
  "region" = ""
  "resources" = tolist(null) /* of object */
  "status" = "not-verified"
  "time_zone" = ""
}
```
</details>
