### PR TITLE
AV-79411 custom user agent in HTTP header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOFMT_FILES?=$$(find . -name '*.go')
 
 GITTAG=$(shell git describe --always --tags)
 VERSION=$(GITTAG:v%=%)
-LINKER_FLAGS=-s -w -X 'github.com/couchbasecloud/terraform-provider-couchbase-cloud/version.ProviderVersion=${VERSION}'
+LINKER_FLAGS=-s -w -X 'github.com/couchbasecloud/terraform-provider-couchbase-capella/version.ProviderVersion=${VERSION}'
 
 GOLANGCI_VERSION=v1.55.2
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOFLAGS=-mod=vendor
 GOOPTS="-p 2"
 GOFMT_FILES?=$$(find . -name '*.go')
 
-GITTAG=$(shell git describe --always --tags)
+GITTAG=$(shell git describe --tags --abbrev=0)
 VERSION=$(GITTAG:v%=%)
 LINKER_FLAGS=-s -w -X 'github.com/couchbasecloud/terraform-provider-couchbase-capella/version.ProviderVersion=${VERSION}'
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -134,6 +134,7 @@ func (c *Client) ExecuteWithRetry(
 		}
 
 		req.Header.Set("Authorization", "Bearer "+authToken)
+		req.Header.Set("User-Agent", userAgent)
 		for header, value := range headers {
 			req.Header.Set(header, value)
 		}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-79411](https://couchbasecloud.atlassian.net/browse/AV-79411)

## Description

Use custom user agent in HTTP header so we can identify requests from terraform.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

Tested by retrieving org details from terraform.  This uses `ExecuteWithRetry`.

Validated with `tcpdump` we get custom user agent:

```
Transmission Control Protocol, Src Port: 60791, Dst Port: 8084, Seq: 1, Ack: 1, Len: 328
Hypertext Transfer Protocol
    GET /v4/organizations/ffffffff-aaaa-1414-eeee-000000000000 HTTP/1.1\r\n
    Host: localhost:8084\r\n
    User-Agent: terraform-provider-couchbase-capella/1.2.0\r\n
    Authorization: Bearer <token>\r\n
    Accept-Encoding: gzip\r\n
```

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code

## Further comments