### PR TITLE
[AV 65759] Fix acceptance tests apikeys

### DIFF
--- a/internal/resources/acceptance_tests/apikey_acceptance_test.go
+++ b/internal/resources/acceptance_tests/apikey_acceptance_test.go
@@ -20,13 +20,13 @@ func TestAccApiKeyResource(t *testing.T) {
 	resourceReference := "couchbase-capella_apikey." + resourceName
 	projectResourceName := "acc_project_" + acctest.GenerateRandomResourceName()
 	projectResourceReference := "couchbase-capella_project." + projectResourceName
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccApiKeyResourceConfig(acctest.Cfg, resourceName, projectResourceName, projectResourceReference),
+				Config: testAccApiKeyResourceConfig(acctest.ProjectCfg, resourceName, projectResourceName, projectResourceReference),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsApiKeyResource(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
@@ -57,13 +57,13 @@ func TestAccApiKeyResourceWithMultipleResources(t *testing.T) {
 	resourceReference := "couchbase-capella_apikey." + resourceName
 	projectResourceName := "acc_project_" + acctest.GenerateRandomResourceName()
 	projectResourceReference := "couchbase-capella_project." + projectResourceName
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccApiKeyResourceConfigWithMultipleResources(acctest.Cfg, resourceName, projectResourceName, projectResourceReference),
+				Config: testAccApiKeyResourceConfigWithMultipleResources(acctest.ProjectCfg, resourceName, projectResourceName, projectResourceReference),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsApiKeyResource(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
@@ -73,11 +73,11 @@ func TestAccApiKeyResourceWithMultipleResources(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "allowed_cidrs.1", "10.1.42.1/23"),
 					resource.TestCheckResourceAttr(resourceReference, "organization_roles.0", "organizationMember"),
 					resource.TestCheckResourceAttr(resourceReference, "resources.#", "2"),
-					resource.TestCheckResourceAttr(resourceReference, "resources.1.roles.0", "projectDataReader"),
-					resource.TestCheckResourceAttr(resourceReference, "resources.1.roles.1", "projectManager"),
-					resource.TestCheckResourceAttr(resourceReference, "resources.1.type", "project"),
 					resource.TestCheckResourceAttr(resourceReference, "resources.0.roles.0", "projectDataReader"),
+					resource.TestCheckResourceAttr(resourceReference, "resources.0.roles.1", "projectManager"),
 					resource.TestCheckResourceAttr(resourceReference, "resources.0.type", "project"),
+					resource.TestCheckResourceAttr(resourceReference, "resources.1.roles.0", "projectDataReader"),
+					resource.TestCheckResourceAttr(resourceReference, "resources.1.type", "project"),
 				),
 			},
 			//// ImportState testing
@@ -94,13 +94,13 @@ func TestAccApiKeyResourceWithMultipleResources(t *testing.T) {
 func TestAccApiKeyResourceWithOnlyReqField(t *testing.T) {
 	resourceName := "acc_apikey_" + acctest.GenerateRandomResourceName()
 	resourceReference := "couchbase-capella_apikey." + resourceName
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccApiKeyResourceConfigWithOnlyReqField(acctest.Cfg, resourceName),
+				Config: testAccApiKeyResourceConfigWithOnlyReqField(acctest.ProjectCfg, resourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsApiKeyResource(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
@@ -120,7 +120,7 @@ func TestAccApiKeyResourceWithOnlyReqField(t *testing.T) {
 			},
 			// Rotate testing
 			{
-				Config: testAccApiKeyResourceConfigWithOnlyReqFieldRotate(acctest.Cfg, resourceName),
+				Config: testAccApiKeyResourceConfigWithOnlyReqFieldRotate(acctest.ProjectCfg, resourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsApiKeyResource(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
@@ -140,13 +140,13 @@ func TestAccApiKeyResourceWithOnlyReqField(t *testing.T) {
 func TestAccApiKeyResourceForOrgOwner(t *testing.T) {
 	resourceName := "acc_apikey_" + acctest.GenerateRandomResourceName()
 	resourceReference := "couchbase-capella_apikey." + resourceName
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccApiKeyResourceConfigForOrgOwner(acctest.Cfg, resourceName),
+				Config: testAccApiKeyResourceConfigForOrgOwner(acctest.ProjectCfg, resourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsApiKeyResource(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
@@ -173,13 +173,13 @@ func TestAccApiKeyResourceForOrgOwner(t *testing.T) {
 
 func TestAccApiKeyResourceInvalidScenarioRotateShouldNotPassedWhileCreate(t *testing.T) {
 	resourceName := "acc_apikey_" + acctest.GenerateRandomResourceName()
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config:      testAccApiKeyResourceConfigRotateSet(acctest.Cfg, resourceName),
+				Config:      testAccApiKeyResourceConfigRotateSet(acctest.ProjectCfg, resourceName),
 				ExpectError: regexp.MustCompile("rotate value should not be set"),
 			},
 		},
@@ -189,7 +189,10 @@ func TestAccApiKeyResourceInvalidScenarioRotateShouldNotPassedWhileCreate(t *tes
 func testAccApiKeyResourceConfig(cfg, resourceName, projectResourceName, projectResourceReference string) string {
 	return fmt.Sprintf(`
 %[1]s
-
+resource "couchbase-capella_project" "terraform_api_test_project" {
+    organization_id = var.organization_id
+	name            = "terraform_api_test_project"
+}
 resource "couchbase-capella_apikey" "%[2]s" {
   organization_id    = var.organization_id
   name               = "%[2]s"
@@ -199,7 +202,7 @@ resource "couchbase-capella_apikey" "%[2]s" {
   allowed_cidrs      = ["10.1.42.1/23", "10.1.42.0/23"]
   resources = [
     {
-      id    = var.project_id
+      id    = couchbase-capella_project.terraform_api_test_project.id
       roles = ["projectManager", "projectDataReader"]
       type  = "project"
     }
@@ -212,11 +215,17 @@ func testAccApiKeyResourceConfigWithMultipleResources(cfg, resourceName, project
 	return fmt.Sprintf(`
 %[1]s
 
-resource "couchbase-capella_project" "%[3]s" {
+resource "couchbase-capella_project" "%[3]s_1" {
     organization_id = var.organization_id
-	name            = "acc_test_project_name"
-	description     = "description"
+	name            = "terraform_api_test_project"
 }
+resource "couchbase-capella_project" "%[3]s_2" {
+    organization_id = var.organization_id
+	name            = "terraform_api_test_project"
+  depends_on = [couchbase-capella_project.%[3]s_1]
+
+}
+
 
 resource "couchbase-capella_apikey" "%[2]s" {
   organization_id    = var.organization_id
@@ -225,12 +234,12 @@ resource "couchbase-capella_apikey" "%[2]s" {
   allowed_cidrs      = ["10.1.42.1/23", "10.1.42.0/23"]
   resources = [
     {
-      id    = %[4]s.id
+      id    = %[4]s_1.id
       roles = ["projectManager", "projectDataReader"]
       type  = "project"
     },
 	{
-      id    = var.project_id
+      id    = %[4]s_2.id
       roles = ["projectDataReader"]
       type  = "project"
     }


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-65759
* `go test -v ./apikey_acceptance_test.go
=== RUN   TestAccApiKeyResource
raw state map[%:12 allowed_cidrs.#:2 allowed_cidrs.0:10.1.42.0/23 allowed_cidrs.1:10.1.42.1/23 audit.%:5 audit.created_at:2023-12-08 07:45:04.888447831 +0000 UTC audit.created_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.modified_at:2023-12-08 07:45:04.888447831 +0000 UTC audit.modified_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.version:1 description:description expiry:150 id:RDkeeGdTmDWb3yhenzHIyUG9huOpyqdZ name:acc_apikey_yctsdztoek organization_id:6af08c0a-8cab-4c1c-b257-b521575c16d0 organization_roles.#:1 organization_roles.0:organizationMember resources.#:1 resources.0.%:3 resources.0.id:c22b6b59-c7b3-4c5d-8070-8c4937d60d7a resources.0.roles.#:2 resources.0.roles.0:projectDataReader resources.0.roles.1:projectManager resources.0.type:project token:UkRrZWVHZFRtRFdiM3loZW56SEl5VUc5aHVPcHlxZFo6TEwwQHVRSkU1SDghUjZlZ01qajA3ZXpYemtFWGJDN2ZlczFTR0AjTCVreVZ3M3pXb1FySEQxMm1AQml4QERFMA==]raw state map[%:12 allowed_cidrs.#:2 allowed_cidrs.0:10.1.42.0/23 allowed_cidrs.1:10.1.42.1/23 audit.%:5 audit.created_at:2023-12-08 07:45:04.888447831 +0000 UTC audit.created_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.modified_at:2023-12-08 07:45:04.888447831 +0000 UTC audit.modified_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.version:1 description:description expiry:150 id:RDkeeGdTmDWb3yhenzHIyUG9huOpyqdZ name:acc_apikey_yctsdztoek organization_id:6af08c0a-8cab-4c1c-b257-b521575c16d0 organization_roles.#:1 organization_roles.0:organizationMember resources.#:1 resources.0.%:3 resources.0.id:c22b6b59-c7b3-4c5d-8070-8c4937d60d7a resources.0.roles.#:2 resources.0.roles.0:projectDataReader resources.0.roles.1:projectManager resources.0.type:project token:UkRrZWVHZFRtRFdiM3loZW56SEl5VUc5aHVPcHlxZFo6TEwwQHVRSkU1SDghUjZlZ01qajA3ZXpYemtFWGJDN2ZlczFTR0AjTCVreVZ3M3pXb1FySEQxMm1AQml4QERFMA==]--- PASS: TestAccApiKeyResource (7.29s)
=== RUN   TestAccApiKeyResourceWithMultipleResources
raw state map[%:12 allowed_cidrs.#:2 allowed_cidrs.0:10.1.42.0/23 allowed_cidrs.1:10.1.42.1/23 audit.%:5 audit.created_at:2023-12-08 07:45:12.186989625 +0000 UTC audit.created_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.modified_at:2023-12-08 07:45:12.186989625 +0000 UTC audit.modified_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.version:1 description: expiry:180 id:4Co4q770G06tCRrCPZPpViIWkuEFK2wT name:acc_apikey_pnrcctvekv organization_id:6af08c0a-8cab-4c1c-b257-b521575c16d0 organization_roles.#:1 organization_roles.0:organizationMember resources.#:2 resources.0.%:3 resources.0.id:569e41fe-af97-4530-a3f5-b239428c3862 resources.0.roles.#:2 resources.0.roles.0:projectDataReader resources.0.roles.1:projectManager resources.0.type:project resources.1.%:3 resources.1.id:8ab56e70-463d-421b-9863-67e31a9b7be0 resources.1.roles.#:1 resources.1.roles.0:projectDataReader resources.1.type:project token:NENvNHE3NzBHMDZ0Q1JyQ1BaUHBWaUlXa3VFRksyd1Q6bVBVI0I3NUFReHVjY1dTU2p6eUJteFIweXJGOUh0YWg0bnNnSEJNcW54WEpKcEQ1RjFoZmNDUkZ1TCVzUTBYVw==]raw state map[%:12 allowed_cidrs.#:2 allowed_cidrs.0:10.1.42.0/23 allowed_cidrs.1:10.1.42.1/23 audit.%:5 audit.created_at:2023-12-08 07:45:12.186989625 +0000 UTC audit.created_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.modified_at:2023-12-08 07:45:12.186989625 +0000 UTC audit.modified_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.version:1 description: expiry:180 id:4Co4q770G06tCRrCPZPpViIWkuEFK2wT name:acc_apikey_pnrcctvekv organization_id:6af08c0a-8cab-4c1c-b257-b521575c16d0 organization_roles.#:1 organization_roles.0:organizationMember resources.#:2 resources.0.%:3 resources.0.id:569e41fe-af97-4530-a3f5-b239428c3862 resources.0.roles.#:2 resources.0.roles.0:projectDataReader resources.0.roles.1:projectManager resources.0.type:project resources.1.%:3 resources.1.id:8ab56e70-463d-421b-9863-67e31a9b7be0 resources.1.roles.#:1 resources.1.roles.0:projectDataReader resources.1.type:project token:NENvNHE3NzBHMDZ0Q1JyQ1BaUHBWaUlXa3VFRksyd1Q6bVBVI0I3NUFReHVjY1dTU2p6eUJteFIweXJGOUh0YWg0bnNnSEJNcW54WEpKcEQ1RjFoZmNDUkZ1TCVzUTBYVw==]--- PASS: TestAccApiKeyResourceWithMultipleResources (10.23s)
=== RUN   TestAccApiKeyResourceWithOnlyReqField
raw state map[%:12 allowed_cidrs.#:1 allowed_cidrs.0:0.0.0.0/0 audit.%:5 audit.created_at:2023-12-08 07:45:21.27497527 +0000 UTC audit.created_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.modified_at:2023-12-08 07:45:21.27497527 +0000 UTC audit.modified_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.version:1 description: expiry:180 id:naHSpyK7haiui7hKVQGfHCXF5S6LflUF name:acc_apikey_keyrlqvopg organization_id:6af08c0a-8cab-4c1c-b257-b521575c16d0 organization_roles.#:2 organization_roles.0:organizationMember organization_roles.1:organizationOwner token:bmFIU3B5SzdoYWl1aTdoS1ZRR2ZIQ1hGNVM2TGZsVUY6YncjVkg3dUZLRHNhTWZCbiE5MzUlUFNMeGtvbmRWcU92ZVlkYmV1QmtDMEtOckdmSXp4aiU1ZTM4Yk5PSndoZA==]raw state map[%:12 allowed_cidrs.#:1 allowed_cidrs.0:0.0.0.0/0 audit.%:5 audit.created_at:2023-12-08 07:45:21.27497527 +0000 UTC audit.created_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.modified_at:2023-12-08 07:45:21.27497527 +0000 UTC audit.modified_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.version:1 description: expiry:180 id:naHSpyK7haiui7hKVQGfHCXF5S6LflUF name:acc_apikey_keyrlqvopg organization_id:6af08c0a-8cab-4c1c-b257-b521575c16d0 organization_roles.#:2 organization_roles.0:organizationMember organization_roles.1:organizationOwner token:bmFIU3B5SzdoYWl1aTdoS1ZRR2ZIQ1hGNVM2TGZsVUY6YncjVkg3dUZLRHNhTWZCbiE5MzUlUFNMeGtvbmRWcU92ZVlkYmV1QmtDMEtOckdmSXp4aiU1ZTM4Yk5PSndoZA==]raw state map[%:12 allowed_cidrs.#:1 allowed_cidrs.0:0.0.0.0/0 audit.%:5 audit.created_at:2023-12-08 07:45:21.27497527 +0000 UTC audit.created_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.modified_at:2023-12-08 07:45:24.189115971 +0000 UTC audit.modified_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.version:2 description: expiry:180 id:naHSpyK7haiui7hKVQGfHCXF5S6LflUF name:acc_apikey_keyrlqvopg organization_id:6af08c0a-8cab-4c1c-b257-b521575c16d0 organization_roles.#:2 organization_roles.0:organizationMember organization_roles.1:organizationOwner rotate:1 secret:abc token:bmFIU3B5SzdoYWl1aTdoS1ZRR2ZIQ1hGNVM2TGZsVUY6YWJj]--- PASS: TestAccApiKeyResourceWithOnlyReqField (5.65s)
=== RUN   TestAccApiKeyResourceForOrgOwner
raw state map[%:12 allowed_cidrs.#:1 allowed_cidrs.0:0.0.0.0/0 audit.%:5 audit.created_at:2023-12-08 07:45:26.94220212 +0000 UTC audit.created_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.modified_at:2023-12-08 07:45:26.94220212 +0000 UTC audit.modified_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.version:1 description: expiry:180 id:w9mtPGmfbMw7E05inqnt6ZG6uiNkctPd name:acc_apikey_uqpvnpcmea organization_id:6af08c0a-8cab-4c1c-b257-b521575c16d0 organization_roles.#:1 organization_roles.0:organizationMember resources.#:1 resources.0.%:3 resources.0.id:1c50d827-cb90-49ca-a47e-dff850f53557 resources.0.roles.#:2 resources.0.roles.0:projectDataReader resources.0.roles.1:projectManager resources.0.type:project token:dzltdFBHbWZiTXc3RTA1aW5xbnQ2Wkc2dWlOa2N0UGQ6RENLUDZjY1dQNmFZNVlnem15N3pOWGp3RjRqc08zVExqZkRDSnk3clBmTWxpM3BETHNJWGxhVFpAYTdaNFJKMw==]raw state map[%:12 allowed_cidrs.#:1 allowed_cidrs.0:0.0.0.0/0 audit.%:5 audit.created_at:2023-12-08 07:45:26.94220212 +0000 UTC audit.created_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.modified_at:2023-12-08 07:45:26.94220212 +0000 UTC audit.modified_by:IcJdV2CXGcktHkQSVJ4Ruu3ZAlS9DJ3X audit.version:1 description: expiry:180 id:w9mtPGmfbMw7E05inqnt6ZG6uiNkctPd name:acc_apikey_uqpvnpcmea organization_id:6af08c0a-8cab-4c1c-b257-b521575c16d0 organization_roles.#:1 organization_roles.0:organizationMember resources.#:1 resources.0.%:3 resources.0.id:1c50d827-cb90-49ca-a47e-dff850f53557 resources.0.roles.#:2 resources.0.roles.0:projectDataReader resources.0.roles.1:projectManager resources.0.type:project token:dzltdFBHbWZiTXc3RTA1aW5xbnQ2Wkc2dWlOa2N0UGQ6RENLUDZjY1dQNmFZNVlnem15N3pOWGp3RjRqc08zVExqZkRDSnk3clBmTWxpM3BETHNJWGxhVFpAYTdaNFJKMw==]--- PASS: TestAccApiKeyResourceForOrgOwner (3.32s)
=== RUN   TestAccApiKeyResourceInvalidScenarioRotateShouldNotPassedWhileCreate
--- PASS: TestAccApiKeyResourceInvalidScenarioRotateShouldNotPassedWhileCreate (0.52s)
PASS
ok  	command-line-arguments	27.678s
`

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Required Checklist:

- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if required)
- [ ] I have run make fmt and formatted my code

## Further comments