### PR TITLE
[AV-68914] Bug - Move type outside of generic function

### DIFF
--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -58,6 +58,13 @@ const (
 	SortByName = "name"
 )
 
+// overlay is a generic struct used to store data and cursor
+// information from paginated responses.
+type overlay[DataSchema any] struct {
+	Data   DataSchema `json:"data"`
+	Cursor Cursor     `json:"cursor"`
+}
+
 // GetPaginated is a generic function used to handle pagination. It executes a get request
 // according to the supplied url parameter. It then iterates through remaining pages to
 // flatten paginated responses into a single slice of responses.
@@ -75,11 +82,6 @@ func GetPaginated[DataSchema ~[]T, T any](
 		baseUrl   = cfg.Url
 	)
 
-	type overlay struct {
-		Data   DataSchema `json:"data"`
-		Cursor Cursor     `json:"cursor"`
-	}
-
 	for {
 		cfg.Url = baseUrl + fmt.Sprintf("?page=%d&perPage=%d&sortBy=%s", page, perPage, string(sortBy))
 		cfg.Method = http.MethodGet
@@ -95,7 +97,7 @@ func GetPaginated[DataSchema ~[]T, T any](
 			return nil, fmt.Errorf("%s: %w", errors.ErrExecutingRequest, err)
 		}
 
-		var decoded overlay
+		var decoded overlay[DataSchema]
 		err = json.Unmarshal(response.Body, &decoded)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", errors.ErrUnmarshallingResponse, err)


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-68914

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
<!-- What does this change do? Why is it needed? -->

Types cannot be declared within a generic function. This change is needed to avoid potential compilation error. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

Successful paginated response for user

```
Terraform will perform the following actions:

  # couchbase-capella_user.new_user will be created
  + resource "couchbase-capella_user" "new_user" {
      + audit                = (known after apply)
      + email                = "john.doe@couchbase.com"
      + enable_notifications = (known after apply)
      + expires_at           = (known after apply)
      + id                   = (known after apply)
      + inactive             = (known after apply)
      + last_login           = (known after apply)
      + name                 = "John ABC"
      + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
      + organization_roles   = [
          + "organizationMember",
        ]
      + region               = (known after apply)
      + resources            = [
          + {
              + id    = "81f8e9e4-6d5b-4cae-a2f7-630218713767"
              + roles = [
                  + "projectDataReaderWriter",
                  + "projectViewer",
                ]
              + type  = "project"
            },
        ]
      + status               = (known after apply)
      + time_zone            = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + new_user   = {
      + audit                = (known after apply)
      + email                = "john.doe@couchbase.com"
      + enable_notifications = (known after apply)
      + expires_at           = (known after apply)
      + id                   = (known after apply)
      + inactive             = (known after apply)
      + last_login           = (known after apply)
      + name                 = "John ABC"
      + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
      + organization_roles   = [
          + "organizationMember",
        ]
      + region               = (known after apply)
      + resources            = [
          + {
              + id    = "81f8e9e4-6d5b-4cae-a2f7-630218713767"
              + roles = [
                  + "projectDataReaderWriter",
                  + "projectViewer",
                ]
              + type  = "project"
            },
        ]
      + status               = (known after apply)
      + time_zone            = (known after apply)
    }
  + user_id    = (known after apply)
  + users_list = {
      + data            = [
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:49:14.006443966 +0000 UTC"
                  + created_by  = "186ca3c2-ca3a-4434-b5fc-358fd3ceed8e"
                  + modified_at = "2023-12-07 14:49:14.006443966 +0000 UTC"
                  + modified_by = "186ca3c2-ca3a-4434-b5fc-358fd3ceed8e"
                  + version     = 1
                }
              + email                = "matty.maclean+10@couchbase.com"
              + enable_notifications = false
              + expires_at           = "2024-03-06T14:49:14.006444549Z"
              + id                   = "186ca3c2-ca3a-4434-b5fc-358fd3ceed8e"
              + inactive             = true
              + last_login           = ""
              + name                 = ""
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "not-verified"
              + time_zone            = ""
            },
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:49:10.828428381 +0000 UTC"
                  + created_by  = "2a3b97d3-5fab-4093-869a-f412f6a78395"
                  + modified_at = "2023-12-07 14:49:10.828428381 +0000 UTC"
                  + modified_by = "2a3b97d3-5fab-4093-869a-f412f6a78395"
                  + version     = 1
                }
              + email                = "matty.maclean+7@couchbase.com"
              + enable_notifications = false
              + expires_at           = "2024-03-06T14:49:10.828428715Z"
              + id                   = "2a3b97d3-5fab-4093-869a-f412f6a78395"
              + inactive             = true
              + last_login           = ""
              + name                 = ""
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "not-verified"
              + time_zone            = ""
            },
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:49:15.0896698 +0000 UTC"
                  + created_by  = "4e1fffc3-d54c-4a8b-84ce-5e86680e6a70"
                  + modified_at = "2023-12-07 14:49:15.0896698 +0000 UTC"
                  + modified_by = "4e1fffc3-d54c-4a8b-84ce-5e86680e6a70"
                  + version     = 1
                }
              + email                = "matty.maclean+11@couchbase.com"
              + enable_notifications = false
              + expires_at           = "2024-03-06T14:49:15.0896703Z"
              + id                   = "4e1fffc3-d54c-4a8b-84ce-5e86680e6a70"
              + inactive             = true
              + last_login           = ""
              + name                 = ""
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "not-verified"
              + time_zone            = ""
            },
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:49:16.154112342 +0000 UTC"
                  + created_by  = "68e31669-0da7-4172-8f65-d264083b7c00"
                  + modified_at = "2023-12-07 14:49:16.154112342 +0000 UTC"
                  + modified_by = "68e31669-0da7-4172-8f65-d264083b7c00"
                  + version     = 1
                }
              + email                = "matty.maclean+12@couchbase.com"
              + enable_notifications = false
              + expires_at           = "2024-03-06T14:49:16.1541128Z"
              + id                   = "68e31669-0da7-4172-8f65-d264083b7c00"
              + inactive             = true
              + last_login           = ""
              + name                 = ""
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "not-verified"
              + time_zone            = ""
            },
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:17:14.730506258 +0000 UTC"
                  + created_by  = "6e8a231c-b334-420d-b7f1-0ad0f27782e8"
                  + modified_at = "2023-12-07 14:17:14.730506258 +0000 UTC"
                  + modified_by = "6e8a231c-b334-420d-b7f1-0ad0f27782e8"
                  + version     = 1
                }
              + email                = "matty.maclean@couchbase.com"
              + enable_notifications = true
              + expires_at           = "2024-03-06T14:45:14.001872633Z"
              + id                   = "6e8a231c-b334-420d-b7f1-0ad0f27782e8"
              + inactive             = false
              + last_login           = "2023-12-07T14:57:27.287433166Z"
              + name                 = "matty.maclean"
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "verified"
              + time_zone            = ""
            },
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:49:12.932238216 +0000 UTC"
                  + created_by  = "6ec3cc83-2da1-443c-8ec8-14f2601608a2"
                  + modified_at = "2023-12-07 14:49:12.932238216 +0000 UTC"
                  + modified_by = "6ec3cc83-2da1-443c-8ec8-14f2601608a2"
                  + version     = 1
                }
              + email                = "matty.maclean+9@couchbase.com"
              + enable_notifications = false
              + expires_at           = "2024-03-06T14:49:12.932239424Z"
              + id                   = "6ec3cc83-2da1-443c-8ec8-14f2601608a2"
              + inactive             = true
              + last_login           = ""
              + name                 = ""
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "not-verified"
              + time_zone            = ""
            },
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:49:06.526772712 +0000 UTC"
                  + created_by  = "9c8d13a6-b80b-473e-9349-145ddfdef23f"
                  + modified_at = "2023-12-07 14:49:06.526772712 +0000 UTC"
                  + modified_by = "9c8d13a6-b80b-473e-9349-145ddfdef23f"
                  + version     = 1
                }
              + email                = "matty.maclean+3@couchbase.com"
              + enable_notifications = false
              + expires_at           = "2024-03-06T14:49:06.526773212Z"
              + id                   = "9c8d13a6-b80b-473e-9349-145ddfdef23f"
              + inactive             = true
              + last_login           = ""
              + name                 = ""
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "not-verified"
              + time_zone            = ""
            },
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:49:07.601253588 +0000 UTC"
                  + created_by  = "9de38b6d-31a3-46e1-ae63-5756674f20b1"
                  + modified_at = "2023-12-07 14:49:07.601253588 +0000 UTC"
                  + modified_by = "9de38b6d-31a3-46e1-ae63-5756674f20b1"
                  + version     = 1
                }
              + email                = "matty.maclean+4@couchbase.com"
              + enable_notifications = false
              + expires_at           = "2024-03-06T14:49:07.601253963Z"
              + id                   = "9de38b6d-31a3-46e1-ae63-5756674f20b1"
              + inactive             = true
              + last_login           = ""
              + name                 = ""
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "not-verified"
              + time_zone            = ""
            },
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:49:11.876351382 +0000 UTC"
                  + created_by  = "a70f8bd0-b5dd-47aa-919e-aa3317c543fc"
                  + modified_at = "2023-12-07 14:49:11.876351382 +0000 UTC"
                  + modified_by = "a70f8bd0-b5dd-47aa-919e-aa3317c543fc"
                  + version     = 1
                }
              + email                = "matty.maclean+8@couchbase.com"
              + enable_notifications = false
              + expires_at           = "2024-03-06T14:49:11.876351757Z"
              + id                   = "a70f8bd0-b5dd-47aa-919e-aa3317c543fc"
              + inactive             = true
              + last_login           = ""
              + name                 = ""
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "not-verified"
              + time_zone            = ""
            },
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:48:25.072984346 +0000 UTC"
                  + created_by  = "ab32558d-9427-4664-8303-29299cbf1729"
                  + modified_at = "2023-12-07 14:48:25.072984346 +0000 UTC"
                  + modified_by = "ab32558d-9427-4664-8303-29299cbf1729"
                  + version     = 1
                }
              + email                = "matty.maclean+2@couchbase.com"
              + enable_notifications = false
              + expires_at           = "2024-03-06T14:48:25.072984888Z"
              + id                   = "ab32558d-9427-4664-8303-29299cbf1729"
              + inactive             = true
              + last_login           = ""
              + name                 = ""
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "not-verified"
              + time_zone            = ""
            },
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:49:09.754362506 +0000 UTC"
                  + created_by  = "d21c57cd-71c5-4a9a-a6da-f38a05b13073"
                  + modified_at = "2023-12-07 14:49:09.754362506 +0000 UTC"
                  + modified_by = "d21c57cd-71c5-4a9a-a6da-f38a05b13073"
                  + version     = 1
                }
              + email                = "matty.maclean+6@couchbase.com"
              + enable_notifications = false
              + expires_at           = "2024-03-06T14:49:09.754363256Z"
              + id                   = "d21c57cd-71c5-4a9a-a6da-f38a05b13073"
              + inactive             = true
              + last_login           = ""
              + name                 = ""
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "not-verified"
              + time_zone            = ""
            },
          + {
              + audit                = {
                  + created_at  = "2023-12-07 14:49:08.675384838 +0000 UTC"
                  + created_by  = "da73f8df-9c50-4d18-80bc-037557b7ebb7"
                  + modified_at = "2023-12-07 14:49:08.675384838 +0000 UTC"
                  + modified_by = "da73f8df-9c50-4d18-80bc-037557b7ebb7"
                  + version     = 1
                }
              + email                = "matty.maclean+5@couchbase.com"
              + enable_notifications = false
              + expires_at           = "2024-03-06T14:49:08.675385255Z"
              + id                   = "da73f8df-9c50-4d18-80bc-037557b7ebb7"
              + inactive             = true
              + last_login           = ""
              + name                 = ""
              + organization_id      = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
              + organization_roles   = [
                  + "organizationOwner",
                ]
              + region               = ""
              + resources            = null
              + status               = "not-verified"
              + time_zone            = ""
            },
        ]
      + organization_id = "ed86f90c-5e14-4880-b4c3-528880e54d0f"
    }
```
</details>

## Required Checklist:

- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if required)
- [ ] I have run make fmt and formatted my code

## Further comments