### PR TITLE
[AV-79969] use noop when resource is destroyed for audit logs

### DIFF
--- a/examples/audit_log_export/README.md
+++ b/examples/audit_log_export/README.md
@@ -13,6 +13,7 @@ In this example, we are going to do the following.
           detecting if resource was updated outside terraform. 
 3. UPDATE: Show it is not supported
 4. IMPORT:  Import an existing audit log export job
+5. DELETE:  It is not supported by API server so it's just a noop (ie removes resource from state file).
 
 
 If you check the `terraform.template.tfvars` file - Make sure you copy the file to `terraform.tfvars` and update the values of the variables as per the correct organization access.
@@ -45,13 +46,13 @@ Terraform will perform the following actions:
   # couchbase-capella_audit_log_export.new_auditlogexport will be created
   + resource "couchbase-capella_audit_log_export" "new_auditlogexport" {
       + audit_log_download_url = (known after apply)
-      + cluster_id            = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id            = "ffffffff-aaaa-1414-eeee-000000000000"
       + created_at            = (known after apply)
       + end                   = "2024-03-13T06:44:15+00:00"
       + expiration            = (known after apply)
       + id                    = (known after apply)
-      + organization_id       = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id            = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id       = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id            = "ffffffff-aaaa-1414-eeee-000000000000"
       + start                 = "2024-03-13T04:44:15+00:00"
       + status                = (known after apply)
     }
@@ -60,20 +61,20 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
   + existing_auditlogexport = {
-      + cluster_id      = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
       + data            = null
-      + organization_id = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id      = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
     }
   + new_auditlogexport      = {
       + audit_log_download_url = (known after apply)
-      + cluster_id            = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id            = "ffffffff-aaaa-1414-eeee-000000000000"
       + created_at            = (known after apply)
       + end                   = "2024-03-13T06:44:15+00:00"
       + expiration            = (known after apply)
       + id                    = (known after apply)
-      + organization_id       = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id            = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id       = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id            = "ffffffff-aaaa-1414-eeee-000000000000"
       + start                 = "2024-03-13T04:44:15+00:00"
       + status                = (known after apply)
     }
@@ -111,13 +112,13 @@ Terraform will perform the following actions:
   # couchbase-capella_audit_log_export.new_auditlogexport will be created
   + resource "couchbase-capella_audit_log_export" "new_auditlogexport" {
       + audit_log_download_url = (known after apply)
-      + cluster_id            = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id            = "ffffffff-aaaa-1414-eeee-000000000000"
       + created_at            = (known after apply)
       + end                   = "2024-03-13T06:44:15+00:00"
       + expiration            = (known after apply)
       + id                    = (known after apply)
-      + organization_id       = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id            = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id       = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id            = "ffffffff-aaaa-1414-eeee-000000000000"
       + start                 = "2024-03-13T04:44:15+00:00"
       + status                = (known after apply)
     }
@@ -126,20 +127,20 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
   + existing_auditlogexport = {
-      + cluster_id      = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
       + data            = null
-      + organization_id = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id      = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
     }
   + new_auditlogexport      = {
       + audit_log_download_url = (known after apply)
-      + cluster_id            = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id            = "ffffffff-aaaa-1414-eeee-000000000000"
       + created_at            = (known after apply)
       + end                   = "2024-03-13T06:44:15+00:00"
       + expiration            = (known after apply)
       + id                    = (known after apply)
-      + organization_id       = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id            = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id       = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id            = "ffffffff-aaaa-1414-eeee-000000000000"
       + start                 = "2024-03-13T04:44:15+00:00"
       + status                = (known after apply)
     }
@@ -151,27 +152,27 @@ Do you want to perform these actions?
   Enter a value: yes
 
 couchbase-capella_audit_log_export.new_auditlogexport: Creating...
-couchbase-capella_audit_log_export.new_auditlogexport: Creation complete after 0s [id=b173a42e-3c2c-4245-af81-f8615d63b5ce]
+couchbase-capella_audit_log_export.new_auditlogexport: Creation complete after 0s [id=ffffffff-aaaa-1414-eeee-000000000000]
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
 Outputs:
 
 existing_auditlogexport = {
-  "cluster_id" = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "data" = toset(null) /* of object */
-  "organization_id" = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-  "project_id" = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
 }
 new_auditlogexport = {
   "audit_log_download_url" = tostring(null)
-  "cluster_id" = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "created_at" = "2024-03-13 06:48:43.596764031 +0000 UTC"
   "end" = "2024-03-13T06:44:15+00:00"
   "expiration" = tostring(null)
-  "id" = "b173a42e-3c2c-4245-af81-f8615d63b5ce"
-  "organization_id" = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-  "project_id" = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+  "id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "start" = "2024-03-13T04:44:15+00:00"
   "status" = tostring(null)
 }
@@ -194,7 +195,7 @@ terraform plan
 │ published releases.
 ╵
 data.couchbase-capella_audit_log_export.existing_auditlogexport: Reading...
-couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=b173a42e-3c2c-4245-af81-f8615d63b5ce]
+couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=ffffffff-aaaa-1414-eeee-000000000000]
 data.couchbase-capella_audit_log_export.existing_auditlogexport: Read complete after 0s
 
 Note: Objects have changed outside of Terraform
@@ -205,7 +206,7 @@ Terraform detected the following changes made outside of Terraform since the las
   ~ resource "couchbase-capella_audit_log_export" "new_auditlogexport" {
       + audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX"
       + expiration            = "2024-03-16 06:48:46.64587117 +0000 UTC"
-        id                    = "b173a42e-3c2c-4245-af81-f8615d63b5ce"
+        id                    = "ffffffff-aaaa-1414-eeee-000000000000"
         # (6 unchanged attributes hidden)
     }
 
@@ -220,13 +221,13 @@ Changes to Outputs:
       ~ data            = null -> [
           + {
               + audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX"
-              + cluster_id            = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+              + cluster_id            = "ffffffff-aaaa-1414-eeee-000000000000"
               + created_at            = "2024-03-13 06:48:43.596764031 +0000 UTC"
               + end                   = "2024-03-13 06:44:15 +0000 UTC"
               + expiration            = "2024-03-16 06:48:46.64587117 +0000 UTC"
-              + id                    = "b173a42e-3c2c-4245-af81-f8615d63b5ce"
-              + organization_id       = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-              + project_id            = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+              + id                    = "ffffffff-aaaa-1414-eeee-000000000000"
+              + organization_id       = "ffffffff-aaaa-1414-eeee-000000000000"
+              + project_id            = "ffffffff-aaaa-1414-eeee-000000000000"
               + start                 = "2024-03-13 04:44:15 +0000 UTC"
               + status                = "Completed"
             },
@@ -236,7 +237,7 @@ Changes to Outputs:
   ~ new_auditlogexport      = {
       ~ audit_log_download_url = null -> "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX"
       ~ expiration            = null -> "2024-03-16 06:48:46.64587117 +0000 UTC"
-        id                    = "b173a42e-3c2c-4245-af81-f8615d63b5ce"
+        id                    = "ffffffff-aaaa-1414-eeee-000000000000"
         # (7 unchanged attributes hidden)
     }
 
@@ -266,7 +267,7 @@ terraform apply
 │ published releases.
 ╵
 data.couchbase-capella_audit_log_export.existing_auditlogexport: Reading...
-couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=b173a42e-3c2c-4245-af81-f8615d63b5ce]
+couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=ffffffff-aaaa-1414-eeee-000000000000]
 data.couchbase-capella_audit_log_export.existing_auditlogexport: Read complete after 0s
 
 Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
@@ -279,7 +280,7 @@ Terraform will perform the following actions:
       ~ audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX" -> (known after apply)
       ~ created_at            = "2024-03-13 06:48:43.596764031 +0000 UTC" -> (known after apply)
       ~ expiration            = "2024-03-16 06:48:46.64587117 +0000 UTC" -> (known after apply)
-        id                    = "b173a42e-3c2c-4245-af81-f8615d63b5ce"
+        id                    = "ffffffff-aaaa-1414-eeee-000000000000"
       ~ start                 = "2024-03-13T04:44:15+00:00" -> "2024-03-13T02:44:15+00:00"
       + status                = (known after apply)
         # (4 unchanged attributes hidden)
@@ -292,7 +293,7 @@ Changes to Outputs:
       ~ audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX" -> (known after apply)
       ~ created_at            = "2024-03-13 06:48:43.596764031 +0000 UTC" -> (known after apply)
       ~ expiration            = "2024-03-16 06:48:46.64587117 +0000 UTC" -> (known after apply)
-        id                    = "b173a42e-3c2c-4245-af81-f8615d63b5ce"
+        id                    = "ffffffff-aaaa-1414-eeee-000000000000"
       ~ start                 = "2024-03-13T04:44:15+00:00" -> "2024-03-13T02:44:15+00:00"
       + status                = (known after apply)
         # (4 unchanged attributes hidden)
@@ -304,7 +305,7 @@ Do you want to perform these actions?
 
   Enter a value: yes
 
-couchbase-capella_audit_log_export.new_auditlogexport: Modifying... [id=b173a42e-3c2c-4245-af81-f8615d63b5ce]
+couchbase-capella_audit_log_export.new_auditlogexport: Modifying... [id=ffffffff-aaaa-1414-eeee-000000000000]
 ╷
 │ Error: Audit Log Export does not support update
 │
@@ -331,26 +332,26 @@ Successfully removed 1 resource instance(s).
 
 ### Now, let's import the resource in Terraform
 
-Command:  `terraform import couchbase-capella_audit_log_export.new_auditlogexport id=4c7cb3f9-2ec8-4e58-add0-5f866357dcff,cluster_id=e17880b4-5124-43a5-a0e5-0735f771eae5,project_id=53fbca2e-56b7-4951-9912-7baa7396a607,organization_id=fabaa8f8-8571-4f8f-961f-6898c15b80d6`
+Command:  `terraform import couchbase-capella_audit_log_export.new_auditlogexport id=ffffffff-aaaa-1414-eeee-000000000000,cluster_id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000000,organization_id=ffffffff-aaaa-1414-eeee-000000000000`
 
 Sample Output:
 ```
-terraform import couchbase-capella_audit_log_export.new_auditlogexport id=4c7cb3f9-2ec8-4e58-add0-5f866357dcff,cluster_id=e17880b4-5124-43a5-a0e5-0735f771eae5,project_id=53fbca2e-56b7-4951-9912-7baa7396a607,organization_id=fabaa8f8-8571-4f8f-961f-6898c15b80d6
-couchbase-capella_audit_log_export.new_auditlogexport: Importing from ID "id=4c7cb3f9-2ec8-4e58-add0-5f866357dcff,cluster_id=e17880b4-5124-43a5-a0e5-0735f771eae5,project_id=53fbca2e-56b7-4951-9912-7baa7396a607,organization_id=fabaa8f8-8571-4f8f-961f-6898c15b80d6"...
+terraform import couchbase-capella_audit_log_export.new_auditlogexport id=ffffffff-aaaa-1414-eeee-000000000000,cluster_id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000000,organization_id=ffffffff-aaaa-1414-eeee-000000000000
+couchbase-capella_audit_log_export.new_auditlogexport: Importing from ID "id=ffffffff-aaaa-1414-eeee-000000000000,cluster_id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000000,organization_id=ffffffff-aaaa-1414-eeee-000000000000"...
 data.couchbase-capella_audit_log_export.existing_auditlogexport: Reading...
 couchbase-capella_audit_log_export.new_auditlogexport: Import prepared!
   Prepared couchbase-capella_audit_log_export for import
-couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=id=4c7cb3f9-2ec8-4e58-add0-5f866357dcff,cluster_id=e17880b4-5124-43a5-a0e5-0735f771eae5,project_id=53fbca2e-56b7-4951-9912-7baa7396a607,organization_id=fabaa8f8-8571-4f8f-961f-6898c15b80d6]
+couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=id=ffffffff-aaaa-1414-eeee-000000000000,cluster_id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000000,organization_id=ffffffff-aaaa-1414-eeee-000000000000]
 
 2024-03-13T12:42:14.621-0700 [WARN]  Provider "registry.terraform.io/couchbasecloud/couchbase-capella" produced an unexpected new value for couchbase-capella_audit_log_export.new_auditlogexport during refresh.
       - .audit_log_download_url: was null, but now cty.StringVal("https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX")
       - .created_at: was null, but now cty.StringVal("2024-03-13 19:38:24.355397616 +0000 UTC")
       - .end: was null, but now cty.StringVal("2024-03-13T19:19:39+00:00")
-      - .id: was cty.StringVal("id=4c7cb3f9-2ec8-4e58-add0-5f866357dcff,cluster_id=e17880b4-5124-43a5-a0e5-0735f771eae5,project_id=53fbca2e-56b7-4951-9912-7baa7396a607,organization_id=fabaa8f8-8571-4f8f-961f-6898c15b80d6"), but now cty.StringVal("4c7cb3f9-2ec8-4e58-add0-5f866357dcff")
-      - .project_id: was null, but now cty.StringVal("53fbca2e-56b7-4951-9912-7baa7396a607")
-      - .cluster_id: was null, but now cty.StringVal("e17880b4-5124-43a5-a0e5-0735f771eae5")
+      - .id: was cty.StringVal("id=ffffffff-aaaa-1414-eeee-000000000000,cluster_id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000000,organization_id=ffffffff-aaaa-1414-eeee-000000000000"), but now cty.StringVal("ffffffff-aaaa-1414-eeee-000000000000")
+      - .project_id: was null, but now cty.StringVal("ffffffff-aaaa-1414-eeee-000000000000")
+      - .cluster_id: was null, but now cty.StringVal("ffffffff-aaaa-1414-eeee-000000000000")
       - .expiration: was null, but now cty.StringVal("2024-03-16 19:38:29.842400291 +0000 UTC")
-      - .organization_id: was null, but now cty.StringVal("fabaa8f8-8571-4f8f-961f-6898c15b80d6")
+      - .organization_id: was null, but now cty.StringVal("ffffffff-aaaa-1414-eeee-000000000000")
       - .start: was null, but now cty.StringVal("2024-03-13T17:19:39+00:00")
 data.couchbase-capella_audit_log_export.existing_auditlogexport: Read complete after 0s
 
@@ -385,7 +386,7 @@ terraform plan
 │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
 ╵
 data.couchbase-capella_audit_log_export.existing_auditlogexport: Reading...
-couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=4c7cb3f9-2ec8-4e58-add0-5f866357dcff]
+couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=ffffffff-aaaa-1414-eeee-000000000000]
 data.couchbase-capella_audit_log_export.existing_auditlogexport: Read complete after 0s
 
 Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
@@ -399,7 +400,7 @@ Terraform will perform the following actions:
       ~ created_at            = "2024-03-13 19:38:24.355397616 +0000 UTC" -> (known after apply)
       ~ end                   = "2024-03-13T19:19:39+00:00" -> "2024-03-13T06:44:15+00:00"
       ~ expiration            = "2024-03-16 19:38:29.842400291 +0000 UTC" -> (known after apply)
-        id                    = "4c7cb3f9-2ec8-4e58-add0-5f866357dcff"
+        id                    = "ffffffff-aaaa-1414-eeee-000000000000"
       ~ start                 = "2024-03-13T17:19:39+00:00" -> "2024-03-13T02:44:15+00:00"
       + status                = (known after apply)
         # (3 unchanged attributes hidden)
@@ -413,25 +414,25 @@ Changes to Outputs:
             # (3 unchanged elements hidden)
             {
                 audit_log_download_url = null
-                cluster_id            = "e17880b4-5124-43a5-a0e5-0735f771eae5"
+                cluster_id            = "ffffffff-aaaa-1414-eeee-000000000000"
                 created_at            = "2024-03-13 19:28:38.869267928 +0000 UTC"
                 end                   = "2024-03-13 06:44:15 +0000 UTC"
                 expiration            = null
-                id                    = "eb39994b-fe95-483f-87c3-41ac4d2ce6d6"
-                organization_id       = "fabaa8f8-8571-4f8f-961f-6898c15b80d6"
-                project_id            = "53fbca2e-56b7-4951-9912-7baa7396a607"
+                id                    = "ffffffff-aaaa-1414-eeee-000000000000"
+                organization_id       = "ffffffff-aaaa-1414-eeee-000000000000"
+                project_id            = "ffffffff-aaaa-1414-eeee-000000000000"
                 start                 = "2024-03-13 02:44:15 +0000 UTC"
                 status                = "no audit log files exist within the requested time frame"
             },
           + {
               + audit_log_download_url = null
-              + cluster_id            = "e17880b4-5124-43a5-a0e5-0735f771eae5"
+              + cluster_id            = "ffffffff-aaaa-1414-eeee-000000000000"
               + created_at            = "2024-03-13 19:52:37.937857032 +0000 UTC"
               + end                   = "2024-03-12 19:19:39 +0000 UTC"
               + expiration            = null
               + id                    = "3043ce42-4f75-4751-927d-4f8128356ab3"
-              + organization_id       = "fabaa8f8-8571-4f8f-961f-6898c15b80d6"
-              + project_id            = "53fbca2e-56b7-4951-9912-7baa7396a607"
+              + organization_id       = "ffffffff-aaaa-1414-eeee-000000000000"
+              + project_id            = "ffffffff-aaaa-1414-eeee-000000000000"
               + start                 = "2024-03-12 17:19:39 +0000 UTC"
               + status                = "no audit log files exist within the requested time frame"
             },
@@ -443,7 +444,7 @@ Changes to Outputs:
       ~ created_at            = "2024-03-13 19:38:24.355397616 +0000 UTC" -> (known after apply)
       ~ end                   = "2024-03-13T19:19:39+00:00" -> "2024-03-13T06:44:15+00:00"
       ~ expiration            = "2024-03-16 19:38:29.842400291 +0000 UTC" -> (known after apply)
-        id                    = "4c7cb3f9-2ec8-4e58-add0-5f866357dcff"
+        id                    = "ffffffff-aaaa-1414-eeee-000000000000"
       ~ start                 = "2024-03-13T17:19:39+00:00" -> "2024-03-13T02:44:15+00:00"
       + status                = (known after apply)
         # (3 unchanged attributes hidden)
@@ -466,7 +467,7 @@ terraform apply --refresh-only
 │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
 ╵
 data.couchbase-capella_audit_log_export.existing_auditlogexport: Reading...
-couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=4c7cb3f9-2ec8-4e58-add0-5f866357dcff]
+couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=ffffffff-aaaa-1414-eeee-000000000000]
 data.couchbase-capella_audit_log_export.existing_auditlogexport: Read complete after 0s
 
 Changes to Outputs:
@@ -475,25 +476,25 @@ Changes to Outputs:
             # (3 unchanged elements hidden)
             {
                 audit_log_download_url = null
-                cluster_id            = "e17880b4-5124-43a5-a0e5-0735f771eae5"
+                cluster_id            = "ffffffff-aaaa-1414-eeee-000000000000"
                 created_at            = "2024-03-13 19:28:38.869267928 +0000 UTC"
                 end                   = "2024-03-13 06:44:15 +0000 UTC"
                 expiration            = null
-                id                    = "eb39994b-fe95-483f-87c3-41ac4d2ce6d6"
-                organization_id       = "fabaa8f8-8571-4f8f-961f-6898c15b80d6"
-                project_id            = "53fbca2e-56b7-4951-9912-7baa7396a607"
+                id                    = "ffffffff-aaaa-1414-eeee-000000000000"
+                organization_id       = "ffffffff-aaaa-1414-eeee-000000000000"
+                project_id            = "ffffffff-aaaa-1414-eeee-000000000000"
                 start                 = "2024-03-13 02:44:15 +0000 UTC"
                 status                = "no audit log files exist within the requested time frame"
             },
           + {
               + audit_log_download_url = null
-              + cluster_id            = "e17880b4-5124-43a5-a0e5-0735f771eae5"
+              + cluster_id            = "ffffffff-aaaa-1414-eeee-000000000000"
               + created_at            = "2024-03-13 19:52:37.937857032 +0000 UTC"
               + end                   = "2024-03-12 19:19:39 +0000 UTC"
               + expiration            = null
               + id                    = "3043ce42-4f75-4751-927d-4f8128356ab3"
-              + organization_id       = "fabaa8f8-8571-4f8f-961f-6898c15b80d6"
-              + project_id            = "53fbca2e-56b7-4951-9912-7baa7396a607"
+              + organization_id       = "ffffffff-aaaa-1414-eeee-000000000000"
+              + project_id            = "ffffffff-aaaa-1414-eeee-000000000000"
               + start                 = "2024-03-12 17:19:39 +0000 UTC"
               + status                = "no audit log files exist within the requested time frame"
             },
@@ -515,82 +516,215 @@ Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
 Outputs:
 
 existing_auditlogexport = {
-  "cluster_id" = "e17880b4-5124-43a5-a0e5-0735f771eae5"
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "data" = toset([
     {
       "audit_log_download_url" = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX"
-      "cluster_id" = "e17880b4-5124-43a5-a0e5-0735f771eae5"
+      "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
       "created_at" = "2024-03-13 19:38:24.355397616 +0000 UTC"
       "end" = "2024-03-13 19:19:39 +0000 UTC"
       "expiration" = "2024-03-16 19:38:29.842400291 +0000 UTC"
-      "id" = "4c7cb3f9-2ec8-4e58-add0-5f866357dcff"
-      "organization_id" = "fabaa8f8-8571-4f8f-961f-6898c15b80d6"
-      "project_id" = "53fbca2e-56b7-4951-9912-7baa7396a607"
+      "id" = "ffffffff-aaaa-1414-eeee-000000000000"
+      "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+      "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
       "start" = "2024-03-13 17:19:39 +0000 UTC"
       "status" = "Completed"
     },
     {
       "audit_log_download_url" = tostring(null)
-      "cluster_id" = "e17880b4-5124-43a5-a0e5-0735f771eae5"
+      "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
       "created_at" = "2024-03-13 19:15:09.371689973 +0000 UTC"
       "end" = "2024-03-13 06:44:15 +0000 UTC"
       "expiration" = tostring(null)
       "id" = "6ddcf7f7-408d-44ca-8e8f-6d6188d2702b"
-      "organization_id" = "fabaa8f8-8571-4f8f-961f-6898c15b80d6"
-      "project_id" = "53fbca2e-56b7-4951-9912-7baa7396a607"
+      "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+      "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
       "start" = "2024-03-13 04:44:15 +0000 UTC"
       "status" = "no audit log files exist within the requested time frame"
     },
     {
       "audit_log_download_url" = tostring(null)
-      "cluster_id" = "e17880b4-5124-43a5-a0e5-0735f771eae5"
+      "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
       "created_at" = "2024-03-13 19:20:11.7025117 +0000 UTC"
       "end" = "2024-03-13 19:19:39 +0000 UTC"
       "expiration" = tostring(null)
       "id" = "93d766c7-119a-4ca6-b0e3-9240d22be878"
-      "organization_id" = "fabaa8f8-8571-4f8f-961f-6898c15b80d6"
-      "project_id" = "53fbca2e-56b7-4951-9912-7baa7396a607"
+      "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+      "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
       "start" = "2024-03-13 17:19:39 +0000 UTC"
       "status" = "no audit log files exist within the requested time frame"
     },
     {
       "audit_log_download_url" = tostring(null)
-      "cluster_id" = "e17880b4-5124-43a5-a0e5-0735f771eae5"
+      "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
       "created_at" = "2024-03-13 19:28:38.869267928 +0000 UTC"
       "end" = "2024-03-13 06:44:15 +0000 UTC"
       "expiration" = tostring(null)
-      "id" = "eb39994b-fe95-483f-87c3-41ac4d2ce6d6"
-      "organization_id" = "fabaa8f8-8571-4f8f-961f-6898c15b80d6"
-      "project_id" = "53fbca2e-56b7-4951-9912-7baa7396a607"
+      "id" = "ffffffff-aaaa-1414-eeee-000000000000"
+      "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+      "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
       "start" = "2024-03-13 02:44:15 +0000 UTC"
       "status" = "no audit log files exist within the requested time frame"
     },
     {
       "audit_log_download_url" = tostring(null)
-      "cluster_id" = "e17880b4-5124-43a5-a0e5-0735f771eae5"
+      "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
       "created_at" = "2024-03-13 19:52:37.937857032 +0000 UTC"
       "end" = "2024-03-12 19:19:39 +0000 UTC"
       "expiration" = tostring(null)
       "id" = "3043ce42-4f75-4751-927d-4f8128356ab3"
-      "organization_id" = "fabaa8f8-8571-4f8f-961f-6898c15b80d6"
-      "project_id" = "53fbca2e-56b7-4951-9912-7baa7396a607"
+      "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+      "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
       "start" = "2024-03-12 17:19:39 +0000 UTC"
       "status" = "no audit log files exist within the requested time frame"
     },
   ])
-  "organization_id" = "fabaa8f8-8571-4f8f-961f-6898c15b80d6"
-  "project_id" = "53fbca2e-56b7-4951-9912-7baa7396a607"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
 }
 new_auditlogexport = {
   "audit_log_download_url" = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX"
-  "cluster_id" = "e17880b4-5124-43a5-a0e5-0735f771eae5"
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "created_at" = "2024-03-13 19:38:24.355397616 +0000 UTC"
   "end" = "2024-03-13T19:19:39+00:00"
   "expiration" = "2024-03-16 19:38:29.842400291 +0000 UTC"
-  "id" = "4c7cb3f9-2ec8-4e58-add0-5f866357dcff"
-  "organization_id" = "fabaa8f8-8571-4f8f-961f-6898c15b80d6"
-  "project_id" = "53fbca2e-56b7-4951-9912-7baa7396a607"
+  "id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "start" = "2024-03-13T17:19:39+00:00"
   "status" = tostring(null)
 }
+```
+
+## DESTROY
+### This only removes resource from the state file.
+
+Command: `terraform destroy`
+
+Sample Output:
+```
+terraform destroy
+╷
+│ Warning: Provider development overrides are in effect
+│
+│ The following provider development overrides are set in the CLI configuration:
+│  - couchbasecloud/couchbase-capella in /Users/$USER/GolandProjects/terraform-provider-couchbase-capella/bin
+│
+│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
+╵
+data.couchbase-capella_audit_log_export.existing_auditlogexport: Reading...
+couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=ffffffff-aaaa-1414-eeee-000000000000]
+data.couchbase-capella_audit_log_export.existing_auditlogexport: Read complete after 0s
+
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+- destroy
+
+Terraform will perform the following actions:
+
+# couchbase-capella_audit_log_export.new_auditlogexport will be destroyed
+- resource "couchbase-capella_audit_log_export" "new_auditlogexport" {
+    - audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX" -> null
+    - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000" -> null
+    - created_at             = "2024-06-10 21:16:50.415705947 +0000 UTC" -> null
+    - end                    = "2024-06-10T21:09:11+00:00" -> null
+    - expiration             = "2024-06-13 21:16:54.37230845 +0000 UTC" -> null
+    - id                     = "ffffffff-aaaa-1414-eeee-000000000000" -> null
+    - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000" -> null
+    - project_id             = "ffffffff-aaaa-1414-eeee-000000000000" -> null
+    - start                  = "2024-06-10T20:09:11+00:00" -> null
+      }
+
+Plan: 0 to add, 0 to change, 1 to destroy.
+
+Changes to Outputs:
+- existing_auditlogexport = {
+    - cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
+    - data            = [
+        - {
+            - audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX"
+            - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+            - created_at             = "2024-06-10 21:16:50.415705947 +0000 UTC"
+            - end                    = "2024-06-10 21:09:11 +0000 UTC"
+            - expiration             = "2024-06-13 21:16:54.37230845 +0000 UTC"
+            - id                     = "ffffffff-aaaa-1414-eeee-000000000000"
+            - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
+            - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+            - start                  = "2024-06-10 20:09:11 +0000 UTC"
+            - status                 = "Completed"
+              },
+        - {
+            - audit_log_download_url = null
+            - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+            - created_at             = "2024-06-10 21:03:15.896348051 +0000 UTC"
+            - end                    = "2024-05-28 21:52:38 +0000 UTC"
+            - expiration             = null
+            - id                     = "058091cf-f966-46a7-96ea-4801ad31bfb2"
+            - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
+            - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+            - start                  = "2024-05-28 18:52:38 +0000 UTC"
+            - status                 = "no audit log files exist within the requested time frame"
+              },
+        - {
+            - audit_log_download_url = null
+            - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+            - created_at             = "2024-06-10 21:03:50.081716726 +0000 UTC"
+            - end                    = "2024-05-28 21:52:38 +0000 UTC"
+            - expiration             = null
+            - id                     = "26cb94d8-5d86-4964-ab5a-bd36fedbf13f"
+            - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
+            - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+            - start                  = "2024-05-28 18:52:38 +0000 UTC"
+            - status                 = "no audit log files exist within the requested time frame"
+              },
+        - {
+            - audit_log_download_url = null
+            - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+            - created_at             = "2024-06-10 21:12:19.656434023 +0000 UTC"
+            - end                    = "2024-06-10 21:09:11 +0000 UTC"
+            - expiration             = null
+            - id                     = "23b12e1a-d84d-48b6-8d09-4df2e5e6b4a7"
+            - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
+            - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+            - start                  = "2024-06-10 20:09:11 +0000 UTC"
+            - status                 = "no audit log files exist within the requested time frame"
+              },
+        - {
+            - audit_log_download_url = null
+            - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+            - created_at             = "2024-06-10 21:14:28.070136553 +0000 UTC"
+            - end                    = "2024-06-10 21:09:11 +0000 UTC"
+            - expiration             = null
+            - id                     = "f658e557-45b7-4be7-a25d-d6c9edc9a122"
+            - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
+            - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+            - start                  = "2024-06-10 20:09:11 +0000 UTC"
+            - status                 = "no audit log files exist within the requested time frame"
+              },
+              ]
+    - organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
+    - project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
+      } -> null
+- new_auditlogexport      = {
+    - audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX"
+    - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+    - created_at             = "2024-06-10 21:16:50.415705947 +0000 UTC"
+    - end                    = "2024-06-10T21:09:11+00:00"
+    - expiration             = "2024-06-13 21:16:54.37230845 +0000 UTC"
+    - id                     = "ffffffff-aaaa-1414-eeee-000000000000"
+    - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
+    - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
+    - start                  = "2024-06-10T20:09:11+00:00"
+    - status                 = null
+      } -> null
+
+Do you really want to destroy all resources?
+Terraform will destroy all your managed infrastructure, as shown above.
+There is no undo. Only 'yes' will be accepted to confirm.
+
+Enter a value: yes
+
+couchbase-capella_audit_log_export.new_auditlogexport: Destroying... [id=ffffffff-aaaa-1414-eeee-000000000000]
+couchbase-capella_audit_log_export.new_auditlogexport: Destruction complete after 0s
+
+Destroy complete! Resources: 1 destroyed.
 ```

--- a/examples/audit_log_export/README.md
+++ b/examples/audit_log_export/README.md
@@ -8,12 +8,11 @@ To run, configure your Couchbase Capella provider as described in README in the 
 
 In this example, we are going to do the following.
 
-1.  CREATE: Create a new audit log export job in Capella per the `create_audit_log_exports.tf` file.
-2.  LIST: List existing audit log export jobs in Capella as stated in the `list_audit_log_exports.tf` file, and
+1. CREATE: Create a new audit log export job in Capella per the `create_audit_log_exports.tf` file.
+2. LIST: List existing audit log export jobs in Capella as stated in the `list_audit_log_exports.tf` file, and
           detecting if resource was updated outside terraform. 
-3.  UPDATE: Show it is not supported
-4.  DELETE: Show it is not supported
-5.  IMPORT:  Import an existing audit log export job
+3. UPDATE: Show it is not supported
+4. IMPORT:  Import an existing audit log export job
 
 
 If you check the `terraform.template.tfvars` file - Make sure you copy the file to `terraform.tfvars` and update the values of the variables as per the correct organization access.
@@ -315,80 +314,6 @@ couchbase-capella_audit_log_export.new_auditlogexport: Modifying... [id=b173a42e
 │
 │ Audit Log Export does not support update
 ╵
-```
-
-###  Delete is not supported
-
-Command: `terraform destroy`
-
-Sample output:
-```
-terraform destroy
-╷
-│ Warning: Provider development overrides are in effect
-│
-│ The following provider development overrides are set in the CLI configuration:
-│  - couchbasecloud/couchbase-capella in /Users/$USER/workspace/terraform-provider-couchbase-capella/bin
-│
-│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
-│ published releases.
-╵
-couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=b173a42e-3c2c-4245-af81-f8615d63b5ce]
-data.couchbase-capella_audit_log_export.existing_auditlogexport: Reading...
-data.couchbase-capella_audit_log_export.existing_auditlogexport: Read complete after 0s
-
-Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-  - destroy
-
-Terraform will perform the following actions:
-
-  # couchbase-capella_audit_log_export.new_auditlogexport will be destroyed
-  - resource "couchbase-capella_audit_log_export" "new_auditlogexport" {
-      - audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX" -> null
-      - cluster_id            = "41938b91-66ed-4c84-b70c-55c3f0ae4266" -> null
-      - created_at            = "2024-03-13 06:48:43.596764031 +0000 UTC" -> null
-      - end                   = "2024-03-13T06:44:15+00:00" -> null
-      - expiration            = "2024-03-16 06:48:46.64587117 +0000 UTC" -> null
-      - id                    = "b173a42e-3c2c-4245-af81-f8615d63b5ce" -> null
-      - organization_id       = "637cea1d-fce5-40a5-9d48-8d0690e656ee" -> null
-      - project_id            = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90" -> null
-      - start                 = "2024-03-13T04:44:15+00:00" -> null
-    }
-
-Plan: 0 to add, 0 to change, 1 to destroy.
-
-Changes to Outputs:
-  - existing_auditlogexport = {
-      - cluster_id      = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
-      - data            = [
-          - {
-              - audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX"
-              - cluster_id            = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
-              - created_at            = "2024-03-13 06:48:43.596764031 +0000 UTC"
-              - end                   = "2024-03-13 06:44:15 +0000 UTC"
-              - expiration            = "2024-03-16 06:48:46.64587117 +0000 UTC"
-              - id                    = "b173a42e-3c2c-4245-af81-f8615d63b5ce"
-              - organization_id       = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-              - project_id            = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
-              - start                 = "2024-03-13 04:44:15 +0000 UTC"
-              - status                = "Completed"
-            },
-        ]
-      - organization_id = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      - project_id      = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
-    } -> null
-
-Do you really want to destroy all resources?
-  Terraform will destroy all your managed infrastructure, as shown above.
-  There is no undo. Only 'yes' will be accepted to confirm.
-
-  Enter a value: yes
-
-couchbase-capella_audit_log_export.new_auditlogexport: Destroying... [id=b173a42e-3c2c-4245-af81-f8615d63b5ce]
-╷
-│ Error: Audit Log Export does not support delete
-│
-│ Audit Log Export does not support delete
 ```
 
 ## IMPORT

--- a/examples/audit_log_settings/README.md
+++ b/examples/audit_log_settings/README.md
@@ -12,7 +12,6 @@ In this example, we are going to do the following.
 2.  UPDATE: Update the audit log settings configuration using Terraform.
 3.  Detect the resource was updated from outside of Terraform
 4.  IMPORT: Import audit log settings that exists in Capella but not in the terraform state file.
-5.  DELETE: Show it is not supported
 
 If you check the `terraform.template.tfvars` file - Make sure you copy the file to `terraform.tfvars` and update the values of the variables as per the correct organization access.
 
@@ -541,79 +540,6 @@ Here, we pass the IDs as a single comma-separated string.
 The first ID in the string is the cluster ID.
 The second ID is the project ID i.e. the ID of the project to which the cluster belongs.
 The third ID is the organization ID i.e. the ID of the organization to which the project belongs.
-
-## DESTROY
-### The audit log settings API does not support delete, so it will throw an error
-
-Command: `terraform destroy`
-
-Sample output:
-```
-terraform apply
-╷
-│ Warning: Provider development overrides are in effect
-│
-│ The following provider development overrides are set in the CLI configuration:
-│  - couchbasecloud/couchbase-capella in /Users/$USER/workspace/terraform-provider-couchbase-capella/bin
-│
-│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
-│ published releases.
-╵
-data.couchbase-capella_audit_log_settings.existing_auditlogsettings: Reading...
-couchbase-capella_audit_log_settings.new_auditlogsettings: Refreshing state...
-data.couchbase-capella_audit_log_settings.existing_auditlogsettings: Read complete after 0s
-
-Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-  - destroy
-
-Terraform will perform the following actions:
-
-  # couchbase-capella_audit_log_settings.new_auditlogsettings will be destroyed
-  # (because couchbase-capella_audit_log_settings.new_auditlogsettings is not in configuration)
-  - resource "couchbase-capella_audit_log_settings" "new_auditlogsettings" {
-      - audit_enabled     = true -> null
-      - cluster_id        = "41938b91-66ed-4c84-b70c-55c3f0ae4266" -> null
-      - disabled_users    = [] -> null
-      - enabled_event_ids = [
-          - 20488,
-          - 20490,
-          - 20491,
-        ] -> null
-      - organization_id   = "637cea1d-fce5-40a5-9d48-8d0690e656ee" -> null
-      - project_id        = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90" -> null
-    }
-
-Plan: 0 to add, 0 to change, 1 to destroy.
-
-Changes to Outputs:
-  - new_auditlogsettings      = {
-      - audit_enabled     = true
-      - cluster_id        = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
-      - disabled_users    = []
-      - enabled_event_ids = [
-          - 20488,
-          - 20490,
-          - 20491,
-        ]
-      - organization_id   = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      - project_id        = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
-    } -> null
-
-Do you want to perform these actions?
-  Terraform will perform the actions described above.
-  Only 'yes' will be accepted to approve.
-
-  Enter a value: yes
-
-couchbase-capella_audit_log_settings.new_auditlogsettings: Destroying...
-2024-03-12T20:41:15.279-0700 [ERROR] provider.terraform-provider-couchbase-capella: Response contains error diagnostic: tf_provider_addr=hashicorp.com/couchbasecloud/couchbase-capella tf_rpc=ApplyResourceChange @caller=/Users/hiteshwalia/.gvm/pkgsets/go1.21.6/global/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.21.0/tfprotov6/internal/diag/diagnostics.go:62 diagnostic_severity=ERROR tf_proto_version=6.4 diagnostic_detail="delete is not supported for audit log settings" tf_req_id=7b0196ba-cd83-fb99-256c-78373905e16b @module=sdk.proto diagnostic_summary="delete is not supported audit log settings" tf_resource_type=couchbase-capella_audit_log_settings timestamp=2024-03-12T20:41:15.278-0700
-2024-03-12T20:41:15.303-0700 [ERROR] vertex "couchbase-capella_audit_log_settings.new_auditlogsettings (destroy)" error: delete is not supported audit log settings
-╷
-│ Error: delete is not supported audit log settings
-│
-│ delete is not supported for audit log settings
-╵
-```
 
 ### This example shows how to configure a disabled user
 ### We use an internal user @eventing in local domain

--- a/examples/audit_log_settings/README.md
+++ b/examples/audit_log_settings/README.md
@@ -12,6 +12,7 @@ In this example, we are going to do the following.
 2.  UPDATE: Update the audit log settings configuration using Terraform.
 3.  Detect the resource was updated from outside of Terraform
 4.  IMPORT: Import audit log settings that exists in Capella but not in the terraform state file.
+5.  DELETE:  It is not supported by API server so it's just a noop (ie removes resource from state file).
 
 If you check the `terraform.template.tfvars` file - Make sure you copy the file to `terraform.tfvars` and update the values of the variables as per the correct organization access.
 
@@ -43,15 +44,15 @@ Terraform will perform the following actions:
   # couchbase-capella_audit_log_settings.new_auditlogsettings will be created
   + resource "couchbase-capella_audit_log_settings" "new_auditlogsettings" {
       + audit_enabled     = true
-      + cluster_id        = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
       + disabled_users    = []
       + enabled_event_ids = [
           + 20488,
           + 20490,
           + 20491,
         ]
-      + organization_id   = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id        = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -59,7 +60,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Changes to Outputs:
   + existing_auditlogsettings = {
       + audit_enabled     = false
-      + cluster_id        = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
       + disabled_users    = []
       + enabled_event_ids = [
           + 8243,
@@ -110,20 +111,20 @@ Changes to Outputs:
           + 45073,
           + 45074,
         ]
-      + organization_id   = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id        = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
     }
   + new_auditlogsettings      = {
       + audit_enabled     = true
-      + cluster_id        = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
       + disabled_users    = []
       + enabled_event_ids = [
           + 20488,
           + 20490,
           + 20491,
         ]
-      + organization_id   = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id        = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
     }
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -159,15 +160,15 @@ Terraform will perform the following actions:
   # couchbase-capella_audit_log_settings.new_auditlogsettings will be created
   + resource "couchbase-capella_audit_log_settings" "new_auditlogsettings" {
       + audit_enabled     = true
-      + cluster_id        = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
       + disabled_users    = []
       + enabled_event_ids = [
           + 20488,
           + 20490,
           + 20491,
         ]
-      + organization_id   = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id        = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -175,7 +176,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Changes to Outputs:
   + existing_auditlogsettings = {
       + audit_enabled     = false
-      + cluster_id        = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
       + disabled_users    = []
       + enabled_event_ids = [
           + 8243,
@@ -226,20 +227,20 @@ Changes to Outputs:
           + 45073,
           + 45074,
         ]
-      + organization_id   = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id        = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
     }
   + new_auditlogsettings      = {
       + audit_enabled     = true
-      + cluster_id        = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+      + cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
       + disabled_users    = []
       + enabled_event_ids = [
           + 20488,
           + 20490,
           + 20491,
         ]
-      + organization_id   = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-      + project_id        = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+      + organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
     }
 
 Do you want to perform these actions?
@@ -257,7 +258,7 @@ Outputs:
 
 existing_auditlogsettings = {
   "audit_enabled" = false
-  "cluster_id" = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "disabled_users" = toset([])
   "enabled_event_ids" = toset([
     8243,
@@ -308,20 +309,20 @@ existing_auditlogsettings = {
     45073,
     45074,
   ])
-  "organization_id" = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-  "project_id" = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
 }
 new_auditlogsettings = {
   "audit_enabled" = true
-  "cluster_id" = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "disabled_users" = tolist([])
   "enabled_event_ids" = tolist([
     20488,
     20490,
     20491,
   ])
-  "organization_id" = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-  "project_id" = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
 }
 
 ```
@@ -436,27 +437,27 @@ Outputs:
 
 existing_auditlogsettings = {
   "audit_enabled" = true
-  "cluster_id" = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "disabled_users" = toset([])
   "enabled_event_ids" = toset([
     20488,
     20490,
     20491,
   ])
-  "organization_id" = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-  "project_id" = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
 }
 new_auditlogsettings = {
   "audit_enabled" = false
-  "cluster_id" = "41938b91-66ed-4c84-b70c-55c3f0ae4266"
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "disabled_users" = tolist([])
   "enabled_event_ids" = tolist([
     20488,
     20490,
     20491,
   ])
-  "organization_id" = "637cea1d-fce5-40a5-9d48-8d0690e656ee"
-  "project_id" = "6aa13dbf-69cb-48e3-97af-d89f57ea7f90"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
 }
 ```
 
@@ -515,8 +516,8 @@ Command: `terraform import couchbase-capella_audit_log_settings.new_auditlogsett
 
 Sample Output:
 ```
-terraform import couchbase-capella_audit_log_settings.new_auditlogsettings id=41938b91-66ed-4c84-b70c-55c3f0ae4266,project_id=6aa13dbf-69cb-48e3-97af-d89f57ea7f90,organization_id=637cea1d-fce5-40a5-9d48-8d0690e656ee
-couchbase-capella_audit_log_settings.new_auditlogsettings: Importing from ID "id=41938b91-66ed-4c84-b70c-55c3f0ae4266,project_id=6aa13dbf-69cb-48e3-97af-d89f57ea7f90,organization_id=637cea1d-fce5-40a5-9d48-8d0690e656ee"...
+terraform import couchbase-capella_audit_log_settings.new_auditlogsettings id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000000,organization_id=ffffffff-aaaa-1414-eeee-000000000000
+couchbase-capella_audit_log_settings.new_auditlogsettings: Importing from ID "id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000000,organization_id=ffffffff-aaaa-1414-eeee-000000000000"...
 data.couchbase-capella_audit_log_settings.existing_auditlogsettings: Reading...
 couchbase-capella_audit_log_settings.new_auditlogsettings: Import prepared!
   Prepared couchbase-capella_audit_log_settings for import
@@ -524,10 +525,10 @@ couchbase-capella_audit_log_settings.new_auditlogsettings: Refreshing state...
 data.couchbase-capella_audit_log_settings.existing_auditlogsettings: Read complete after 1s
 2024-03-12T20:35:56.149-0700 [WARN]  Provider "registry.terraform.io/couchbasecloud/couchbase-capella" produced an unexpected new value for couchbase-capella_audit_log_settings.new_auditlogsettings during refresh.
       - .enabled_event_ids: was null, but now cty.ListVal([]cty.Value{cty.NumberIntVal(20488), cty.NumberIntVal(20490), cty.NumberIntVal(20491)})
-      - .organization_id: was null, but now cty.StringVal("637cea1d-fce5-40a5-9d48-8d0690e656ee")
-      - .project_id: was null, but now cty.StringVal("6aa13dbf-69cb-48e3-97af-d89f57ea7f90")
+      - .organization_id: was null, but now cty.StringVal("ffffffff-aaaa-1414-eeee-000000000000")
+      - .project_id: was null, but now cty.StringVal("ffffffff-aaaa-1414-eeee-000000000000")
       - .audit_enabled: was null, but now cty.True
-      - .cluster_id: was cty.StringVal("id=41938b91-66ed-4c84-b70c-55c3f0ae4266,project_id=6aa13dbf-69cb-48e3-97af-d89f57ea7f90,organization_id=637cea1d-fce5-40a5-9d48-8d0690e656ee"), but now cty.StringVal("41938b91-66ed-4c84-b70c-55c3f0ae4266")
+      - .cluster_id: was cty.StringVal("id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000000,organization_id=ffffffff-aaaa-1414-eeee-000000000000"), but now cty.StringVal("ffffffff-aaaa-1414-eeee-000000000000")
       - .disabled_users: was null, but now cty.ListValEmpty(cty.Object(map[string]cty.Type{"domain":cty.String, "name":cty.String}))
 
 Import successful!
@@ -571,7 +572,7 @@ Terraform will perform the following actions:
   # couchbase-capella_audit_log_settings.new_auditlogsettings will be created
   + resource "couchbase-capella_audit_log_settings" "new_auditlogsettings" {
       + audit_enabled     = true
-      + cluster_id        = "eb057928-b374-4a7f-a975-c495d7943594"
+      + cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
       + disabled_users    = [
           + {
               + domain = "local"
@@ -583,8 +584,8 @@ Terraform will perform the following actions:
           + 20490,
           + 20491,
         ]
-      + organization_id   = "2cde9b42-0399-471c-a86d-c3f281eba5c0"
-      + project_id        = "3a5d9251-4247-4c51-aeb6-b799b41a91ba"
+      + organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -592,19 +593,19 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Changes to Outputs:
   + existing_auditlogsettings = {
       + audit_enabled     = true
-      + cluster_id        = "eb057928-b374-4a7f-a975-c495d7943594"
+      + cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
       + disabled_users    = []
       + enabled_event_ids = [
           + 20488,
           + 20490,
           + 20491,
         ]
-      + organization_id   = "2cde9b42-0399-471c-a86d-c3f281eba5c0"
-      + project_id        = "3a5d9251-4247-4c51-aeb6-b799b41a91ba"
+      + organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
     }
   + new_auditlogsettings      = {
       + audit_enabled     = true
-      + cluster_id        = "eb057928-b374-4a7f-a975-c495d7943594"
+      + cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
       + disabled_users    = [
           + {
               + domain = "local"
@@ -616,8 +617,8 @@ Changes to Outputs:
           + 20490,
           + 20491,
         ]
-      + organization_id   = "2cde9b42-0399-471c-a86d-c3f281eba5c0"
-      + project_id        = "3a5d9251-4247-4c51-aeb6-b799b41a91ba"
+      + organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
     }
 
 Do you want to perform these actions?
@@ -635,19 +636,19 @@ Outputs:
 
 existing_auditlogsettings = {
   "audit_enabled" = true
-  "cluster_id" = "eb057928-b374-4a7f-a975-c495d7943594"
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "disabled_users" = toset([])
   "enabled_event_ids" = toset([
     20488,
     20490,
     20491,
   ])
-  "organization_id" = "2cde9b42-0399-471c-a86d-c3f281eba5c0"
-  "project_id" = "3a5d9251-4247-4c51-aeb6-b799b41a91ba"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
 }
 new_auditlogsettings = {
   "audit_enabled" = true
-  "cluster_id" = "eb057928-b374-4a7f-a975-c495d7943594"
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
   "disabled_users" = toset([
     {
       "domain" = "local"
@@ -659,7 +660,74 @@ new_auditlogsettings = {
     20490,
     20491,
   ])
-  "organization_id" = "2cde9b42-0399-471c-a86d-c3f281eba5c0"
-  "project_id" = "3a5d9251-4247-4c51-aeb6-b799b41a91ba"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
 }
+```
+
+## DESTROY
+### This only removes resource from the state file.
+
+Command: `terraform destroy`
+
+Sample Output:
+```
+terraform destroy
+╷
+│ Warning: Provider development overrides are in effect
+│
+│ The following provider development overrides are set in the CLI configuration:
+│  - couchbasecloud/couchbase-capella in /Users/$USER/GolandProjects/terraform-provider-couchbase-capella/bin
+│
+│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
+╵
+data.couchbase-capella_audit_log_settings.existing_auditlogsettings: Reading...
+couchbase-capella_audit_log_settings.new_auditlogsettings: Refreshing state...
+data.couchbase-capella_audit_log_settings.existing_auditlogsettings: Read complete after 1s
+
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+  - destroy
+
+Terraform will perform the following actions:
+
+  # couchbase-capella_audit_log_settings.new_auditlogsettings will be destroyed
+  - resource "couchbase-capella_audit_log_settings" "new_auditlogsettings" {
+      - audit_enabled     = true -> null
+      - cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000" -> null
+      - disabled_users    = [] -> null
+      - enabled_event_ids = [
+          - 20488,
+          - 20490,
+          - 20491,
+        ] -> null
+      - organization_id   = "ffffffff-aaaa-1414-eeee-000000000000" -> null
+      - project_id        = "ffffffff-aaaa-1414-eeee-000000000000" -> null
+    }
+
+Plan: 0 to add, 0 to change, 1 to destroy.
+
+Changes to Outputs:
+  - existing_auditlogsettings = {
+      - audit_enabled     = true
+      - cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
+      - disabled_users    = []
+      - enabled_event_ids = [
+          - 20488,
+          - 20490,
+          - 20491,
+        ]
+      - organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
+      - project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
+    } -> null
+
+Do you really want to destroy all resources?
+  Terraform will destroy all your managed infrastructure, as shown above.
+  There is no undo. Only 'yes' will be accepted to confirm.
+
+  Enter a value: yes
+
+couchbase-capella_audit_log_settings.new_auditlogsettings: Destroying...
+couchbase-capella_audit_log_settings.new_auditlogsettings: Destruction complete after 0s
+
+Destroy complete! Resources: 1 destroyed.
 ```

--- a/examples/getting_started/README.md
+++ b/examples/getting_started/README.md
@@ -3045,11 +3045,8 @@ couchbase-capella_cluster.new_cluster: Destruction complete after 8m40s
 couchbase-capella_project.new_project: Destroying... [id=ffffffff-aaaa-1414-eeee-000000000000]
 couchbase-capella_project.new_project: Destruction complete after 2s
 couchbase-capella_audit_log_settings.new_auditlogsettings: Destroying...
-╷
-│ Error: delete is not supported for audit log settings
-│
-│ delete is not supported for audit log settings
- 
-
+couchbase-capella_audit_log_settings.new_auditlogsettings: Destruction complete after 0s
+couchbase-capella_audit_log_export.new_auditlogexport: Destroying... [id=ffffffff-aaaa-1414-eeee-000000000000]
+couchbase-capella_audit_log_export.new_auditlogexport: Destruction complete after 0s
 
 ```

--- a/internal/resources/audit_log_export.go
+++ b/internal/resources/audit_log_export.go
@@ -225,9 +225,11 @@ func (a *AuditLogExport) Update(_ context.Context, _ resource.UpdateRequest, res
 	)
 }
 
-// Delete is not supported as audit log export API does not have delete endpoint, so we do a noop.
 func (a *AuditLogExport) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.State.RemoveResource(ctx)
+	// There is no V4 API to delete audit log export, so we do a noop.
+	//
+	// The framework will automatically update the state file. See:
+	// https://developer.hashicorp.com/terraform/plugin/framework/resources/delete#recommendations
 }
 
 func (a *AuditLogExport) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/resources/audit_log_export.go
+++ b/internal/resources/audit_log_export.go
@@ -225,12 +225,9 @@ func (a *AuditLogExport) Update(_ context.Context, _ resource.UpdateRequest, res
 	)
 }
 
-// Delete is not supported as audit log export API does not have delete endpoint.
-func (a *AuditLogExport) Delete(_ context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.Diagnostics.AddError(
-		"Audit Log Export does not support delete",
-		"Audit Log Export does not support delete",
-	)
+// Delete is not supported as audit log export API does not have delete endpoint, so we do a noop.
+func (a *AuditLogExport) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.State.RemoveResource(ctx)
 }
 
 func (a *AuditLogExport) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/resources/audit_log_settings.go
+++ b/internal/resources/audit_log_settings.go
@@ -273,12 +273,9 @@ func (a *AuditLogSettings) Update(ctx context.Context, req resource.UpdateReques
 	}
 }
 
-// AuditLogSettings does not have delete endpoint.
-func (a *AuditLogSettings) Delete(_ context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.Diagnostics.AddError(
-		"delete is not supported for audit log settings",
-		"delete is not supported for audit log settings",
-	)
+// AuditLogSettings does not have delete endpoint, so we do a noop.
+func (a *AuditLogSettings) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.State.RemoveResource(ctx)
 }
 
 func (a *AuditLogSettings) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/resources/audit_log_settings.go
+++ b/internal/resources/audit_log_settings.go
@@ -273,9 +273,11 @@ func (a *AuditLogSettings) Update(ctx context.Context, req resource.UpdateReques
 	}
 }
 
-// AuditLogSettings does not have delete endpoint, so we do a noop.
 func (a *AuditLogSettings) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.State.RemoveResource(ctx)
+	// There is no V4 API to delete audit log settings, so we do a noop.
+	//
+	// The framework will automatically update the state file. See:
+	// https://developer.hashicorp.com/terraform/plugin/framework/resources/delete#recommendations
 }
 
 func (a *AuditLogSettings) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-79969](https://couchbasecloud.atlassian.net/browse/AV-79969)

## Description

Currently delete returns an error.  This can be problematic.  For example, if there is an error during create the resource is marked as tainted.  If you then run terraform plan , terraform will destroy the resource.  Since delete returns an error, this will also fail.  

It is better to do a noop for delete.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [X] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

// validate no error on destroy settings

```
terraform destroy
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/$USER/GolandProjects/terraform-provider-couchbase-capella/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.couchbase-capella_audit_log_settings.existing_auditlogsettings: Reading...
couchbase-capella_audit_log_settings.new_auditlogsettings: Refreshing state...
data.couchbase-capella_audit_log_settings.existing_auditlogsettings: Read complete after 1s

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # couchbase-capella_audit_log_settings.new_auditlogsettings will be destroyed
  - resource "couchbase-capella_audit_log_settings" "new_auditlogsettings" {
      - audit_enabled     = true -> null
      - cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000" -> null
      - disabled_users    = [] -> null
      - enabled_event_ids = [
          - 20488,
          - 20490,
          - 20491,
        ] -> null
      - organization_id   = "ffffffff-aaaa-1414-eeee-000000000000" -> null
      - project_id        = "ffffffff-aaaa-1414-eeee-000000000000" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - existing_auditlogsettings = {
      - audit_enabled     = true
      - cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
      - disabled_users    = []
      - enabled_event_ids = [
          - 20488,
          - 20490,
          - 20491,
        ]
      - organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
      - project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
    } -> null
  - new_auditlogsettings      = {
      - audit_enabled     = true
      - cluster_id        = "ffffffff-aaaa-1414-eeee-000000000000"
      - disabled_users    = []
      - enabled_event_ids = [
          - 20488,
          - 20490,
          - 20491,
        ]
      - organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
      - project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
    } -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

couchbase-capella_audit_log_settings.new_auditlogsettings: Destroying...
couchbase-capella_audit_log_settings.new_auditlogsettings: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```

// validate no error on destroy export

```
terraform destroy
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/$USER/GolandProjects/terraform-provider-couchbase-capella/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.couchbase-capella_audit_log_export.existing_auditlogexport: Reading...
couchbase-capella_audit_log_export.new_auditlogexport: Refreshing state... [id=ffffffff-aaaa-1414-eeee-000000000000]
data.couchbase-capella_audit_log_export.existing_auditlogexport: Read complete after 0s

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # couchbase-capella_audit_log_export.new_auditlogexport will be destroyed
  - resource "couchbase-capella_audit_log_export" "new_auditlogexport" {
      - audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX" -> null
      - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000" -> null
      - created_at             = "2024-06-10 21:16:50.415705947 +0000 UTC" -> null
      - end                    = "2024-06-10T21:09:11+00:00" -> null
      - expiration             = "2024-06-13 21:16:54.37230845 +0000 UTC" -> null
      - id                     = "ffffffff-aaaa-1414-eeee-000000000000" -> null
      - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000" -> null
      - project_id             = "ffffffff-aaaa-1414-eeee-000000000000" -> null
      - start                  = "2024-06-10T20:09:11+00:00" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - existing_auditlogexport = {
      - cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      - data            = [
          - {
              - audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX"
              - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
              - created_at             = "2024-06-10 21:16:50.415705947 +0000 UTC"
              - end                    = "2024-06-10 21:09:11 +0000 UTC"
              - expiration             = "2024-06-13 21:16:54.37230845 +0000 UTC"
              - id                     = "ffffffff-aaaa-1414-eeee-000000000000"
              - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
              - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
              - start                  = "2024-06-10 20:09:11 +0000 UTC"
              - status                 = "Completed"
            },
          - {
              - audit_log_download_url = null
              - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
              - created_at             = "2024-06-10 21:03:15.896348051 +0000 UTC"
              - end                    = "2024-05-28 21:52:38 +0000 UTC"
              - expiration             = null
              - id                     = "058091cf-f966-46a7-96ea-4801ad31bfb2"
              - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
              - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
              - start                  = "2024-05-28 18:52:38 +0000 UTC"
              - status                 = "no audit log files exist within the requested time frame"
            },
          - {
              - audit_log_download_url = null
              - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
              - created_at             = "2024-06-10 21:03:50.081716726 +0000 UTC"
              - end                    = "2024-05-28 21:52:38 +0000 UTC"
              - expiration             = null
              - id                     = "26cb94d8-5d86-4964-ab5a-bd36fedbf13f"
              - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
              - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
              - start                  = "2024-05-28 18:52:38 +0000 UTC"
              - status                 = "no audit log files exist within the requested time frame"
            },
          - {
              - audit_log_download_url = null
              - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
              - created_at             = "2024-06-10 21:12:19.656434023 +0000 UTC"
              - end                    = "2024-06-10 21:09:11 +0000 UTC"
              - expiration             = null
              - id                     = "23b12e1a-d84d-48b6-8d09-4df2e5e6b4a7"
              - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
              - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
              - start                  = "2024-06-10 20:09:11 +0000 UTC"
              - status                 = "no audit log files exist within the requested time frame"
            },
          - {
              - audit_log_download_url = null
              - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
              - created_at             = "2024-06-10 21:14:28.070136553 +0000 UTC"
              - end                    = "2024-06-10 21:09:11 +0000 UTC"
              - expiration             = null
              - id                     = "f658e557-45b7-4be7-a25d-d6c9edc9a122"
              - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
              - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
              - start                  = "2024-06-10 20:09:11 +0000 UTC"
              - status                 = "no audit log files exist within the requested time frame"
            },
        ]
      - organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      - project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
    } -> null
  - new_auditlogexport      = {
      - audit_log_download_url = "https://cb-audit-logs-1234.s3.amazonaws.com/export/cluster-audit-logs-5678-from-2000-01-01-to-2000-01-02.tar.gz?X-Amz-Algorithm=X&X-Amz-Credential=XXX&X-Amz-Date=1999&X-Amz-Expires=1&X-Amz-Security-Token=XXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX"
      - cluster_id             = "ffffffff-aaaa-1414-eeee-000000000000"
      - created_at             = "2024-06-10 21:16:50.415705947 +0000 UTC"
      - end                    = "2024-06-10T21:09:11+00:00"
      - expiration             = "2024-06-13 21:16:54.37230845 +0000 UTC"
      - id                     = "ffffffff-aaaa-1414-eeee-000000000000"
      - organization_id        = "ffffffff-aaaa-1414-eeee-000000000000"
      - project_id             = "ffffffff-aaaa-1414-eeee-000000000000"
      - start                  = "2024-06-10T20:09:11+00:00"
      - status                 = null
    } -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

couchbase-capella_audit_log_export.new_auditlogexport: Destroying... [id=ffffffff-aaaa-1414-eeee-000000000000]
couchbase-capella_audit_log_export.new_auditlogexport: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code

## Further comments