### PR TITLE
AV-83066 - Resolving getting started folder bugs

### DIFF
--- a/examples/database_credential/terraform.template.tfvars
+++ b/examples/database_credential/terraform.template.tfvars
@@ -16,7 +16,7 @@ access = [
         name = "new_terraform_bucket"
         scopes = [
           {
-            name        = "_default"
+            name = "_default"
           }
         ]
       }]

--- a/examples/database_credential/terraform.template.tfvars
+++ b/examples/database_credential/terraform.template.tfvars
@@ -17,7 +17,6 @@ access = [
         scopes = [
           {
             name        = "_default"
-            collections = ["_default"]
           }
         ]
       }]

--- a/examples/getting_started/audit_logs.tf
+++ b/examples/getting_started/audit_logs.tf
@@ -1,7 +1,7 @@
 data "couchbase-capella_audit_log_event_ids" "event_list" {
   organization_id = var.organization_id
-  project_id      = var.project_id
-  cluster_id      = var.cluster_id
+   project_id      = couchbase-capella_project.new_project.id
+   cluster_id      = couchbase-capella_cluster.new_cluster.id
 }
 
 # List of query event ids
@@ -12,8 +12,8 @@ locals {
 # Local variable n1ql_event_ids is used to provide
 resource "couchbase-capella_audit_log_settings" "new_auditlogsettings" {
   organization_id   = var.organization_id
-  project_id        = var.project_id
-  cluster_id        = var.cluster_id
+   project_id       = couchbase-capella_project.new_project.id
+    cluster_id      = couchbase-capella_cluster.new_cluster.id
   audit_enabled     = var.audit_log_settings.audit_enabled
   enabled_event_ids = local.n1ql_event_ids
   disabled_users    = var.audit_log_settings.disabled_users

--- a/examples/getting_started/audit_logs.tf
+++ b/examples/getting_started/audit_logs.tf
@@ -1,7 +1,7 @@
 data "couchbase-capella_audit_log_event_ids" "event_list" {
   organization_id = var.organization_id
-   project_id      = couchbase-capella_project.new_project.id
-   cluster_id      = couchbase-capella_cluster.new_cluster.id
+  project_id      = couchbase-capella_project.new_project.id
+  cluster_id      = couchbase-capella_cluster.new_cluster.id
 }
 
 # List of query event ids
@@ -12,8 +12,8 @@ locals {
 # Local variable n1ql_event_ids is used to provide
 resource "couchbase-capella_audit_log_settings" "new_auditlogsettings" {
   organization_id   = var.organization_id
-   project_id       = couchbase-capella_project.new_project.id
-    cluster_id      = couchbase-capella_cluster.new_cluster.id
+  project_id        = couchbase-capella_project.new_project.id
+  cluster_id        = couchbase-capella_cluster.new_cluster.id
   audit_enabled     = var.audit_log_settings.audit_enabled
   enabled_event_ids = local.n1ql_event_ids
   disabled_users    = var.audit_log_settings.disabled_users

--- a/examples/getting_started/terraform.template.tfvars
+++ b/examples/getting_started/terraform.template.tfvars
@@ -44,7 +44,6 @@ access = [
         scopes = [
           {
             name        = "_default"
-            collections = ["_default"]
           }
         ]
       }]

--- a/examples/getting_started/terraform.template.tfvars
+++ b/examples/getting_started/terraform.template.tfvars
@@ -43,7 +43,7 @@ access = [
         name = "new_terraform_bucket"
         scopes = [
           {
-            name        = "_default"
+            name = "_default"
           }
         ]
       }]

--- a/examples/getting_started/terraform.template.tfvars
+++ b/examples/getting_started/terraform.template.tfvars
@@ -28,7 +28,7 @@ disk = {
 }
 
 support = {
-  plan     = "developer pro"
+  plan     = "enterprise"
   timezone = "PT"
 }
 


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-83066

## Description

Updating the .tf file bugs in getting started folder. 
<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

Tested on DEV-

In the examples/getting_started folder-

running terraform apply -
**resources created successfully**

```
terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/paulomee.de/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.couchbase-capella_organization.existing_organization: Reading...
couchbase-capella_project.new_project: Refreshing state... [id=ffffffff-aaaa-1414-eeee-000000000000]
data.couchbase-capella_organization.existing_organization: Read complete after 1s [name=cbc-dev]
couchbase-capella_apikey.new_apikey: Refreshing state... [id=ffffffff-aaaa-1414-eeee-000000000000]
couchbase-capella_user.new_user: Refreshing state... [id=ffffffff-aaaa-1414-eeee-000000000000]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.couchbase-capella_audit_log_event_ids.event_list will be read during apply
  # (config refers to values not yet known)
 <= data "couchbase-capella_audit_log_event_ids" "event_list" {
      + cluster_id      = (known after apply)
      + data            = (known after apply)
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
    }

  # data.couchbase-capella_certificate.existing_certificate will be read during apply
  # (config refers to values not yet known)
 <= data "couchbase-capella_certificate" "existing_certificate" {
      + cluster_id      = (known after apply)
      + data            = (known after apply)
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
    }

  # couchbase-capella_allowlist.new_allowlist will be created
  + resource "couchbase-capella_allowlist" "new_allowlist" {
      + audit           = (known after apply)
      + cidr            = "8.8.8.8/32"
      + cluster_id      = (known after apply)
      + comment         = "Allow access from a public IP"
      + expires_at      = "2043-11-30T23:59:59.465Z"
      + id              = (known after apply)
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
    }

  # couchbase-capella_app_service.new_app_service will be created
  + resource "couchbase-capella_app_service" "new_app_service" {
      + audit           = (known after apply)
      + cloud_provider  = (known after apply)
      + cluster_id      = (known after apply)
      + compute         = {
          + cpu = 2
          + ram = 4
        }
      + current_state   = (known after apply)
      + description     = "My First test app service."
      + etag            = (known after apply)
      + id              = (known after apply)
      + name            = "new-terraform-app-service"
      + nodes           = 2
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + version         = (known after apply)
    }

  # couchbase-capella_audit_log_settings.new_auditlogsettings will be created
  + resource "couchbase-capella_audit_log_settings" "new_auditlogsettings" {
      + audit_enabled     = true
      + cluster_id        = (known after apply)
      + disabled_users    = []
      + enabled_event_ids = (known after apply)
      + organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
    }

  # couchbase-capella_bucket.new_bucket will be created
  + resource "couchbase-capella_bucket" "new_bucket" {
      + bucket_conflict_resolution = "seqno"
      + cluster_id                 = (known after apply)
      + durability_level           = "none"
      + eviction_policy            = "fullEviction"
      + flush                      = false
      + id                         = (known after apply)
      + memory_allocation_in_mb    = 100
      + name                       = "new_terraform_bucket"
      + organization_id            = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id                 = "ffffffff-aaaa-1414-eeee-000000000000"
      + replicas                   = 1
      + stats                      = (known after apply)
      + storage_backend            = "couchstore"
      + time_to_live_in_seconds    = 0
      + type                       = "couchbase"
    }

  # couchbase-capella_cluster.new_cluster will be created
  + resource "couchbase-capella_cluster" "new_cluster" {
      + app_service_id   = (known after apply)
      + audit            = (known after apply)
      + availability     = {
          + type = "multi"
        }
      + cloud_provider   = {
          + cidr   = "10.255.0.0/24"
          + region = "us-east-1"
          + type   = "aws"
        }
      + couchbase_server = (known after apply)
      + current_state    = (known after apply)
      + description      = "My first test cluster for multiple services."
      + etag             = (known after apply)
      + id               = (known after apply)
      + name             = "My First Terraform Cluster"
      + organization_id  = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id       = "ffffffff-aaaa-1414-eeee-000000000000"
      + service_groups   = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      + support          = {
          + plan     = "enterprise"
          + timezone = "PT"
        }
    }

  # couchbase-capella_cluster_onoff_schedule.new_cluster_onoff_schedule will be created
  + resource "couchbase-capella_cluster_onoff_schedule" "new_cluster_onoff_schedule" {
      + cluster_id      = (known after apply)
      + days            = [
          + {
              + day   = "monday"
              + from  = {
                  + hour   = 12
                  + minute = 30
                }
              + state = "custom"
              + to    = {
                  + hour   = 14
                  + minute = 30
                }
            },
          + {
              + day   = "tuesday"
              + from  = {
                  + hour   = 12
                  + minute = 0
                }
              + state = "custom"
              + to    = {
                  + hour   = 19
                  + minute = 30
                }
            },
          + {
              + day   = "wednesday"
              + state = "on"
            },
          + {
              + day   = "thursday"
              + from  = {
                  + hour   = 12
                  + minute = 30
                }
              + state = "custom"
            },
          + {
              + day   = "friday"
              + from  = {
                  + hour   = 0
                  + minute = 0
                }
              + state = "custom"
              + to    = {
                  + hour   = 12
                  + minute = 30
                }
            },
          + {
              + day   = "saturday"
              + from  = {
                  + hour   = 12
                  + minute = 30
                }
              + state = "custom"
              + to    = {
                  + hour   = 14
                  + minute = 0
                }
            },
          + {
              + day   = "sunday"
              + state = "off"
            },
        ]
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + timezone        = "US/Pacific"
    }

  # couchbase-capella_collection.new_collection will be created
  + resource "couchbase-capella_collection" "new_collection" {
      + bucket_id       = (known after apply)
      + cluster_id      = (known after apply)
      + collection_name = "new_terraform_collection"
      + max_ttl         = 200
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + scope_name      = "new_terraform_scope"
    }

  # couchbase-capella_database_credential.new_database_credential will be created
  + resource "couchbase-capella_database_credential" "new_database_credential" {
      + access          = [
          + {
              + privileges = [
                  + "data_reader",
                ]
            },
          + {
              + privileges = [
                  + "data_writer",
                ]
              + resources  = {
                  + buckets = [
                      + {
                          + name   = "new_terraform_bucket"
                          + scopes = [
                              + {
                                  + name = "_default"
                                },
                            ]
                        },
                    ]
                }
            },
        ]
      + audit           = (known after apply)
      + cluster_id      = (known after apply)
      + id              = (known after apply)
      + name            = "terraform_db_credential"
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + password        = (sensitive value)
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
    }

  # couchbase-capella_sample_bucket.new_sample_bucket will be created
  + resource "couchbase-capella_sample_bucket" "new_sample_bucket" {
      + bucket_conflict_resolution = (known after apply)
      + cluster_id                 = (known after apply)
      + durability_level           = (known after apply)
      + eviction_policy            = (known after apply)
      + flush                      = (known after apply)
      + id                         = (known after apply)
      + memory_allocation_in_mb    = (known after apply)
      + name                       = "gamesim-sample"
      + organization_id            = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id                 = "ffffffff-aaaa-1414-eeee-000000000000"
      + replicas                   = (known after apply)
      + stats                      = (known after apply)
      + storage_backend            = (known after apply)
      + time_to_live_in_seconds    = (known after apply)
      + type                       = (known after apply)
    }

  # couchbase-capella_scope.new_scope will be created
  + resource "couchbase-capella_scope" "new_scope" {
      + bucket_id       = (known after apply)
      + cluster_id      = (known after apply)
      + collections     = (known after apply)
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + scope_name      = "new_terraform_scope"
    }

Plan: 10 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + app_service            = {
      + audit           = (known after apply)
      + cloud_provider  = (known after apply)
      + cluster_id      = (known after apply)
      + compute         = {
          + cpu = 2
          + ram = 4
        }
      + current_state   = (known after apply)
      + description     = "My First test app service."
      + etag            = (known after apply)
      + id              = (known after apply)
      + if_match        = null
      + name            = "new-terraform-app-service"
      + nodes           = 2
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + version         = (known after apply)
    }
  + certificate            = {
      + cluster_id      = (known after apply)
      + data            = (known after apply)
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
    }
  + cluster                = {
      + app_service_id   = (known after apply)
      + audit            = (known after apply)
      + availability     = {
          + type = "multi"
        }
      + cloud_provider   = {
          + cidr   = "10.255.0.0/24"
          + region = "us-east-1"
          + type   = "aws"
        }
      + couchbase_server = (known after apply)
      + current_state    = (known after apply)
      + description      = "My first test cluster for multiple services."
      + etag             = (known after apply)
      + id               = (known after apply)
      + if_match         = null
      + name             = "My First Terraform Cluster"
      + organization_id  = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id       = "ffffffff-aaaa-1414-eeee-000000000000"
      + service_groups   = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      + support          = {
          + plan     = "enterprise"
          + timezone = "PT"
        }
    }
  + cluster_onoff_schedule = {
      + cluster_id      = (known after apply)
      + days            = [
          + {
              + day   = "monday"
              + from  = {
                  + hour   = 12
                  + minute = 30
                }
              + state = "custom"
              + to    = {
                  + hour   = 14
                  + minute = 30
                }
            },
          + {
              + day   = "tuesday"
              + from  = {
                  + hour   = 12
                  + minute = 0
                }
              + state = "custom"
              + to    = {
                  + hour   = 19
                  + minute = 30
                }
            },
          + {
              + day   = "wednesday"
              + from  = null
              + state = "on"
              + to    = null
            },
          + {
              + day   = "thursday"
              + from  = {
                  + hour   = 12
                  + minute = 30
                }
              + state = "custom"
              + to    = null
            },
          + {
              + day   = "friday"
              + from  = {
                  + hour   = 0
                  + minute = 0
                }
              + state = "custom"
              + to    = {
                  + hour   = 12
                  + minute = 30
                }
            },
          + {
              + day   = "saturday"
              + from  = {
                  + hour   = 12
                  + minute = 30
                }
              + state = "custom"
              + to    = {
                  + hour   = 14
                  + minute = 0
                }
            },
          + {
              + day   = "sunday"
              + from  = null
              + state = "off"
              + to    = null
            },
        ]
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + timezone        = "US/Pacific"
    }
  + collection             = {
      + bucket_id       = (known after apply)
      + cluster_id      = (known after apply)
      + collection_name = "new_terraform_collection"
      + max_ttl         = 200
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + scope_name      = "new_terraform_scope"
    }
  + database_credential    = (sensitive value)
  + new_auditlogsettings   = {
      + audit_enabled     = true
      + cluster_id        = (known after apply)
      + disabled_users    = []
      + enabled_event_ids = (known after apply)
      + organization_id   = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id        = "ffffffff-aaaa-1414-eeee-000000000000"
    }
  + scope                  = {
      + bucket_id       = (known after apply)
      + cluster_id      = (known after apply)
      + collections     = (known after apply)
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + scope_name      = "new_terraform_scope"
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cluster.new_cluster: Creating...
couchbase-capella_cluster.new_cluster: Still creating... [10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m40s elapsed]
couchbase-capella_cluster.new_cluster: Creation complete after 2m45s [id=ffffffff-aaaa-1414-eeee-000000000000]
data.couchbase-capella_certificate.existing_certificate: Reading...
data.couchbase-capella_audit_log_event_ids.event_list: Reading...
couchbase-capella_allowlist.new_allowlist: Creating...
couchbase-capella_sample_bucket.new_sample_bucket: Creating...
couchbase-capella_bucket.new_bucket: Creating...
couchbase-capella_cluster_onoff_schedule.new_cluster_onoff_schedule: Creating...
couchbase-capella_database_credential.new_database_credential: Creating...
data.couchbase-capella_certificate.existing_certificate: Read complete after 0s
couchbase-capella_cluster_onoff_schedule.new_cluster_onoff_schedule: Creation complete after 0s
data.couchbase-capella_audit_log_event_ids.event_list: Read complete after 0s
couchbase-capella_bucket.new_bucket: Creation complete after 1s [id=bmV3X3RlcnJhZm9ybV9idWNrZXQ=]
couchbase-capella_scope.new_scope: Creating...
couchbase-capella_audit_log_settings.new_auditlogsettings: Creating...
couchbase-capella_scope.new_scope: Creation complete after 0s
couchbase-capella_collection.new_collection: Creating...
couchbase-capella_collection.new_collection: Creation complete after 0s
couchbase-capella_database_credential.new_database_credential: Creation complete after 2s [id=ffffffff-aaaa-1414-eeee-000000000000]
couchbase-capella_audit_log_settings.new_auditlogsettings: Creation complete after 4s
couchbase-capella_allowlist.new_allowlist: Creation complete after 7s [id=ffffffff-aaaa-1414-eeee-000000000000]
couchbase-capella_sample_bucket.new_sample_bucket: Still creating... [10s elapsed]
couchbase-capella_sample_bucket.new_sample_bucket: Still creating... [20s elapsed]
couchbase-capella_sample_bucket.new_sample_bucket: Creation complete after 22s [id=Z2FtZXNpbS1zYW1wbGU=]
couchbase-capella_app_service.new_app_service: Creating...
couchbase-capella_app_service.new_app_service: Still creating... [10s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [20s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [30s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [40s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [50s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [1m0s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [1m10s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [1m20s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [1m30s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [1m40s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [1m50s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [2m0s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [2m10s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [2m20s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [2m30s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [2m40s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [2m50s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [3m0s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [3m10s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [3m20s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [3m30s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [3m40s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [3m50s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [4m0s elapsed]
couchbase-capella_app_service.new_app_service: Still creating... [4m10s elapsed]
couchbase-capella_app_service.new_app_service: Creation complete after 4m16s [id=ffffffff-aaaa-1414-eeee-000000000000]

Apply complete! Resources: 10 added, 0 changed, 0 destroyed.

Outputs:

apikey = <sensitive>
app_service = {
  "audit" = {
    "created_at" = "2024-07-30 19:17:56.233442297 +0000 UTC"
    "created_by" = "redacted"
    "modified_at" = "2024-07-30 19:22:11.306111869 +0000 UTC"
    "modified_by" = "redated"
    "version" = 7
  }
  "cloud_provider" = "AWS"
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "compute" = {
    "cpu" = 2
    "ram" = 4
  }
  "current_state" = "healthy"
  "description" = "My First test app service."
  "etag" = "Version: 7"
  "id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "if_match" = tostring(null)
  "name" = "new-terraform-app-service"
  "nodes" = 2
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "version" = "3.1.8-1.0.0"
}
bucket = "new_terraform_bucket"
certificate = {
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "data" = tolist([
    {
      "certificate" = <<-EOT
      -----BEGIN CERTIFICATE-----
      --<redacted>--
      -----END CERTIFICATE-----
      EOT
    },
  ])
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
}
cluster = {
  "app_service_id" = tostring(null)
  "audit" = {
    "created_at" = "2024-07-30 19:14:49.583190727 +0000 UTC"
    "created_by" = "redacted"
    "modified_at" = "2024-07-30 19:17:31.086004803 +0000 UTC"
    "modified_by" = "redacted"
    "version" = 5
  }
  "availability" = {
    "type" = "multi"
  }
  "cloud_provider" = {
    "cidr" = "10.255.0.0/24"
    "region" = "us-east-1"
    "type" = "aws"
  }
  "couchbase_server" = {
    "version" = "7.6"
  }
  "current_state" = "healthy"
  "description" = "My first test cluster for multiple services."
  "etag" = "Version: 5"
  "id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "if_match" = tostring(null)
  "name" = "My First Terraform Cluster"
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "service_groups" = toset([
    {
      "node" = {
        "compute" = {
          "cpu" = 4
          "ram" = 16
        }
        "disk" = {
          "autoexpansion" = tobool(null)
          "iops" = 5000
          "storage" = 50
          "type" = "io2"
        }
      }
      "num_of_nodes" = 3
      "services" = toset([
        "data",
        "index",
        "query",
      ])
    },
  ])
  "support" = {
    "plan" = "enterprise"
    "timezone" = "PT"
  }
}
cluster_onoff_schedule = {
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "days" = tolist([
    {
      "day" = "monday"
      "from" = {
        "hour" = 12
        "minute" = 30
      }
      "state" = "custom"
      "to" = {
        "hour" = 14
        "minute" = 30
      }
    },
    {
      "day" = "tuesday"
      "from" = {
        "hour" = 12
        "minute" = 0
      }
      "state" = "custom"
      "to" = {
        "hour" = 19
        "minute" = 30
      }
    },
    {
      "day" = "wednesday"
      "from" = null /* object */
      "state" = "on"
      "to" = null /* object */
    },
    {
      "day" = "thursday"
      "from" = {
        "hour" = 12
        "minute" = 30
      }
      "state" = "custom"
      "to" = null /* object */
    },
    {
      "day" = "friday"
      "from" = {
        "hour" = 0
        "minute" = 0
      }
      "state" = "custom"
      "to" = {
        "hour" = 12
        "minute" = 30
      }
    },
    {
      "day" = "saturday"
      "from" = {
        "hour" = 12
        "minute" = 30
      }
      "state" = "custom"
      "to" = {
        "hour" = 14
        "minute" = 0
      }
    },
    {
      "day" = "sunday"
      "from" = null /* object */
      "state" = "off"
      "to" = null /* object */
    },
  ])
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "timezone" = "US/Pacific"
}
collection = {
  "bucket_id" = "bmV3X3RlcnJhZm9ybV9idWNrZXQ="
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "collection_name" = "new_terraform_collection"
  "max_ttl" = 200
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "scope_name" = "new_terraform_scope"
}
database_credential = <sensitive>
new_auditlogsettings = {
  "audit_enabled" = true
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "disabled_users" = toset([])
  "enabled_event_ids" = toset([
    28672,
    28673,
    28674,
    28675,
    28676,
    28677,
    28678,
    28679,
    28680,
    28681,
    28682,
    28683,
    28684,
    28685,
    28686,
    28687,
    28688,
    28689,
    28690,
    28691,
    28692,
    28693,
    28694,
    28695,
    28697,
    28698,
    28699,
    28700,
    28701,
    28702,
    28704,
    28705,
    28706,
    28707,
    28708,
    28709,
    28710,
    28711,
    28712,
    28713,
    28714,
    28715,
    28716,
    28717,
    28718,
    28719,
    28720,
    28721,
    28722,
    28723,
    28724,
    28725,
    28726,
    28727,
    28728,
    28729,
    28730,
    28731,
    28732,
    28733,
    28734,
    28735,
    28736,
    28737,
  ])
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
}
organization = {
  "audit" = {
    "created_at" = "2020-07-22 12:38:57.437248116 +0000 UTC"
    "created_by" = ""
    "modified_at" = "2024-07-09 14:14:37.176385072 +0000 UTC"
    "modified_by" = "ffffffff-aaaa-1414-eeee-000000000000"
    "version" = 0
  }
  "description" = ""
  "name" = "cbc-dev"
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "preferences" = {
    "session_duration" = 7200
  }
}
project = "My First Terraform Project"
sample_bucket = "gamesim-sample"
scope = {
  "bucket_id" = "bmV3X3RlcnJhZm9ybV9idWNrZXQ="
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "collections" = toset([])
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "scope_name" = "new_terraform_scope"
}
user = {
  "audit" = {
    "created_at" = "2024-07-30 19:13:48.428677756 +0000 UTC"
    "created_by" = "redacted"
    "modified_at" = "2024-07-30 19:13:48.428677756 +0000 UTC"
    "modified_by" = "redacted"
    "version" = 1
  }
  "email" = "paulomee.de+test99@couchbase.com"
  "enable_notifications" = false
  "expires_at" = "2024-10-28T19:13:48.428678297Z"
  "id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "inactive" = true
  "last_login" = ""
  "name" = "Paulomee De"
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "organization_roles" = tolist([
    "organizationMember",
  ])
  "region" = ""
  "resources" = toset([
    {
      "id" = "ffffffff-aaaa-1414-eeee-000000000000"
      "roles" = toset([
        "projectDataReaderWriter",
        "projectViewer",
      ])
      "type" = "project"
    },
  ])
  "status" = "not-verified"
  "time_zone" = ""
}

```






Testing the change for example folder db_credentials-
Successful-

```
terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/paulomee.de/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.couchbase-capella_database_credentials.existing_credentials: Reading...
data.couchbase-capella_database_credentials.existing_credentials: Read complete after 0s

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_database_credential.new_database_credential will be created
  + resource "couchbase-capella_database_credential" "new_database_credential" {
      + access          = [
          + {
              + privileges = [
                  + "data_reader",
                ]
            },
          + {
              + privileges = [
                  + "data_writer",
                ]
              + resources  = {
                  + buckets = [
                      + {
                          + name   = "b1"
                          + scopes = [
                              + {
                                  + name = "_default"
                                },
                            ]
                        },
                    ]
                }
            },
        ]
      + audit           = (known after apply)
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + id              = (known after apply)
      + name            = "test_db_user"
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + password        = (sensitive value)
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + database_credential_id    = (known after apply)
  + new_database_credential   = (sensitive value)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_database_credential.new_database_credential: Creating...
couchbase-capella_database_credential.new_database_credential: Creation complete after 1s [id=ffffffff-aaaa-1414-eeee-000000000000]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

database_credential_id = "ffffffff-aaaa-1414-eeee-000000000000"
database_credentials_list = {
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "data" = tolist(null) /* of object */
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
}
new_database_credential = <sensitive>

``` 
</details>

## Required Checklist:

- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if required)
- [x] I have run make fmt and formatted my code

## Further comments