### PR TITLE
AV-83067 | no server version check for acceptance tests

### DIFF
--- a/internal/resources/acceptance_tests/cluster_acceptance_test.go
+++ b/internal/resources/acceptance_tests/cluster_acceptance_test.go
@@ -60,7 +60,6 @@ func TestAccClusterResourceWithOnlyReqFieldAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "50"),
@@ -97,7 +96,6 @@ func TestAccClusterResourceWithOnlyReqFieldAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.cpu", "8"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.ram", "32"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.storage", "51"),
@@ -129,7 +127,6 @@ func TestAccClusterResourceWithOnlyReqFieldAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.cpu", "8"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.ram", "32"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.storage", "51"),
@@ -186,7 +183,6 @@ func TestAccClusterResourceWithOptionalFieldAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "50"),
@@ -249,7 +245,6 @@ func TestAccClusterResourceAzure(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "azure"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "eastus"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "1024"),
@@ -282,7 +277,6 @@ func TestAccClusterResourceAzure(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "azure"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "eastus"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "32"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "64"),
@@ -308,7 +302,6 @@ func TestAccClusterResourceAzure(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "azure"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "eastus"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "1024"),
@@ -334,7 +327,6 @@ func TestAccClusterResourceAzure(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "azure"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "eastus"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "1024"),
@@ -392,7 +384,6 @@ func TestAccClusterResourceGCP(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "gcp"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "64"),
@@ -424,7 +415,6 @@ func TestAccClusterResourceGCP(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "gcp"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.cpu", "8"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.ram", "16"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.storage", "51"),
@@ -522,7 +512,6 @@ func TestAccClusterResourceNotFound(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "50"),
@@ -556,7 +545,6 @@ func TestAccClusterResourceNotFound(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.2"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.cpu", "8"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.ram", "32"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.storage", "51"),
@@ -652,9 +640,7 @@ resource "couchbase-capella_cluster" "%[2]s" {
   project_id      = %[4]s.id
   name            = "Terraform Acceptance Test Cluster"
   description     = "My first test cluster for multiple services."
-  couchbase_server = {
-    version = "7.2"
-  }
+
   cloud_provider = {
     type   = "aws"
     region = "us-east-1"
@@ -720,9 +706,7 @@ resource "couchbase-capella_cluster" "%[2]s" {
   project_id      = %[4]s.id
   name            = "Terraform Acceptance Test Cluster"
   description     = "My first test cluster for multiple services."
-  couchbase_server = {
-    version = "7.2"
-  }
+
   cloud_provider = {
     type   = "aws"
     region = "us-east-1"
@@ -793,9 +777,7 @@ resource "couchbase-capella_cluster" "%[2]s" {
     region = "eastus"
     cidr   = "%[5]s"
   }
-  couchbase_server = {
-    version = "7.2"
-  }
+
   service_groups = [
     {
       node = {
@@ -846,9 +828,7 @@ resource "couchbase-capella_cluster" "%[2]s" {
     region = "eastus"
     cidr   = "%[5]s"
   }
-  couchbase_server = {
-    version = "7.2"
-  }
+
   service_groups = [
     {
       node = {
@@ -897,9 +877,7 @@ resource "couchbase-capella_cluster" "%[2]s" {
     region = "eastus"
     cidr   = "%[5]s"
   }
-  couchbase_server = {
-    version = "7.2"
-  }
+
   service_groups = [
     {
       node = {
@@ -952,9 +930,7 @@ resource "couchbase-capella_cluster" "%[2]s" {
     region = "eastus"
     cidr   = "%[5]s"
   }
-  couchbase_server = {
-    version = "7.2"
-  }
+
   service_groups = [
     {
       node = {
@@ -1018,9 +994,7 @@ resource "couchbase-capella_cluster"  "%[2]s" {
 	region = "us-east1",
     cidr   = "%[5]s"
   }
-  couchbase_server = {
-    version = "7.2"
-  } 
+
   service_groups = [
 		{
 			node = {
@@ -1070,9 +1044,7 @@ resource "couchbase-capella_cluster"  "%[2]s" {
 	region = "us-east1",
     cidr   = "%[5]s"
   }
-  couchbase_server = {
-    version = "7.2"
-  } 
+
   service_groups = [
 		{
 			node = {
@@ -1254,9 +1226,7 @@ resource "couchbase-capella_cluster"  "%[2]s" {
 	region = "us-east1",
     cidr   = "%[5]s"
   }
-  couchbase_server = {
-    version = "7.2"
-  } 
+
   service_groups = [
 		{
 			node = {

--- a/internal/resources/acceptance_tests/security_acceptance_tests/clusters_security_acceptance_test.go
+++ b/internal/resources/acceptance_tests/security_acceptance_tests/clusters_security_acceptance_test.go
@@ -60,7 +60,6 @@ func TestAccCreateClusterOrgOwner(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.1"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "50"),
@@ -150,7 +149,6 @@ func TestAccCreateClusterProjOwner(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.1"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "50"),
@@ -198,7 +196,6 @@ func TestAccCreateClusterProjManager(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
-					resource.TestCheckResourceAttr(resourceReference, "couchbase_server.version", "7.1"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "50"),
@@ -298,9 +295,7 @@ resource "capella_cluster" "%[2]s" {
   project_id      = var.project_id
   name            = "Terraform Acceptance Test Cluster"
   description     = "My first test cluster for multiple services."
-  couchbase_server = {
-    version = "7.1"
-  }
+
   cloud_provider = {
     type   = "aws"
     region = "us-east-1"


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-83067](https://couchbasecloud.atlassian.net/browse/AV-83067)

## Description

remove server version check in acceptance tests.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

```
TF_ACC=1 go test -timeout=300m -v ./... -run TestAccOrganizationDataSource -run TestAccProjectResource -run TestAccCreate
ProjectWithReqFields -run TestAccCreateProjectOptFields -run TestAccValidProjectUpdate -run TestAccInvalidProjectResource -run TestAccDeleteProjectBeforeDestroy -run TestAccClusterResourceAzure -run TestAccClusterResourceGCP -run TestAccClusterResourceWithOnlyReqFieldAWS
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/appservice	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/backup	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/backup_schedule	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/bucket	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/cluster	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/organization	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/sample_bucket	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/scope	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api	0.289s [no tests to run]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/provider	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/datasources	0.280s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/resources	0.285s [no tests to run]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/testing	[no test files]
?   	github.com/couchbasecloud/terraform-provider-couchbase-capella/version	[no test files]
=== RUN   TestAccClusterResourceWithOnlyReqFieldAWS
=== PAUSE TestAccClusterResourceWithOnlyReqFieldAWS
=== CONT  TestAccClusterResourceWithOnlyReqFieldAWS
raw state map[%:15 audit.%:5 audit.created_at:2024-07-26 21:04:37.836969044 +0000 UTC audit.created_by:40WWyBdwMsG8sxWVX6LQH72ivgY84O4J audit.modified_at:2024-07-26 21:07:31.750286243 +0000 UTC audit.modified_by:40WWyBdwMsG8sxWVX6LQH72ivgY84O4J audit.version:5 availability.%:1 availability.type:multi cloud_provider.%:3 cloud_provider.cidr:10.255.250.0/23 cloud_provider.region:us-east-1 cloud_provider.type:aws couchbase_server.%:1 couchbase_server.version:7.6 current_state:healthy description: etag:Version: 5 id:2452c739-b5d9-4101-a966-20cb48a9a3aa name:acc_cluster_muqndvmyzy organization_id:50788c60-0cad-4556-b592-f20033ad3959 project_id:dce19495-14e6-4bfc-b2f1-1f2e9a72f965 service_groups.#:1 service_groups.0.%:3 service_groups.0.node.%:2 service_groups.0.node.compute.%:2 service_groups.0.node.compute.cpu:4 service_groups.0.node.compute.ram:16 service_groups.0.node.disk.%:4 service_groups.0.node.disk.iops:3000 service_groups.0.node.disk.storage:50 service_groups.0.node.disk.type:io2 service_groups.0.num_of_nodes:3 service_groups.0.services.#:3 service_groups.0.services.0:data service_groups.0.services.1:index service_groups.0.services.2:query support.%:2 support.plan:developer pro support.timezone:PT]raw state map[%:15 audit.%:5 audit.created_at:2024-07-26 21:04:37.836969044 +0000 UTC audit.created_by:40WWyBdwMsG8sxWVX6LQH72ivgY84O4J audit.modified_at:2024-07-26 21:07:31.750286243 +0000 UTC audit.modified_by:40WWyBdwMsG8sxWVX6LQH72ivgY84O4J audit.version:5 availability.%:1 availability.type:multi cloud_provider.%:3 cloud_provider.cidr:10.255.250.0/23 cloud_provider.region:us-east-1 cloud_provider.type:aws couchbase_server.%:1 couchbase_server.version:7.6 current_state:healthy description: etag:Version: 5 id:2452c739-b5d9-4101-a966-20cb48a9a3aa name:acc_cluster_muqndvmyzy organization_id:50788c60-0cad-4556-b592-f20033ad3959 project_id:dce19495-14e6-4bfc-b2f1-1f2e9a72f965 service_groups.#:1 service_groups.0.%:3 service_groups.0.node.%:2 service_groups.0.node.compute.%:2 service_groups.0.node.compute.cpu:4 service_groups.0.node.compute.ram:16 service_groups.0.node.disk.%:4 service_groups.0.node.disk.iops:3000 service_groups.0.node.disk.storage:50 service_groups.0.node.disk.type:io2 service_groups.0.num_of_nodes:3 service_groups.0.services.#:3 service_groups.0.services.0:data service_groups.0.services.1:index service_groups.0.services.2:query support.%:2 support.plan:developer pro support.timezone:PT]raw state map[%:15 audit.%:5 audit.created_at:2024-07-26 21:04:37.836969044 +0000 UTC audit.created_by:40WWyBdwMsG8sxWVX6LQH72ivgY84O4J audit.modified_at:2024-07-26 21:13:37.812177396 +0000 UTC audit.modified_by:40WWyBdwMsG8sxWVX6LQH72ivgY84O4J audit.version:11 availability.%:1 availability.type:multi cloud_provider.%:3 cloud_provider.cidr:10.255.250.0/23 cloud_provider.region:us-east-1 cloud_provider.type:aws couchbase_server.%:1 couchbase_server.version:7.6 current_state:healthy description:Cluster Updated. etag:Version: 11 id:2452c739-b5d9-4101-a966-20cb48a9a3aa if_match:5 name:Terraform Acceptance Test Cluster Update organization_id:50788c60-0cad-4556-b592-f20033ad3959 project_id:dce19495-14e6-4bfc-b2f1-1f2e9a72f965 service_groups.#:2 service_groups.0.%:3 service_groups.0.node.%:2 service_groups.0.node.compute.%:2 service_groups.0.node.compute.cpu:4 service_groups.0.node.compute.ram:16 service_groups.0.node.disk.%:4 service_groups.0.node.disk.iops:3001 service_groups.0.node.disk.storage:51 service_groups.0.node.disk.type:gp3 service_groups.0.num_of_nodes:3 service_groups.0.services.#:1 service_groups.0.services.0:data service_groups.1.%:3 service_groups.1.node.%:2 service_groups.1.node.compute.%:2 service_groups.1.node.compute.cpu:8 service_groups.1.node.compute.ram:32 service_groups.1.node.disk.%:4 service_groups.1.node.disk.iops:3001 service_groups.1.node.disk.storage:51 service_groups.1.node.disk.type:gp3 service_groups.1.num_of_nodes:2 service_groups.1.services.#:2 service_groups.1.services.0:index service_groups.1.services.1:query support.%:2 support.plan:enterprise support.timezone:IST]raw state map[%:15 audit.%:5 audit.created_at:2024-07-26 21:04:37.836969044 +0000 UTC audit.created_by:40WWyBdwMsG8sxWVX6LQH72ivgY84O4J audit.modified_at:2024-07-26 21:13:57.929093323 +0000 UTC audit.modified_by:40WWyBdwMsG8sxWVX6LQH72ivgY84O4J audit.version:16 availability.%:1 availability.type:multi cloud_provider.%:3 cloud_provider.cidr:10.255.250.0/23 cloud_provider.region:us-east-1 cloud_provider.type:aws couchbase_server.%:1 couchbase_server.version:7.6 current_state:healthy description:Cluster Updated. etag:Version: 16 id:2452c739-b5d9-4101-a966-20cb48a9a3aa name:Terraform Acceptance Test Cluster Update 2 organization_id:50788c60-0cad-4556-b592-f20033ad3959 project_id:dce19495-14e6-4bfc-b2f1-1f2e9a72f965 service_groups.#:2 service_groups.0.%:3 service_groups.0.node.%:2 service_groups.0.node.compute.%:2 service_groups.0.node.compute.cpu:4 service_groups.0.node.compute.ram:16 service_groups.0.node.disk.%:4 service_groups.0.node.disk.iops:3001 service_groups.0.node.disk.storage:51 service_groups.0.node.disk.type:gp3 service_groups.0.num_of_nodes:3 service_groups.0.services.#:1 service_groups.0.services.0:data service_groups.1.%:3 service_groups.1.node.%:2 service_groups.1.node.compute.%:2 service_groups.1.node.compute.cpu:8 service_groups.1.node.compute.ram:32 service_groups.1.node.disk.%:4 service_groups.1.node.disk.iops:3001 service_groups.1.node.disk.storage:51 service_groups.1.node.disk.type:gp3 service_groups.1.num_of_nodes:2 service_groups.1.services.#:2 service_groups.1.services.0:index service_groups.1.services.1:query support.%:2 support.plan:enterprise support.timezone:IST]--- PASS: TestAccClusterResourceWithOnlyReqFieldAWS (833.51s)
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/resources/acceptance_tests	833.804s
testing: warning: no tests to run
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/resources/acceptance_tests/security_acceptance_tests	0.295s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema	0.281s [no tests to run]
```

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code

## Further comments