### PR TITLE
[AV-71279] Support autoexpansion for Azure cluster resource

### DIFF
--- a/examples/cluster/azure/README.md
+++ b/examples/cluster/azure/README.md
@@ -1,0 +1,238 @@
+# Azure Cluster Example
+
+This example shows how to create a Cluster on Azure, with autoexpansion enabled.
+
+For autoexpansion it requires this disk variable in `terraform.template.tfvars`:
+
+```
+disk = {
+  type = "P6"
+  autoexpansion = true
+}
+```
+
+It should be added to `variables.tf`:
+
+```
+type = object({
+    size = optional(number)
+    type = string
+    iops = optional(number)
+    autoexpansion = optional(bool)
+  })
+```
+
+and referenced in `create_cluster.tf`:
+
+```
+disk = {
+    type    = var.disk.type
+    autoexpansion = var.disk.autoexpansion
+}
+```
+
+Sample Output:
+
+```
+terraform apply -var-file terraform.template.tfvars
+
+Terraform will perform the following actions:
+
+  # couchbase-capella_cluster.new_cluster will be created
+  + resource "couchbase-capella_cluster" "new_cluster" {
+      + app_service_id     = (known after apply)
+      + audit              = (known after apply)
+      + availability       = {
+          + type = "single"
+        }
+      + cloud_provider     = {
+          + cidr   = "10.0.6.0/23"
+          + region = "eastus"
+          + type   = "azure"
+        }
+      + configuration_type = (known after apply)
+      + couchbase_server   = (known after apply)
+      + current_state      = (known after apply)
+      + description        = "My first test cluster for multiple services."
+      + etag               = (known after apply)
+      + id                 = (known after apply)
+      + name               = "New Terraform Azure Cluster 6"
+      + organization_id    = "7dc36559-a544-4ce6-a132-5da412f350e9"
+      + project_id         = "693f1cb1-982b-4c52-8119-3f5dc6828489"
+      + service_groups     = [
+          + {
+              + node         = {
+                  + compute = {
+                      + cpu = 4
+                      + ram = 16
+                    }
+                  + disk    = {
+                      + autoexpansion = true
+                      + iops          = (known after apply)
+                      + storage       = (known after apply)
+                      + type          = "P6"
+                    }
+                }
+              + num_of_nodes = 3
+              + services     = [
+                  + "data",
+                ]
+            },
+        ]
+      + support            = {
+          + plan     = "basic"
+          + timezone = "PT"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + cluster_id  = (known after apply)
+  + new_cluster = {
+      + app_service_id     = (known after apply)
+      + audit              = (known after apply)
+      + availability       = {
+          + type = "single"
+        }
+      + cloud_provider     = {
+          + cidr   = "10.0.6.0/23"
+          + region = "eastus"
+          + type   = "azure"
+        }
+      + configuration_type = (known after apply)
+      + couchbase_server   = (known after apply)
+      + current_state      = (known after apply)
+      + description        = "My first test cluster for multiple services."
+      + etag               = (known after apply)
+      + id                 = (known after apply)
+      + if_match           = null
+      + name               = "New Terraform Azure Cluster 6"
+      + organization_id    = "7dc36559-a544-4ce6-a132-5da412f350e9"
+      + project_id         = "693f1cb1-982b-4c52-8119-3f5dc6828489"
+      + service_groups     = [
+          + {
+              + node         = {
+                  + compute = {
+                      + cpu = 4
+                      + ram = 16
+                    }
+                  + disk    = {
+                      + autoexpansion = true
+                      + iops          = (known after apply)
+                      + storage       = (known after apply)
+                      + type          = "P6"
+                    }
+                }
+              + num_of_nodes = 3
+              + services     = [
+                  + "data",
+                ]
+            },
+        ]
+      + support            = {
+          + plan     = "basic"
+          + timezone = "PT"
+        }
+    }
+
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value: yes
+
+
+couchbase-capella_cluster.new_cluster: Creating...
+couchbase-capella_cluster.new_cluster: Still creating... [10s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [20s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [30s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [40s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [50s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [1m0s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [1m10s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [1m20s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [1m30s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [1m40s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [1m50s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [2m0s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [2m10s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [2m20s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [2m30s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [2m40s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [2m50s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [3m0s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [3m10s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [3m20s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [3m30s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [3m40s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [3m50s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [4m0s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [4m10s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [4m20s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [4m30s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [4m40s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [4m50s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [5m0s elapsed]
+couchbase-capella_cluster.new_cluster: Still creating... [5m10s elapsed]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+cluster_id = "10d5c496-502f-430e-99fb-25fa8bd7285a"
+new_cluster = {
+  "app_service_id" = tostring(null)
+  "audit" = {
+    "created_at" = "2024-01-18 20:48:53.703590843 +0000 UTC"
+    "created_by" = "GGZjZ6bOhAiuFJoJ0M1NoFHwm6RHZvkv"
+    "modified_at" = "2024-01-18 20:54:04.672833562 +0000 UTC"
+    "modified_by" = "GGZjZ6bOhAiuFJoJ0M1NoFHwm6RHZvkv"
+    "version" = 3
+  }
+  "availability" = {
+    "type" = "single"
+  }
+  "cloud_provider" = {
+    "cidr" = "10.0.6.0/23"
+    "region" = "eastus"
+    "type" = "azure"
+  }
+  "configuration_type" = "multiNode"
+  "couchbase_server" = {
+    "version" = "7.2"
+  }
+  "current_state" = "healthy"
+  "description" = "My first test cluster for multiple services."
+  "etag" = "Version: 3"
+  "id" = "10d5c496-502f-430e-99fb-25fa8bd7285a"
+  "if_match" = tostring(null)
+  "name" = "New Terraform Azure Cluster 6"
+  "organization_id" = "7dc36559-a544-4ce6-a132-5da412f350e9"
+  "project_id" = "693f1cb1-982b-4c52-8119-3f5dc6828489"
+  "service_groups" = toset([
+    {
+      "node" = {
+        "compute" = {
+          "cpu" = 4
+          "ram" = 16
+        }
+        "disk" = {
+          "autoexpansion" = true
+          "iops" = 240
+          "storage" = 64
+          "type" = "P6"
+        }
+      }
+      "num_of_nodes" = 3
+      "services" = toset([
+        "data",
+      ])
+    },
+  ])
+  "support" = {
+    "plan" = "basic"
+    "timezone" = "PT"
+  }
+}
+```

--- a/examples/cluster/azure/create_cluster.tf
+++ b/examples/cluster/azure/create_cluster.tf
@@ -1,0 +1,43 @@
+output "new_cluster" {
+  value = couchbase-capella_cluster.new_cluster
+}
+
+output "cluster_id" {
+  value = couchbase-capella_cluster.new_cluster.id
+}
+
+resource "couchbase-capella_cluster" "new_cluster" {
+  organization_id = var.organization_id
+  project_id      = var.project_id
+  name            = var.cluster.name
+  description     = "My first test cluster for multiple services."
+  cloud_provider = {
+    type   = var.cloud_provider.name
+    region = var.cloud_provider.region
+    cidr   = var.cluster.cidr
+  }
+  service_groups = [
+    {
+      node = {
+        compute = {
+          cpu = var.compute.cpu
+          ram = var.compute.ram
+        }
+        disk = {
+          type    = var.disk.type
+          autoexpansion = var.disk.autoexpansion
+        }
+      }
+      num_of_nodes = var.cluster.node_count
+      services     = var.cluster.couchbase_services
+    }
+  ]
+  availability = {
+    "type" : var.cluster.availability_zone
+  }
+  support = {
+    plan     = var.support.plan
+    timezone = var.support.timezone
+  }
+}
+

--- a/examples/cluster/azure/create_cluster.tf
+++ b/examples/cluster/azure/create_cluster.tf
@@ -24,7 +24,7 @@ resource "couchbase-capella_cluster" "new_cluster" {
           ram = var.compute.ram
         }
         disk = {
-          type    = var.disk.type
+          type          = var.disk.type
           autoexpansion = var.disk.autoexpansion
         }
       }

--- a/examples/cluster/azure/main.tf
+++ b/examples/cluster/azure/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    couchbase-capella = {
+      source = "couchbasecloud/couchbase-capella"
+    }
+  }
+}
+
+provider "couchbase-capella" {
+  authentication_token = var.auth_token
+}
+

--- a/examples/cluster/azure/terraform.template.tfvars
+++ b/examples/cluster/azure/terraform.template.tfvars
@@ -21,7 +21,7 @@ compute = {
 }
 
 disk = {
-  type = "P6"
+  type          = "P6"
   autoexpansion = true
 }
 

--- a/examples/cluster/azure/terraform.template.tfvars
+++ b/examples/cluster/azure/terraform.template.tfvars
@@ -1,0 +1,31 @@
+auth_token      = "<v4-api-key-secret>"
+organization_id = "<organization_id>"
+project_id      = "<project_id>"
+
+cloud_provider = {
+  name   = "azure",
+  region = "eastus"
+}
+
+cluster = {
+  name               = "New Terraform Azure Cluster 6"
+  cidr               = "10.0.6.0/23"
+  node_count         = 3
+  couchbase_services = ["data"]
+  availability_zone  = "single"
+}
+
+compute = {
+  cpu = 4
+  ram = 16
+}
+
+disk = {
+  type = "P6"
+  autoexpansion = true
+}
+
+support = {
+  plan     = "basic"
+  timezone = "PT"
+}

--- a/examples/cluster/azure/variables.tf
+++ b/examples/cluster/azure/variables.tf
@@ -45,9 +45,9 @@ variable "disk" {
   description = "All nodes' disk configuration"
 
   type = object({
-    size = optional(number)
-    type = string
-    iops = optional(number)
+    size          = optional(number)
+    type          = string
+    iops          = optional(number)
     autoexpansion = optional(bool)
   })
 }

--- a/examples/cluster/azure/variables.tf
+++ b/examples/cluster/azure/variables.tf
@@ -1,0 +1,62 @@
+variable "auth_token" {
+  description = "Authentication API Key"
+  sensitive   = true
+}
+
+variable "organization_id" {
+  description = "Capella Organization ID"
+}
+
+variable "project_id" {
+  description = "Project Name for Project Created via Terraform"
+}
+
+variable "cloud_provider" {
+  description = "Cloud Provider details useful for cluster creation"
+
+  type = object({
+    name   = string
+    region = string
+  })
+}
+
+variable "cluster" {
+  description = "Cluster configuration details useful for creation"
+
+  type = object({
+    name               = string
+    cidr               = string
+    node_count         = number
+    couchbase_services = list(string)
+    availability_zone  = string
+  })
+}
+
+variable "compute" {
+  description = "All cluster node compute configuration"
+
+  type = object({
+    cpu = number
+    ram = number
+  })
+}
+
+variable "disk" {
+  description = "All nodes' disk configuration"
+
+  type = object({
+    size = optional(number)
+    type = string
+    iops = optional(number)
+    autoexpansion = optional(bool)
+  })
+}
+
+variable "support" {
+  description = "Support configuration applicable to the cluster during creation"
+
+  type = object({
+    plan     = string
+    timezone = string
+  })
+}

--- a/internal/api/cluster/node.go
+++ b/internal/api/cluster/node.go
@@ -60,6 +60,9 @@ type DiskAzure struct {
 	// Type depicts type of disk. Please choose from the given list
 	// for Azure cloud provider.
 	Type DiskAzureType `json:"type"`
+
+	// Autoexpansion determines if disk auto expansion is enabled
+	Autoexpansion *bool `json:"autoexpansion,omitempty"`
 }
 
 // DiskAzureType depicts type of disk. Please choose from the given list for Azure cloud provider.

--- a/internal/datasources/cluster_schema.go
+++ b/internal/datasources/cluster_schema.go
@@ -49,9 +49,10 @@ func ClusterSchema() schema.Schema {
 											"disk": schema.SingleNestedAttribute{
 												Computed: true,
 												Attributes: map[string]schema.Attribute{
-													"type":    computedStringAttribute,
-													"storage": computedInt64Attribute,
-													"iops":    computedInt64Attribute,
+													"type":          computedStringAttribute,
+													"storage":       computedInt64Attribute,
+													"iops":          computedInt64Attribute,
+													"autoexpansion": computedBoolAttribute,
 												},
 											},
 										},

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -638,6 +638,12 @@ func (c *Cluster) morphToApiServiceGroups(plan providerschema.Cluster) ([]cluste
 				iops := int(serviceGroup.Node.Disk.IOPS.ValueInt64())
 				diskAzure.Iops = &iops
 			}
+
+			if serviceGroup.Node != nil && !serviceGroup.Node.Disk.Autoexpansion.IsNull() {
+				autoexpansion := serviceGroup.Node.Disk.Autoexpansion.ValueBool()
+				diskAzure.Autoexpansion = &autoexpansion
+			}
+
 			if err := node.FromDiskAzure(diskAzure); err != nil {
 				return nil, fmt.Errorf("%s: %w", errors.ErrConvertingServiceGroups, err)
 			}

--- a/internal/resources/cluster_schema.go
+++ b/internal/resources/cluster_schema.go
@@ -63,9 +63,10 @@ func ClusterSchema() schema.Schema {
 										"In the case of GCP, only 'pd ssd' disk type is available, and you cannot set the 'IOPS' field.",
 									Required: true,
 									Attributes: map[string]schema.Attribute{
-										"type":    stringAttribute(required),
-										"storage": int64Attribute(optional, computed),
-										"iops":    int64Attribute(optional, computed),
+										"type":          stringAttribute(required),
+										"storage":       int64Attribute(optional, computed),
+										"iops":          int64Attribute(optional, computed),
+										"autoexpansion": boolAttribute(optional, computed),
 									},
 								},
 							},

--- a/internal/schema/cluster.go
+++ b/internal/schema/cluster.go
@@ -99,9 +99,10 @@ type Node struct {
 
 // Node_Disk is the type of disk on a particular node that is supported per cloud provider during cluster creation.
 type Node_Disk struct {
-	Type    types.String `tfsdk:"type"`
-	Storage types.Int64  `tfsdk:"storage"`
-	IOPS    types.Int64  `tfsdk:"iops"`
+	Type          types.String `tfsdk:"type"`
+	Storage       types.Int64  `tfsdk:"storage"`
+	IOPS          types.Int64  `tfsdk:"iops"`
+	Autoexpansion types.Bool   `tfsdk:"autoexpansion"`
 }
 
 // Support defines the support plan and timezone for this particular cluster.

--- a/internal/schema/cluster.go
+++ b/internal/schema/cluster.go
@@ -246,9 +246,10 @@ func morphToTerraformServiceGroups(cluster *clusterapi.GetClusterResponse) ([]Se
 			}
 
 			newServiceGroup.Node.Disk = Node_Disk{
-				Type:    types.StringValue(string(azureDisk.Type)),
-				Storage: types.Int64Value(int64(*azureDisk.Storage)),
-				IOPS:    types.Int64Value(int64(*azureDisk.Iops)),
+				Type:          types.StringValue(string(azureDisk.Type)),
+				Storage:       types.Int64Value(int64(*azureDisk.Storage)),
+				IOPS:          types.Int64Value(int64(*azureDisk.Iops)),
+				Autoexpansion: types.BoolValue(*azureDisk.Autoexpansion),
 			}
 		case clusterapi.Gcp:
 			gcpDisk, err := serviceGroup.Node.AsDiskGCP()


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-71279](https://couchbasecloud.atlassian.net/browse/AV-71279)

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
<!-- What does this change do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [X] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [X] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

#### acceptance testing

```
make testacc

TF_ACC=1 go test -timeout=300m -v ./... -run TestAccOrganizationDataSource -run TestAccProjectResource -run TestAccCreateProjectWithReqFields -run TestAccCreateProjectOptFields -run TestAccValidProjectUpdate -run TestAccInvalidProjectResource -run TestAccDeleteProjectBeforeDestroy -run TestAccClusterResourceAzure -run TestAccClusterResourceGCP -run TestAccClusterResourceWithOnlyReqFieldAWS
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/appservice	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/backup	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/backup_schedule	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/bucket	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/cluster	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/organization	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api	(cached) [no tests to run]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/provider	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/datasources	0.201s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/resources	0.257s [no tests to run]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/testing	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/version	[no test files]
=== RUN   TestAccClusterResourceWithOnlyReqFieldAWS
=== PAUSE TestAccClusterResourceWithOnlyReqFieldAWS
=== CONT  TestAccClusterResourceWithOnlyReqFieldAWS
raw state map[%:16 audit.%:5 audit.created_at:2024-01-19 06:08:15.297788777 +0000 UTC audit.created_by:gH90bWxTnQCXOupNbbAp0ghfpdmcApw0 audit.modified_at:2024-01-19 06:10:12.4927354 +0000 UTC audit.modified_by:gH90bWxTnQCXOupNbbAp0ghfpdmcApw0 audit.version:5 availability.%:1 availability.type:multi cloud_provider.%:3 cloud_provider.cidr:10.208.250.0/23 cloud_provider.region:us-east-1 cloud_provider.type:aws configuration_type:multiNode couchbase_server.%:1 couchbase_server.version:7.2 current_state:healthy description: etag:Version: 5 id:8c1938dd-06d6-4b8b-aa50-786b532493a0 name:acc_cluster_mxckojabzm organization_id:299e6638-492a-4acc-921d-1818a8da0603 project_id:88d307c3-28f6-48e6-8a63-5ded4591f3da service_groups.#:1 service_groups.0.%:3 service_groups.0.node.%:2 service_groups.0.node.compute.%:2 service_groups.0.node.compute.cpu:4 service_groups.0.node.compute.ram:16 service_groups.0.node.disk.%:4 service_groups.0.node.disk.iops:3000 service_groups.0.node.disk.storage:50 service_groups.0.node.disk.type:io2 service_groups.0.num_of_nodes:3 service_groups.0.services.#:3 service_groups.0.services.0:data service_groups.0.services.1:index service_groups.0.services.2:query support.%:2 support.plan:developer pro support.timezone:PT]raw state map[%:16 audit.%:5 audit.created_at:2024-01-19 06:08:15.297788777 +0000 UTC audit.created_by:gH90bWxTnQCXOupNbbAp0ghfpdmcApw0 audit.modified_at:2024-01-19 06:10:12.4927354 +0000 UTC audit.modified_by:gH90bWxTnQCXOupNbbAp0ghfpdmcApw0 audit.version:5 availability.%:1 availability.type:multi cloud_provider.%:3 cloud_provider.cidr:10.208.250.0/23 cloud_provider.region:us-east-1 cloud_provider.type:aws configuration_type:multiNode couchbase_server.%:1 couchbase_server.version:7.2 current_state:healthy description: etag:Version: 5 id:8c1938dd-06d6-4b8b-aa50-786b532493a0 name:acc_cluster_mxckojabzm organization_id:299e6638-492a-4acc-921d-1818a8da0603 project_id:88d307c3-28f6-48e6-8a63-5ded4591f3da service_groups.#:1 service_groups.0.%:3 service_groups.0.node.%:2 service_groups.0.node.compute.%:2 service_groups.0.node.compute.cpu:4 service_groups.0.node.compute.ram:16 service_groups.0.node.disk.%:4 service_groups.0.node.disk.iops:3000 service_groups.0.node.disk.storage:50 service_groups.0.node.disk.type:io2 service_groups.0.num_of_nodes:3 service_groups.0.services.#:3 service_groups.0.services.0:data service_groups.0.services.1:index service_groups.0.services.2:query support.%:2 support.plan:developer pro support.timezone:PT]raw state map[%:16 audit.%:5 audit.created_at:2024-01-19 06:08:15.297788777 +0000 UTC audit.created_by:gH90bWxTnQCXOupNbbAp0ghfpdmcApw0 audit.modified_at:2024-01-19 06:16:02.299725008 +0000 UTC audit.modified_by:gH90bWxTnQCXOupNbbAp0ghfpdmcApw0 audit.version:11 availability.%:1 availability.type:multi cloud_provider.%:3 cloud_provider.cidr:10.208.250.0/23 cloud_provider.region:us-east-1 cloud_provider.type:aws configuration_type:multiNode couchbase_server.%:1 couchbase_server.version:7.2 current_state:healthy description:Cluster Updated. etag:Version: 11 id:8c1938dd-06d6-4b8b-aa50-786b532493a0 if_match:5 name:Terraform Acceptance Test Cluster Update organization_id:299e6638-492a-4acc-921d-1818a8da0603 project_id:88d307c3-28f6-48e6-8a63-5ded4591f3da service_groups.#:2 service_groups.0.%:3 service_groups.0.node.%:2 service_groups.0.node.compute.%:2 service_groups.0.node.compute.cpu:4 service_groups.0.node.compute.ram:16 service_groups.0.node.disk.%:4 service_groups.0.node.disk.iops:3001 service_groups.0.node.disk.storage:51 service_groups.0.node.disk.type:gp3 service_groups.0.num_of_nodes:3 service_groups.0.services.#:1 service_groups.0.services.0:data service_groups.1.%:3 service_groups.1.node.%:2 service_groups.1.node.compute.%:2 service_groups.1.node.compute.cpu:8 service_groups.1.node.compute.ram:32 service_groups.1.node.disk.%:4 service_groups.1.node.disk.iops:3001 service_groups.1.node.disk.storage:51 service_groups.1.node.disk.type:gp3 service_groups.1.num_of_nodes:2 service_groups.1.services.#:2 service_groups.1.services.0:index service_groups.1.services.1:query support.%:2 support.plan:enterprise support.timezone:IST]raw state map[%:16 audit.%:5 audit.created_at:2024-01-19 06:08:15.297788777 +0000 UTC audit.created_by:gH90bWxTnQCXOupNbbAp0ghfpdmcApw0 audit.modified_at:2024-01-19 06:16:09.374476336 +0000 UTC audit.modified_by:gH90bWxTnQCXOupNbbAp0ghfpdmcApw0 audit.version:16 availability.%:1 availability.type:multi cloud_provider.%:3 cloud_provider.cidr:10.208.250.0/23 cloud_provider.region:us-east-1 cloud_provider.type:aws configuration_type:multiNode couchbase_server.%:1 couchbase_server.version:7.2 current_state:healthy description:Cluster Updated. etag:Version: 16 id:8c1938dd-06d6-4b8b-aa50-786b532493a0 name:Terraform Acceptance Test Cluster Update 2 organization_id:299e6638-492a-4acc-921d-1818a8da0603 project_id:88d307c3-28f6-48e6-8a63-5ded4591f3da service_groups.#:2 service_groups.0.%:3 service_groups.0.node.%:2 service_groups.0.node.compute.%:2 service_groups.0.node.compute.cpu:4 service_groups.0.node.compute.ram:16 service_groups.0.node.disk.%:4 service_groups.0.node.disk.iops:3001 service_groups.0.node.disk.storage:51 service_groups.0.node.disk.type:gp3 service_groups.0.num_of_nodes:3 service_groups.0.services.#:1 service_groups.0.services.0:data service_groups.1.%:3 service_groups.1.node.%:2 service_groups.1.node.compute.%:2 service_groups.1.node.compute.cpu:8 service_groups.1.node.compute.ram:32 service_groups.1.node.disk.%:4 service_groups.1.node.disk.iops:3001 service_groups.1.node.disk.storage:51 service_groups.1.node.disk.type:gp3 service_groups.1.num_of_nodes:2 service_groups.1.services.#:2 service_groups.1.services.0:index service_groups.1.services.1:query support.%:2 support.plan:enterprise support.timezone:IST]--- PASS: TestAccClusterResourceWithOnlyReqFieldAWS (824.76s)
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/resources/acceptance_tests	825.030s
testing: warning: no tests to run
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/resources/acceptance_tests/security_acceptance_tests	0.270s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema	(cached) [no tests to run]
```

#### manual test to create azure cluster with autoexpansion enabled

```
terraform apply -var-file terraform.template.tfvars
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/hiteshwalia/GolandProjects/terraform-provider-couchbase-capella/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_cluster.new_cluster will be created
  + resource "couchbase-capella_cluster" "new_cluster" {
      + app_service_id     = (known after apply)
      + audit              = (known after apply)
      + availability       = {
          + type = "single"
        }
      + cloud_provider     = {
          + cidr   = "10.0.6.0/23"
          + region = "eastus"
          + type   = "azure"
        }
      + configuration_type = (known after apply)
      + couchbase_server   = (known after apply)
      + current_state      = (known after apply)
      + description        = "My first test cluster for multiple services."
      + etag               = (known after apply)
      + id                 = (known after apply)
      + name               = "New Terraform Azure Cluster 6"
      + organization_id    = "7dc36559-a544-4ce6-a132-5da412f350e9"
      + project_id         = "693f1cb1-982b-4c52-8119-3f5dc6828489"
      + service_groups     = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = true
                      + iops          = (known after apply)
                      + storage       = (known after apply)
                      + type          = "P6"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                ]
            },
        ]
      + support            = {
          + plan     = "basic"
          + timezone = "PT"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + cluster_id  = (known after apply)
  + new_cluster = {
      + app_service_id     = (known after apply)
      + audit              = (known after apply)
      + availability       = {
          + type = "single"
        }
      + cloud_provider     = {
          + cidr   = "10.0.6.0/23"
          + region = "eastus"
          + type   = "azure"
        }
      + configuration_type = (known after apply)
      + couchbase_server   = (known after apply)
      + current_state      = (known after apply)
      + description        = "My first test cluster for multiple services."
      + etag               = (known after apply)
      + id                 = (known after apply)
      + if_match           = null
      + name               = "New Terraform Azure Cluster 6"
      + organization_id    = "7dc36559-a544-4ce6-a132-5da412f350e9"
      + project_id         = "693f1cb1-982b-4c52-8119-3f5dc6828489"
      + service_groups     = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = true
                      + iops          = (known after apply)
                      + storage       = (known after apply)
                      + type          = "P6"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                ]
            },
        ]
      + support            = {
          + plan     = "basic"
          + timezone = "PT"
        }
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cluster.new_cluster: Creating...
couchbase-capella_cluster.new_cluster: Still creating... [10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [3m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [3m10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [3m20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [3m30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [3m40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [3m50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [4m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [4m10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [4m20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [4m30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [4m40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [4m50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [5m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [5m10s elapsed]
couchbase-capella_cluster.new_cluster: Creation complete after 5m11s [id=10d5c496-502f-430e-99fb-25fa8bd7285a]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

cluster_id = "10d5c496-502f-430e-99fb-25fa8bd7285a"
new_cluster = {
  "app_service_id" = tostring(null)
  "audit" = {
    "created_at" = "2024-01-18 20:48:53.703590843 +0000 UTC"
    "created_by" = "GGZjZ6bOhAiuFJoJ0M1NoFHwm6RHZvkv"
    "modified_at" = "2024-01-18 20:54:04.672833562 +0000 UTC"
    "modified_by" = "GGZjZ6bOhAiuFJoJ0M1NoFHwm6RHZvkv"
    "version" = 3
  }
  "availability" = {
    "type" = "single"
  }
  "cloud_provider" = {
    "cidr" = "10.0.6.0/23"
    "region" = "eastus"
    "type" = "azure"
  }
  "configuration_type" = "multiNode"
  "couchbase_server" = {
    "version" = "7.2"
  }
  "current_state" = "healthy"
  "description" = "My first test cluster for multiple services."
  "etag" = "Version: 3"
  "id" = "10d5c496-502f-430e-99fb-25fa8bd7285a"
  "if_match" = tostring(null)
  "name" = "New Terraform Azure Cluster 6"
  "organization_id" = "7dc36559-a544-4ce6-a132-5da412f350e9"
  "project_id" = "693f1cb1-982b-4c52-8119-3f5dc6828489"
  "service_groups" = toset([
    {
      "node" = {
        "compute" = {
          "cpu" = 4
          "ram" = 16
        }
        "disk" = {
          "autoexpansion" = true
          "iops" = 240
          "storage" = 64
          "type" = "P6"
        }
      }
      "num_of_nodes" = 3
      "services" = toset([
        "data",
      ])
    },
  ])
  "support" = {
    "plan" = "basic"
    "timezone" = "PT"
  }
}
```

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code

## Further comments