### PR TITLE
[AV-77464] fix export schema

### DIFF
--- a/internal/resources/audit_log_export_schema.go
+++ b/internal/resources/audit_log_export_schema.go
@@ -7,16 +7,16 @@ import (
 func AuditLogExportSchema() schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"id":                     stringAttribute([]string{required}),
+			"id":                     stringAttribute([]string{computed}),
 			"organization_id":        stringAttribute([]string{required}),
 			"project_id":             stringAttribute([]string{required}),
 			"cluster_id":             stringAttribute([]string{required}),
-			"audit_log_download_url": stringAttribute([]string{required}),
-			"expiration":             stringAttribute([]string{required}),
+			"audit_log_download_url": stringAttribute([]string{computed}),
+			"expiration":             stringAttribute([]string{computed}),
 			"start":                  stringAttribute([]string{required}),
 			"end":                    stringAttribute([]string{required}),
-			"created_at":             stringAttribute([]string{required}),
-			"status":                 stringAttribute([]string{required}),
+			"created_at":             stringAttribute([]string{computed}),
+			"status":                 stringAttribute([]string{computed}),
 		},
 	}
 }

--- a/internal/resources/audit_log_export_schema.go
+++ b/internal/resources/audit_log_export_schema.go
@@ -7,7 +7,7 @@ import (
 func AuditLogExportSchema() schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"id":                     stringAttribute([]string{useStateForUnknown}),
+			"id":                     stringAttribute([]string{computed, useStateForUnknown}),
 			"organization_id":        stringAttribute([]string{required}),
 			"project_id":             stringAttribute([]string{required}),
 			"cluster_id":             stringAttribute([]string{required}),

--- a/internal/resources/audit_log_export_schema.go
+++ b/internal/resources/audit_log_export_schema.go
@@ -8,15 +8,15 @@ func AuditLogExportSchema() schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id":                     stringAttribute([]string{computed, useStateForUnknown}),
-			"organization_id":        stringAttribute([]string{required}),
-			"project_id":             stringAttribute([]string{required}),
-			"cluster_id":             stringAttribute([]string{required}),
-			"audit_log_download_url": stringAttribute([]string{computed}),
-			"expiration":             stringAttribute([]string{computed}),
-			"start":                  stringAttribute([]string{required}),
-			"end":                    stringAttribute([]string{required}),
-			"created_at":             stringAttribute([]string{computed}),
-			"status":                 stringAttribute([]string{computed}),
+			"organization_id":        stringAttribute([]string{required, requiresReplace}),
+			"project_id":             stringAttribute([]string{required, requiresReplace}),
+			"cluster_id":             stringAttribute([]string{required, requiresReplace}),
+			"audit_log_download_url": stringAttribute([]string{computed, requiresReplace}),
+			"expiration":             stringAttribute([]string{computed, requiresReplace}),
+			"start":                  stringAttribute([]string{required, requiresReplace}),
+			"end":                    stringAttribute([]string{required, requiresReplace}),
+			"created_at":             stringAttribute([]string{computed, requiresReplace}),
+			"status":                 stringAttribute([]string{computed, requiresReplace}),
 		},
 	}
 }

--- a/internal/resources/audit_log_export_schema.go
+++ b/internal/resources/audit_log_export_schema.go
@@ -7,7 +7,7 @@ import (
 func AuditLogExportSchema() schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"id":                     stringAttribute([]string{computed}),
+			"id":                     stringAttribute([]string{useStateForUnknown}),
 			"organization_id":        stringAttribute([]string{required}),
 			"project_id":             stringAttribute([]string{required}),
 			"cluster_id":             stringAttribute([]string{required}),

--- a/internal/resources/audit_log_export_schema.go
+++ b/internal/resources/audit_log_export_schema.go
@@ -8,15 +8,15 @@ func AuditLogExportSchema() schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id":                     stringAttribute([]string{computed, useStateForUnknown}),
-			"organization_id":        stringAttribute([]string{required, requiresReplace}),
-			"project_id":             stringAttribute([]string{required, requiresReplace}),
-			"cluster_id":             stringAttribute([]string{required, requiresReplace}),
-			"audit_log_download_url": stringAttribute([]string{computed, requiresReplace}),
-			"expiration":             stringAttribute([]string{computed, requiresReplace}),
-			"start":                  stringAttribute([]string{required, requiresReplace}),
-			"end":                    stringAttribute([]string{required, requiresReplace}),
-			"created_at":             stringAttribute([]string{computed, requiresReplace}),
-			"status":                 stringAttribute([]string{computed, requiresReplace}),
+			"organization_id":        stringAttribute([]string{required}),
+			"project_id":             stringAttribute([]string{required}),
+			"cluster_id":             stringAttribute([]string{required}),
+			"audit_log_download_url": stringAttribute([]string{computed}),
+			"expiration":             stringAttribute([]string{computed}),
+			"start":                  stringAttribute([]string{required}),
+			"end":                    stringAttribute([]string{required}),
+			"created_at":             stringAttribute([]string{computed}),
+			"status":                 stringAttribute([]string{computed}),
 		},
 	}
 }


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-77464](https://couchbasecloud.atlassian.net/browse/AV-77464)

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
<!-- What does this change do? Why is it needed? -->

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

```
terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/hiteshwalia/GolandProjects/terraform-provider-couchbase-capella/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.couchbase-capella_audit_log_export.existing_auditlogexport: Reading...
data.couchbase-capella_audit_log_export.existing_auditlogexport: Read complete after 0s

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_audit_log_export.new_auditlogexport will be created
  + resource "couchbase-capella_audit_log_export" "new_auditlogexport" {
      + audit_log_download_url = (known after apply)
      + cluster_id             = "c77d74c6-b852-4db3-993e-9c42310eba27"
      + created_at             = (known after apply)
      + end                    = "2024-04-22T21:28:05+00:00"
      + expiration             = (known after apply)
      + id                     = (known after apply)
      + organization_id        = "ee1d97a0-3541-486f-beb9-9bb9e1207f19"
      + project_id             = "e371395a-0188-407f-bb31-a8be08e30c35"
      + start                  = "2024-04-22T20:28:05+00:00"
      + status                 = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + existing_auditlogexport = {
      + cluster_id      = "c77d74c6-b852-4db3-993e-9c42310eba27"
      + data            = null
      + organization_id = "ee1d97a0-3541-486f-beb9-9bb9e1207f19"
      + project_id      = "e371395a-0188-407f-bb31-a8be08e30c35"
    }
  + new_auditlogexport      = {
      + audit_log_download_url = (known after apply)
      + cluster_id             = "c77d74c6-b852-4db3-993e-9c42310eba27"
      + created_at             = (known after apply)
      + end                    = "2024-04-22T21:28:05+00:00"
      + expiration             = (known after apply)
      + id                     = (known after apply)
      + organization_id        = "ee1d97a0-3541-486f-beb9-9bb9e1207f19"
      + project_id             = "e371395a-0188-407f-bb31-a8be08e30c35"
      + start                  = "2024-04-22T20:28:05+00:00"
      + status                 = (known after apply)
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_audit_log_export.new_auditlogexport: Creating...
couchbase-capella_audit_log_export.new_auditlogexport: Creation complete after 0s [id=c9503f90-87c5-4b40-906b-b3e173cdf74c]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

existing_auditlogexport = {
  "cluster_id" = "c77d74c6-b852-4db3-993e-9c42310eba27"
  "data" = toset(null) /* of object */
  "organization_id" = "ee1d97a0-3541-486f-beb9-9bb9e1207f19"
  "project_id" = "e371395a-0188-407f-bb31-a8be08e30c35"
}
new_auditlogexport = {
  "audit_log_download_url" = tostring(null)
  "cluster_id" = "c77d74c6-b852-4db3-993e-9c42310eba27"
  "created_at" = "2024-04-29 18:46:53.272560598 +0000 UTC"
  "end" = "2024-04-22T21:28:05+00:00"
  "expiration" = tostring(null)
  "id" = "c9503f90-87c5-4b40-906b-b3e173cdf74c"
  "organization_id" = "ee1d97a0-3541-486f-beb9-9bb9e1207f19"
  "project_id" = "e371395a-0188-407f-bb31-a8be08e30c35"
  "start" = "2024-04-22T20:28:05+00:00"
  "status" = tostring(null)
}
```

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code

## Further comments