### PR TITLE
fix format issue for regex check

### DIFF
--- a/internal/resources/acceptance_tests/organization_acceptance_test.go
+++ b/internal/resources/acceptance_tests/organization_acceptance_test.go
@@ -50,7 +50,7 @@ func TestAccOrganizationDataSource(t *testing.T) {
 
 			{
 				Config:      testAccOrganizationResourceConfig(cfg.Cfg, "123456-abcd-4567890"),
-				ExpectError: regexp.MustCompile("server cannot or will not process the request.*"),
+				ExpectError: regexp.MustCompile("server cannot or will not process.*"),
 			},
 		},
 	})


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-XXXXX

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
Fix jenkins error due to regex format mismatch
<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
TF_ACC=1 go test -timeout=300m -v ./... -run TestAccOrganizationDataSource
=== RUN   TestAccOrganizationDataSource
--- PASS: TestAccOrganizationDataSource (5.12s)
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/resources/acceptance_tests
</details>

## Required Checklist:

- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if required)
- [ ] I have run make fmt and formatted my code

## Further comments