### PR TITLE
[AV-77965] Add acceptance test for audit log export

### DIFF
--- a/internal/resources/acceptance_tests/audit_log_export_acceptance_test.go
+++ b/internal/resources/acceptance_tests/audit_log_export_acceptance_test.go
@@ -1,0 +1,222 @@
+package acceptance_tests
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+	acctest "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/testing"
+)
+
+const (
+	ExportStatusNoAuditLogs = "no audit log files exist within the requested time frame"
+)
+
+func TestAccAuditLogExportTestCases(t *testing.T) {
+	clusterResourceName := "acc_cluster_" + acctest.GenerateRandomResourceName()
+	clusterResourceReference := "couchbase-capella_cluster." + clusterResourceName
+	projectName := "acc_project_" + acctest.GenerateRandomResourceName()
+	projectResourceReference := "couchbase-capella_project." + projectName
+	cidr, err := acctest.GetCIDR("aws")
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	auditLogSettingsResourceName := "acc_audit_log_settings_" + acctest.GenerateRandomResourceName()
+	auditLogExportResourceName := "acc_audit_log_export_" + acctest.GenerateRandomResourceName()
+	auditLogExportResourceReference := "couchbase-capella_audit_log_export." + auditLogExportResourceName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAuditLogExportSetup(acctest.Cfg, projectName, projectResourceReference, clusterResourceName, clusterResourceReference, cidr, auditLogSettingsResourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAuditLogExportGetCluster(clusterResourceReference),
+				),
+			},
+			{
+				Config: testAccAuditLogExportConfig(acctest.Cfg, projectName, projectResourceReference, clusterResourceName, clusterResourceReference, cidr, auditLogExportResourceName, auditLogExportResourceReference),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(auditLogExportResourceReference, "expiration", ""),
+					resource.TestCheckResourceAttr(auditLogExportResourceReference, "audit_log_download_url", ""),
+					resource.TestCheckResourceAttr(auditLogExportResourceReference, "status", ExportStatusNoAuditLogs),
+				),
+			},
+		},
+	})
+}
+
+// create cluster and enable audit logs
+func testAccAuditLogExportSetup(providerAndVariables, projectName, projectResourceReference, clusterResourceName, clusterResourceReference, cidr, auditLogSettingsResourceName string) string {
+	config := fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_project" "%[2]s" {
+    organization_id = var.organization_id
+	name            = "%[2]s"
+	description     = "terraform audit log export test cluster"
+}
+
+resource "couchbase-capella_cluster" "%[4]s" {
+  organization_id = var.organization_id
+  project_id      = %[3]s.id
+  name            = "terraform audit log export test cluster"
+  description     = "terraform audit log export test cluster"
+  configuration_type = "multiNode"
+  cloud_provider = {
+    type   = "aws"
+    region = "us-east-1"
+    cidr   = "%[6]s"
+  }
+  service_groups = [
+    {
+      node = {
+        compute = {
+          cpu = 4
+          ram = 16
+        }
+        disk = {
+          storage = 50
+          type    = "gp3"
+          iops    = 3000
+        }
+      }
+      num_of_nodes = 3
+      services     = ["data"]
+    }
+  ]
+  availability = {
+    "type" : "multi"
+  }
+  support = {
+    plan     = "enterprise"
+    timezone = "PT"
+  }
+}
+
+resource "couchbase-capella_audit_log_settings" "%[7]s" {
+  organization_id   = var.organization_id
+  project_id        = %[3]s.id
+  cluster_id        = %[5]s.id
+  audit_enabled     = true
+  enabled_event_ids = [8243, 8257, 8265]
+  disabled_users    = []
+}
+
+`, providerAndVariables, projectName, projectResourceReference, clusterResourceName, clusterResourceReference, cidr, auditLogSettingsResourceName)
+
+	return config
+}
+
+func testAccAuditLogExportGetCluster(resourceReference string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// retrieve the resource by name from state
+
+		var rawState map[string]string
+		for _, m := range s.Modules {
+			if len(m.Resources) > 0 {
+				if v, ok := m.Resources[resourceReference]; ok {
+					rawState = v.Primary.Attributes
+				}
+			}
+		}
+		fmt.Printf("raw state %s", rawState)
+		data, err := acctest.TestClient()
+		if err != nil {
+			return err
+		}
+		err = getCluster(data, rawState["organization_id"], rawState["project_id"], rawState["id"])
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func getCluster(data *providerschema.Data, organizationId, projectId, clusterId string) error {
+	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s", data.HostURL, organizationId, projectId, clusterId)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	_, err := data.Client.ExecuteWithRetry(
+		context.Background(),
+		cfg,
+		nil,
+		data.Token,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testAccAuditLogExportConfig(providerAndVariables, projectName, projectResourceReference, clusterResourceName, clusterResourceReference, cidr, auditLogExportResourceName, auditLogExportResourceReference string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_project" "%[2]s" {
+    organization_id = var.organization_id
+	name            = "%[2]s"
+	description     = "terraform audit log export test cluster"
+}
+
+resource "couchbase-capella_cluster" "%[4]s" {
+  organization_id = var.organization_id
+  project_id      = %[3]s.id
+  name            = "terraform audit log export test cluster"
+  description     = "terraform audit log export test cluster"
+  configuration_type = "multiNode"
+  cloud_provider = {
+    type   = "aws"
+    region = "us-east-1"
+    cidr   = "%[6]s"
+  }
+  service_groups = [
+    {
+      node = {
+        compute = {
+          cpu = 4
+          ram = 16
+        }
+        disk = {
+          storage = 50
+          type    = "gp3"
+          iops    = 3000
+        }
+      }
+      num_of_nodes = 3
+      services     = ["data"]
+    }
+  ]
+  availability = {
+    "type" : "multi"
+  }
+  support = {
+    plan     = "enterprise"
+    timezone = "PT"
+  }
+}
+
+output "%[7]s" {
+  value = %[8]s
+}
+
+resource "couchbase-capella_audit_log_export" "%[7]s" {
+ organization_id = var.organization_id
+ project_id = %[3]s.id 
+ cluster_id = %[5]s.id
+ start    = "%[9]s"
+ end      = "%[10]s"
+}
+
+`, providerAndVariables, projectName, projectResourceReference, clusterResourceName, clusterResourceReference, cidr, auditLogExportResourceName, auditLogExportResourceReference, time.Now().Add(-2*time.Hour).Format("2006-01-02T15:04:05-07:00"), time.Now().Add(-1*time.Hour).Format("2006-01-02T15:04:05-07:00"))
+}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-77965](https://couchbasecloud.atlassian.net/browse/AV-77965)

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
<!-- What does this change do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

Ran acceptance test locally.  Failure is expected in below test run as delete not supported by API.  

```
TF_ACC=1 go test -timeout=300m -v -run TestAccAuditLogExportTestCases
=== RUN   TestAccAuditLogExportTestCases
audit_log_export_acceptance_test.go:36: Step 2/2 error: Error running apply: exit status 1

        Error: delete is not supported for audit log settings

        delete is not supported for audit log settings
    panic.go:626: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: delete is not supported for audit log settings

        delete is not supported for audit log settings

        Error: Audit Log Export does not support delete

        Audit Log Export does not support delete
--- FAIL: TestAccAuditLogExportTestCases (136.09s)
FAIL
exit status 1
FAIL	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/resources/acceptance_tests	136.371s
```

For below test failure is expected.  I deliberately set wrong schema in provider code ie all attributes set to required..

```
TF_ACC=1 go test -timeout=300m -v -run TestAccAuditLogExportTestCases
=== RUN   TestAccAuditLogExportTestCases

Error: Missing required argument

          on terraform_plugin_test.tf line 79, in resource "couchbase-capella_audit_log_export" "acc_audit_log_export_scagynyawr":
          79: resource "couchbase-capella_audit_log_export" "acc_audit_log_export_scagynyawr" {

        The argument "id" is required, but no definition was found.

        Error: Missing required argument

          on terraform_plugin_test.tf line 79, in resource "couchbase-capella_audit_log_export" "acc_audit_log_export_scagynyawr":
          79: resource "couchbase-capella_audit_log_export" "acc_audit_log_export_scagynyawr" {

        The argument "status" is required, but no definition was found.

        Error: Missing required argument

          on terraform_plugin_test.tf line 79, in resource "couchbase-capella_audit_log_export" "acc_audit_log_export_scagynyawr":
          79: resource "couchbase-capella_audit_log_export" "acc_audit_log_export_scagynyawr" {

        The argument "created_at" is required, but no definition was found.

        Error: Missing required argument

          on terraform_plugin_test.tf line 79, in resource "couchbase-capella_audit_log_export" "acc_audit_log_export_scagynyawr":
          79: resource "couchbase-capella_audit_log_export" "acc_audit_log_export_scagynyawr" {

        The argument "expiration" is required, but no definition was found.
```

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code

## Further comments