### PR TITLE
AV-84160 make cluster timezone optional

### DIFF
--- a/internal/resources/acceptance_tests/cluster_acceptance_test.go
+++ b/internal/resources/acceptance_tests/cluster_acceptance_test.go
@@ -73,9 +73,7 @@ func TestAccClusterResourceWithOnlyReqFieldAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "availability.type", "multi"),
 					resource.TestCheckResourceAttr(resourceReference, "support.plan", "developer pro"),
 					resource.TestCheckResourceAttr(resourceReference, "support.timezone", "PT"),
-
-					//When the cluster is created for the first time, the ETag of the created cluster is 5
-					//resource.TestCheckResourceAttr(resourceReference, "etag", "Version: 5"),
+					resource.TestCheckResourceAttrSet(resourceReference, "etag"),
 				),
 			},
 			//// ImportState testing
@@ -84,6 +82,10 @@ func TestAccClusterResourceWithOnlyReqFieldAWS(t *testing.T) {
 				ImportStateIdFunc: generateClusterImportIdForResource(resourceReference),
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"audit.modified_at",
+					"audit.version",
+				},
 			},
 			// Update number of nodes, compute type, disk size and type, cluster name, support plan, time zone and description from empty string,
 			// and Read testing

--- a/internal/resources/acceptance_tests/cluster_acceptance_test.go
+++ b/internal/resources/acceptance_tests/cluster_acceptance_test.go
@@ -438,6 +438,117 @@ func TestAccClusterResourceGCP(t *testing.T) {
 		},
 	})
 }
+func TestAccClusterResourceWithReqFieldsAWSBasicPlan(t *testing.T) {
+	resourceName := "acc_cluster_" + acctest.GenerateRandomResourceName()
+	resourceReference := "couchbase-capella_cluster." + resourceName
+	projectResourceName := "acc_project_" + acctest.GenerateRandomResourceName()
+	projectResourceReference := "couchbase-capella_project." + projectResourceName
+	cidr := "10.255.250.0/23"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				PreConfig: testAccProjecCreationWaitTime(),
+				Config:    testAccClusterResourceConfigReqFieldsBasicPlan(acctest.Cfg, resourceName, projectResourceName, projectResourceReference, cidr),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
+					resource.TestCheckResourceAttr(resourceReference, "description", ""),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "50"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.type", "io2"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.iops", "3000"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.num_of_nodes", "3"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.#", "3"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.0", "data"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.1", "index"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.2", "query"),
+					resource.TestCheckResourceAttr(resourceReference, "availability.type", "single"),
+					resource.TestCheckResourceAttr(resourceReference, "support.plan", "basic"),
+
+					//When the cluster is created for the first time, the ETag of the created cluster is 5
+					//resource.TestCheckResourceAttr(resourceReference, "etag", "Version: 5"),
+				),
+			},
+			//// ImportState testing
+			{
+				ResourceName:      resourceReference,
+				ImportStateIdFunc: generateClusterImportIdForResource(resourceReference),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update number of nodes, compute type, disk size and type, cluster name, support plan, time zone and description from empty string,
+			// and Read testing
+			{
+				Config: testAccClusterResourceConfigUpdateWhenClusterCreatedWithReqFieldOnlyAndIfMatchBasicPlan(acctest.Cfg, resourceName, projectResourceName, projectResourceReference, cidr),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "name", "Terraform Acceptance Test Cluster Update"),
+					resource.TestCheckResourceAttr(resourceReference, "description", "Cluster Updated."),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.cpu", "8"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.ram", "32"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.storage", "51"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.type", "gp3"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.iops", "3001"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.num_of_nodes", "2"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.services.#", "2"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.services.0", "index"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.services.1", "query"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "51"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.type", "gp3"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.iops", "3001"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.num_of_nodes", "3"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.0", "data"),
+					resource.TestCheckResourceAttr(resourceReference, "availability.type", "single"),
+					resource.TestCheckResourceAttr(resourceReference, "support.plan", "basic"),
+				),
+			},
+			{
+				Config: testAccClusterResourceConfigUpdateWhenClusterCreatedWithReqFieldOnly(acctest.Cfg, resourceName, projectResourceName, projectResourceReference, cidr),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "name", "Terraform Acceptance Test Cluster Update 2"),
+					resource.TestCheckResourceAttr(resourceReference, "description", "Cluster Updated."),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.cpu", "8"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.ram", "32"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.storage", "51"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.type", "gp3"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.iops", "3001"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.num_of_nodes", "2"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.services.#", "2"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.services.0", "index"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.services.1", "query"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "51"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.type", "gp3"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.iops", "3001"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.num_of_nodes", "3"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.0", "data"),
+					resource.TestCheckResourceAttr(resourceReference, "availability.type", "multi"),
+					resource.TestCheckResourceAttr(resourceReference, "support.plan", "enterprise"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
 
 // TestAccClusterResourceWithOptionalFieldAWSInvalidScenario is a Terraform acceptance test that covers an invalid scenario
 // during the creation of a cluster resource with optional fields for an AWS (Amazon Web Services) cloud provider.
@@ -572,6 +683,52 @@ func TestAccClusterResourceNotFound(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccClusterResourceConfigReqFieldsBasicPlan(cfg, resourceName, projectResourceName, projectResourceReference, cidr string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_project" "%[3]s" {
+    organization_id = var.organization_id
+	name            = "acc_test_project_name"
+	description     = "description"
+}
+
+resource "couchbase-capella_cluster" "%[2]s" {
+  organization_id = var.organization_id
+  project_id      = %[4]s.id
+  name            = "%[2]s"
+  cloud_provider = {
+    type   = "aws"
+    region = "us-east-1"
+    cidr   = "%[5]s"
+  }
+  service_groups = [
+    {
+      node = {
+        compute = {
+          cpu = 4
+          ram = 16
+        }
+        disk = {
+          storage = 50
+          type    = "io2"
+          iops    = 3000
+        }
+      }
+      num_of_nodes = 3
+      services     = ["data", "index", "query"]
+    }
+  ]
+  availability = {
+    "type" : "single"
+  }
+  support = {
+    plan     = "basic"
+  }
+}
+`, cfg, resourceName, projectResourceName, projectResourceReference, cidr)
 }
 
 // testAccClusterResourceConfigWithOnlyReqField generates a Terraform configuration string for testing an acceptance test
@@ -1134,6 +1291,69 @@ resource "couchbase-capella_cluster" "%[2]s" {
     plan     = "enterprise"
     timezone = "IST"
   }
+}
+`, cfg, resourceName, projectResourceName, projectResourceReference, cidr)
+}
+
+func testAccClusterResourceConfigUpdateWhenClusterCreatedWithReqFieldOnlyAndIfMatchBasicPlan(cfg, resourceName, projectResourceName, projectResourceReference, cidr string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_project" "%[3]s" {
+    organization_id = var.organization_id
+	name            = "acc_test_project_name"
+	description     = "description"
+}
+
+resource "couchbase-capella_cluster" "%[2]s" {
+  organization_id = var.organization_id
+  project_id      = %[4]s.id
+  name            = "Terraform Acceptance Test Cluster Update"
+  description     = "Cluster Updated."
+  cloud_provider = {
+    type   = "aws"
+    region = "us-east-1"
+    cidr   = "%[5]s"
+  }
+  service_groups = [
+    {
+      node = {
+        compute = {
+          cpu = 8
+          ram = 32
+        }
+        disk = {
+          storage = 51
+          type    = "gp3"
+          iops    = 3001
+        }
+      }
+      num_of_nodes = 2
+      services     = ["index", "query"]
+    },
+    {
+      node = {
+        compute = {
+          cpu = 4
+          ram = 16
+        }
+        disk = {
+          storage = 51
+          type    = "gp3"
+          iops    = 3001
+        }
+      }
+      num_of_nodes = 3
+      services     = ["data"]
+    }
+  ]
+  availability = {
+    "type" : "single"
+  }
+  support = {
+    plan     = "basic"
+  }
+  if_match = 5
 }
 `, cfg, resourceName, projectResourceName, projectResourceReference, cidr)
 }

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -85,9 +85,12 @@ func (c *Cluster) Create(ctx context.Context, req resource.CreateRequest, resp *
 			Type:   clusterapi.CloudProviderType(plan.CloudProvider.Type.ValueString()),
 		},
 		Support: clusterapi.Support{
-			Plan:     clusterapi.SupportPlan(plan.Support.Plan.ValueString()),
-			Timezone: clusterapi.SupportTimezone(plan.Support.Timezone.ValueString()),
+			Plan: clusterapi.SupportPlan(plan.Support.Plan.ValueString()),
 		},
+	}
+
+	if !plan.Support.Timezone.IsNull() && !plan.Support.Timezone.IsUnknown() {
+		clusterRequest.Support.Timezone = clusterapi.SupportTimezone(plan.Support.Timezone.ValueString())
 	}
 
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
@@ -322,9 +325,12 @@ func (c *Cluster) Update(ctx context.Context, req resource.UpdateRequest, resp *
 		Description: plan.Description.ValueString(),
 		Name:        plan.Name.ValueString(),
 		Support: clusterapi.Support{
-			Plan:     clusterapi.SupportPlan(plan.Support.Plan.ValueString()),
-			Timezone: clusterapi.SupportTimezone(plan.Support.Timezone.ValueString()),
+			Plan: clusterapi.SupportPlan(plan.Support.Plan.ValueString()),
 		},
+	}
+
+	if !plan.Support.Timezone.IsNull() && !plan.Support.Timezone.IsUnknown() {
+		ClusterRequest.Support.Timezone = clusterapi.SupportTimezone(plan.Support.Timezone.ValueString())
 	}
 
 	serviceGroups, err := c.morphToApiServiceGroups(plan)

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -93,11 +93,11 @@ func (c *Cluster) Create(ctx context.Context, req resource.CreateRequest, resp *
 		clusterRequest.Support.Timezone = clusterapi.SupportTimezone(plan.Support.Timezone.ValueString())
 
 		if clusterRequest.Support.Plan == clusterapi.SupportPlan("basic") && clusterRequest.Support.Timezone != clusterapi.SupportTimezone("PT") {
-			resp.Diagnostics.AddError(
-				"Error creating cluster",
-				"Could not create cluster, unexpected error: Invalid timezone provided for basic cluster",
+			resp.Diagnostics.AddWarning(
+				"Warning during cluster creation",
+				"Timezone field is ignored for basic plan",
 			)
-			return
+			clusterRequest.Support.Timezone = clusterapi.SupportTimezone("PT")
 		}
 	}
 
@@ -341,11 +341,11 @@ func (c *Cluster) Update(ctx context.Context, req resource.UpdateRequest, resp *
 		ClusterRequest.Support.Timezone = clusterapi.SupportTimezone(plan.Support.Timezone.ValueString())
 
 		if ClusterRequest.Support.Plan == clusterapi.SupportPlan("basic") && ClusterRequest.Support.Timezone != clusterapi.SupportTimezone("PT") {
-			resp.Diagnostics.AddError(
-				"Error creating cluster",
-				"Could not update cluster, unexpected error: Invalid timezone provided for basic cluster",
+			resp.Diagnostics.AddWarning(
+				"Warning during cluster update",
+				"Timezone field is ignored for basic plan",
 			)
-			return
+			ClusterRequest.Support.Timezone = clusterapi.SupportTimezone("PT")
 		}
 	}
 

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -91,6 +91,14 @@ func (c *Cluster) Create(ctx context.Context, req resource.CreateRequest, resp *
 
 	if !plan.Support.Timezone.IsNull() && !plan.Support.Timezone.IsUnknown() {
 		clusterRequest.Support.Timezone = clusterapi.SupportTimezone(plan.Support.Timezone.ValueString())
+
+		if clusterRequest.Support.Plan == clusterapi.SupportPlan("basic") && clusterRequest.Support.Timezone != clusterapi.SupportTimezone("PT") {
+			resp.Diagnostics.AddError(
+				"Error creating cluster",
+				"Could not create cluster, unexpected error: Invalid timezone provided for basic cluster",
+			)
+			return
+		}
 	}
 
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
@@ -331,6 +339,14 @@ func (c *Cluster) Update(ctx context.Context, req resource.UpdateRequest, resp *
 
 	if !plan.Support.Timezone.IsNull() && !plan.Support.Timezone.IsUnknown() {
 		ClusterRequest.Support.Timezone = clusterapi.SupportTimezone(plan.Support.Timezone.ValueString())
+
+		if ClusterRequest.Support.Plan == clusterapi.SupportPlan("basic") && ClusterRequest.Support.Timezone != clusterapi.SupportTimezone("PT") {
+			resp.Diagnostics.AddError(
+				"Error creating cluster",
+				"Could not update cluster, unexpected error: Invalid timezone provided for basic cluster",
+			)
+			return
+		}
 	}
 
 	serviceGroups, err := c.morphToApiServiceGroups(plan)

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -93,11 +93,11 @@ func (c *Cluster) Create(ctx context.Context, req resource.CreateRequest, resp *
 		clusterRequest.Support.Timezone = clusterapi.SupportTimezone(plan.Support.Timezone.ValueString())
 
 		if clusterRequest.Support.Plan == clusterapi.SupportPlan("basic") && clusterRequest.Support.Timezone != clusterapi.SupportTimezone("PT") {
-			resp.Diagnostics.AddWarning(
-				"Warning during cluster creation",
-				"Timezone field is ignored for basic plan",
+			resp.Diagnostics.AddError(
+				"Error creating cluster",
+				"Could not create cluster, unexpected error: Invalid timezone provided for basic cluster",
 			)
-			clusterRequest.Support.Timezone = clusterapi.SupportTimezone("PT")
+			return
 		}
 	}
 
@@ -341,11 +341,11 @@ func (c *Cluster) Update(ctx context.Context, req resource.UpdateRequest, resp *
 		ClusterRequest.Support.Timezone = clusterapi.SupportTimezone(plan.Support.Timezone.ValueString())
 
 		if ClusterRequest.Support.Plan == clusterapi.SupportPlan("basic") && ClusterRequest.Support.Timezone != clusterapi.SupportTimezone("PT") {
-			resp.Diagnostics.AddWarning(
-				"Warning during cluster update",
-				"Timezone field is ignored for basic plan",
+			resp.Diagnostics.AddError(
+				"Error creating cluster",
+				"Could not update cluster, unexpected error: Invalid timezone provided for basic cluster",
 			)
-			ClusterRequest.Support.Timezone = clusterapi.SupportTimezone("PT")
+			return
 		}
 	}
 

--- a/internal/resources/cluster_schema.go
+++ b/internal/resources/cluster_schema.go
@@ -88,7 +88,7 @@ func ClusterSchema() schema.Schema {
 				Required: true,
 				Attributes: map[string]schema.Attribute{
 					"plan":     stringAttribute([]string{required}),
-					"timezone": stringAttribute([]string{required}),
+					"timezone": stringAttribute([]string{computed, optional}),
 				},
 			},
 			"current_state":  stringAttribute([]string{computed}),


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-84160](https://couchbasecloud.atlassian.net/browse/AV-84160)

## Description

Timezones field for clusters is optional in management API, but not in terraform. This change makes timezone field optional and throws an improved error for invalid timezones for basic support plan.


<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach
<details>
<summary>Exclude timezone for basic package</summary>

```
Terraform apply
data.couchbase-capella_clusters.existing_clusters: Reading...
data.couchbase-capella_clusters.existing_clusters: Read complete after 1s

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_cluster.new_cluster will be created
  + resource "couchbase-capella_cluster" "new_cluster" {
      + app_service_id   = (known after apply)
      + audit            = (known after apply)
      + availability     = {
          + type = "single"
        }
      + cloud_provider   = {
          + cidr   = "192.168.0.0/20"
          + region = "us-east-1"
          + type   = "aws"
        }
      + couchbase_server = (known after apply)
      + current_state    = (known after apply)
      + description      = "My first test cluster for multiple services."
      + etag             = (known after apply)
      + id               = (known after apply)
      + name             = "Terraform Cluster"
      + organization_id  = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
      + project_id       = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
      + service_groups   = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      + support          = {
          + plan     = "basic"
          + timezone = (known after apply)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + cluster_id    = (known after apply)
  + clusters_list = {
      + data            = [
          + {
              + app_service_id   = null
              + audit            = {
                  + created_at  = "2024-08-14 22:05:15.973136361 +0000 UTC"
                  + created_by  = "99b8dc97-b8ae-44af-8ccd-897e3802c3cb"
                  + modified_at = "2024-08-14 22:16:30.048801207 +0000 UTC"
                  + modified_by = "99b8dc97-b8ae-44af-8ccd-897e3802c3cb"
                  + version     = 9
                }
              + availability     = {
                  + type = "multi"
                }
              + cloud_provider   = {
                  + cidr   = "10.0.11.0/24"
                  + region = "us-east-1"
                  + type   = "aws"
                }
              + couchbase_server = {
                  + version = "7.6.2"
                }
              + current_state    = "turnedOff"
              + description      = ""
              + id               = "78a4f313-fd4a-4e6c-a8f8-91d8e7f01fca"
              + name             = "xdcr-s"
              + organization_id  = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
              + project_id       = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
              + service_groups   = [
                  + {
                      + node         = {
                          + compute = {
                              + cpu = 8
                              + ram = 16
                            }
                          + disk    = {
                              + autoexpansion = null
                              + iops          = 3000
                              + storage       = 50
                              + type          = "gp3"
                            }
                        }
                      + num_of_nodes = 3
                      + services     = [
                          + "index",
                          + "data",
                          + "query",
                        ]
                    },
                ]
              + support          = {
                  + plan     = "developer pro"
                  + timezone = "PT"
                }
            },
          + {
              + app_service_id   = null
              + audit            = {
                  + created_at  = "2024-08-15 01:58:11.418207711 +0000 UTC"
                  + created_by  = "15c82fa5-d24e-4bd6-b7ae-acf3d026a133"
                  + modified_at = "2024-08-15 02:00:57.762728749 +0000 UTC"
                  + modified_by = "15c82fa5-d24e-4bd6-b7ae-acf3d026a133"
                  + version     = 5
                }
              + availability     = {
                  + type = "single"
                }
              + cloud_provider   = {
                  + cidr   = "10.0.10.0/24"
                  + region = "us-east-1"
                  + type   = "aws"
                }
              + couchbase_server = {
                  + version = "7.6.2"
                }
              + current_state    = "healthy"
              + description      = ""
              + id               = "e8bad75c-1acc-4a8d-a00f-70dd4993936f"
              + name             = "mintdennisritchie"
              + organization_id  = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
              + project_id       = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
              + service_groups   = [
                  + {
                      + node         = {
                          + compute = {
                              + cpu = 4
                              + ram = 16
                            }
                          + disk    = {
                              + autoexpansion = null
                              + iops          = 3000
                              + storage       = 50
                              + type          = "gp3"
                            }
                        }
                      + num_of_nodes = 1
                      + services     = [
                          + "search",
                          + "index",
                          + "data",
                          + "query",
                        ]
                    },
                ]
              + support          = {
                  + plan     = "developer pro"
                  + timezone = "PT"
                }
            },
          + {
              + app_service_id   = null
              + audit            = {
                  + created_at  = "2024-08-15 06:14:35.605118068 +0000 UTC"
                  + created_by  = "fa7fa7ea-ed3c-4252-9dc5-366378c4f123"
                  + modified_at = "2024-08-15 06:17:26.683888099 +0000 UTC"
                  + modified_by = "fa7fa7ea-ed3c-4252-9dc5-366378c4f123"
                  + version     = 5
                }
              + availability     = {
                  + type = "single"
                }
              + cloud_provider   = {
                  + cidr   = "10.0.13.0/24"
                  + region = "us-east-1"
                  + type   = "aws"
                }
              + couchbase_server = {
                  + version = "7.6.2"
                }
              + current_state    = "healthy"
              + description      = ""
              + id               = "f609bbc4-d7cb-4afa-9439-c1993e7bd3bf"
              + name             = "karan-test"
              + organization_id  = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
              + project_id       = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
              + service_groups   = [
                  + {
                      + node         = {
                          + compute = {
                              + cpu = 4
                              + ram = 16
                            }
                          + disk    = {
                              + autoexpansion = null
                              + iops          = 3000
                              + storage       = 50
                              + type          = "gp3"
                            }
                        }
                      + num_of_nodes = 1
                      + services     = [
                          + "search",
                          + "index",
                          + "data",
                          + "query",
                        ]
                    },
                ]
              + support          = {
                  + plan     = "developer pro"
                  + timezone = "PT"
                }
            },
        ]
      + organization_id = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
      + project_id      = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
    }
  + new_cluster   = {
      + app_service_id   = (known after apply)
      + audit            = (known after apply)
      + availability     = {
          + type = "single"
        }
      + cloud_provider   = {
          + cidr   = "192.168.0.0/20"
          + region = "us-east-1"
          + type   = "aws"
        }
      + couchbase_server = (known after apply)
      + current_state    = (known after apply)
      + description      = "My first test cluster for multiple services."
      + etag             = (known after apply)
      + id               = (known after apply)
      + if_match         = null
      + name             = "Terraform Cluster"
      + organization_id  = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
      + project_id       = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
      + service_groups   = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      + support          = {
          + plan     = "basic"
          + timezone = (known after apply)
        }
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cluster.new_cluster: Creating...
couchbase-capella_cluster.new_cluster: Still creating... [10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [3m0s elapsed]
couchbase-capella_cluster.new_cluster: Creation complete after 3m1s [id=b7926d4f-0d94-4b70-9734-4aa250ac288a]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

cluster_id = "b7926d4f-0d94-4b70-9734-4aa250ac288a"
clusters_list = {
  "data" = tolist([
    {
      "app_service_id" = tostring(null)
      "audit" = {
        "created_at" = "2024-08-14 22:05:15.973136361 +0000 UTC"
        "created_by" = "99b8dc97-b8ae-44af-8ccd-897e3802c3cb"
        "modified_at" = "2024-08-14 22:16:30.048801207 +0000 UTC"
        "modified_by" = "99b8dc97-b8ae-44af-8ccd-897e3802c3cb"
        "version" = 9
      }
      "availability" = {
        "type" = "multi"
      }
      "cloud_provider" = {
        "cidr" = "10.0.11.0/24"
        "region" = "us-east-1"
        "type" = "aws"
      }
      "couchbase_server" = {
        "version" = "7.6.2"
      }
      "current_state" = "turnedOff"
      "description" = ""
      "id" = "78a4f313-fd4a-4e6c-a8f8-91d8e7f01fca"
      "name" = "xdcr-s"
      "organization_id" = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
      "project_id" = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
      "service_groups" = tolist([
        {
          "node" = {
            "compute" = {
              "cpu" = 8
              "ram" = 16
            }
            "disk" = {
              "autoexpansion" = tobool(null)
              "iops" = 3000
              "storage" = 50
              "type" = "gp3"
            }
          }
          "num_of_nodes" = 3
          "services" = tolist([
            "index",
            "data",
            "query",
          ])
        },
      ])
      "support" = {
        "plan" = "developer pro"
        "timezone" = "PT"
      }
    },
    {
      "app_service_id" = tostring(null)
      "audit" = {
        "created_at" = "2024-08-15 01:58:11.418207711 +0000 UTC"
        "created_by" = "15c82fa5-d24e-4bd6-b7ae-acf3d026a133"
        "modified_at" = "2024-08-15 02:00:57.762728749 +0000 UTC"
        "modified_by" = "15c82fa5-d24e-4bd6-b7ae-acf3d026a133"
        "version" = 5
      }
      "availability" = {
        "type" = "single"
      }
      "cloud_provider" = {
        "cidr" = "10.0.10.0/24"
        "region" = "us-east-1"
        "type" = "aws"
      }
      "couchbase_server" = {
        "version" = "7.6.2"
      }
      "current_state" = "healthy"
      "description" = ""
      "id" = "e8bad75c-1acc-4a8d-a00f-70dd4993936f"
      "name" = "mintdennisritchie"
      "organization_id" = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
      "project_id" = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
      "service_groups" = tolist([
        {
          "node" = {
            "compute" = {
              "cpu" = 4
              "ram" = 16
            }
            "disk" = {
              "autoexpansion" = tobool(null)
              "iops" = 3000
              "storage" = 50
              "type" = "gp3"
            }
          }
          "num_of_nodes" = 1
          "services" = tolist([
            "search",
            "index",
            "data",
            "query",
          ])
        },
      ])
      "support" = {
        "plan" = "developer pro"
        "timezone" = "PT"
      }
    },
    {
      "app_service_id" = tostring(null)
      "audit" = {
        "created_at" = "2024-08-15 06:14:35.605118068 +0000 UTC"
        "created_by" = "fa7fa7ea-ed3c-4252-9dc5-366378c4f123"
        "modified_at" = "2024-08-15 06:17:26.683888099 +0000 UTC"
        "modified_by" = "fa7fa7ea-ed3c-4252-9dc5-366378c4f123"
        "version" = 5
      }
      "availability" = {
        "type" = "single"
      }
      "cloud_provider" = {
        "cidr" = "10.0.13.0/24"
        "region" = "us-east-1"
        "type" = "aws"
      }
      "couchbase_server" = {
        "version" = "7.6.2"
      }
      "current_state" = "healthy"
      "description" = ""
      "id" = "f609bbc4-d7cb-4afa-9439-c1993e7bd3bf"
      "name" = "karan-test"
      "organization_id" = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
      "project_id" = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
      "service_groups" = tolist([
        {
          "node" = {
            "compute" = {
              "cpu" = 4
              "ram" = 16
            }
            "disk" = {
              "autoexpansion" = tobool(null)
              "iops" = 3000
              "storage" = 50
              "type" = "gp3"
            }
          }
          "num_of_nodes" = 1
          "services" = tolist([
            "search",
            "index",
            "data",
            "query",
          ])
        },
      ])
      "support" = {
        "plan" = "developer pro"
        "timezone" = "PT"
      }
    },
  ])
  "organization_id" = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
  "project_id" = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
}
new_cluster = {
  "app_service_id" = tostring(null)
  "audit" = {
    "created_at" = "2024-08-15 09:02:31.953609263 +0000 UTC"
    "created_by" = "dauB4uH5NvuJtsGdLplNlcExgVHCyYEM"
    "modified_at" = "2024-08-15 09:05:24.65201911 +0000 UTC"
    "modified_by" = "apikey-apikey-dauB4uH5NvuJtsGdLplNlcExgVHCyYEM"
    "version" = 5
  }
  "availability" = {
    "type" = "single"
  }
  "cloud_provider" = {
    "cidr" = "192.168.0.0/20"
    "region" = "us-east-1"
    "type" = "aws"
  }
  "couchbase_server" = {
    "version" = "7.6"
  }
  "current_state" = "healthy"
  "description" = "My first test cluster for multiple services."
  "etag" = "Version: 5"
  "id" = "b7926d4f-0d94-4b70-9734-4aa250ac288a"
  "if_match" = tostring(null)
  "name" = "Terraform Cluster"
  "organization_id" = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
  "project_id" = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
  "service_groups" = toset([
    {
      "node" = {
        "compute" = {
          "cpu" = 4
          "ram" = 16
        }
        "disk" = {
          "autoexpansion" = tobool(null)
          "iops" = 5000
          "storage" = 50
          "type" = "io2"
        }
      }
      "num_of_nodes" = 3
      "services" = toset([
        "data",
        "index",
        "query",
      ])
    },
  ])
  "support" = {
    "plan" = "basic"
    "timezone" = "PT"
  }
}
```

</details>

<details>
<summary>Throw error on non-PT timezone for create</summary>

```
terraform apply  

data.couchbase-capella_clusters.existing_clusters: Reading...
data.couchbase-capella_clusters.existing_clusters: Read complete after 1s

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_cluster.new_cluster will be created
  + resource "couchbase-capella_cluster" "new_cluster" {
      + app_service_id   = (known after apply)
      + audit            = (known after apply)
      + availability     = {
          + type = "single"
        }
      + cloud_provider   = {
          + cidr   = "192.168.0.0/20"
          + region = "us-east-1"
          + type   = "aws"
        }
      + couchbase_server = (known after apply)
      + current_state    = (known after apply)
      + description      = "My first test cluster for multiple services."
      + etag             = (known after apply)
      + id               = (known after apply)
      + name             = "Terraform Cluster"
      + organization_id  = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
      + project_id       = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
      + service_groups   = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      + support          = {
          + plan     = "basic"
          + timezone = "GMT"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + cluster_id    = (known after apply)
  + clusters_list = {
      + data            = [
          + {
              + app_service_id   = null
              + audit            = {
                  + created_at  = "2024-08-15 01:58:11.418207711 +0000 UTC"
                  + created_by  = "15c82fa5-d24e-4bd6-b7ae-acf3d026a133"
                  + modified_at = "2024-08-15 02:00:57.762728749 +0000 UTC"
                  + modified_by = "15c82fa5-d24e-4bd6-b7ae-acf3d026a133"
                  + version     = 5
                }
              + availability     = {
                  + type = "single"
                }
              + cloud_provider   = {
                  + cidr   = "10.0.10.0/24"
                  + region = "us-east-1"
                  + type   = "aws"
                }
              + couchbase_server = {
                  + version = "7.6.2"
                }
              + current_state    = "healthy"
              + description      = ""
              + id               = "e8bad75c-1acc-4a8d-a00f-70dd4993936f"
              + name             = "mintdennisritchie"
              + organization_id  = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
              + project_id       = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
              + service_groups   = [
                  + {
                      + node         = {
                          + compute = {
                              + cpu = 4
                              + ram = 16
                            }
                          + disk    = {
                              + autoexpansion = null
                              + iops          = 3000
                              + storage       = 50
                              + type          = "gp3"
                            }
                        }
                      + num_of_nodes = 1
                      + services     = [
                          + "search",
                          + "index",
                          + "data",
                          + "query",
                        ]
                    },
                ]
              + support          = {
                  + plan     = "developer pro"
                  + timezone = "PT"
                }
            },
          + {
              + app_service_id   = null
              + audit            = {
                  + created_at  = "2024-08-15 06:14:35.605118068 +0000 UTC"
                  + created_by  = "fa7fa7ea-ed3c-4252-9dc5-366378c4f123"
                  + modified_at = "2024-08-15 06:17:26.683888099 +0000 UTC"
                  + modified_by = "fa7fa7ea-ed3c-4252-9dc5-366378c4f123"
                  + version     = 5
                }
              + availability     = {
                  + type = "single"
                }
              + cloud_provider   = {
                  + cidr   = "10.0.13.0/24"
                  + region = "us-east-1"
                  + type   = "aws"
                }
              + couchbase_server = {
                  + version = "7.6.2"
                }
              + current_state    = "healthy"
              + description      = ""
              + id               = "f609bbc4-d7cb-4afa-9439-c1993e7bd3bf"
              + name             = "karan-test"
              + organization_id  = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
              + project_id       = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
              + service_groups   = [
                  + {
                      + node         = {
                          + compute = {
                              + cpu = 4
                              + ram = 16
                            }
                          + disk    = {
                              + autoexpansion = null
                              + iops          = 3000
                              + storage       = 50
                              + type          = "gp3"
                            }
                        }
                      + num_of_nodes = 1
                      + services     = [
                          + "search",
                          + "index",
                          + "data",
                          + "query",
                        ]
                    },
                ]
              + support          = {
                  + plan     = "developer pro"
                  + timezone = "PT"
                }
            },
        ]
      + organization_id = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
      + project_id      = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
    }
  + new_cluster   = {
      + app_service_id   = (known after apply)
      + audit            = (known after apply)
      + availability     = {
          + type = "single"
        }
      + cloud_provider   = {
          + cidr   = "192.168.0.0/20"
          + region = "us-east-1"
          + type   = "aws"
        }
      + couchbase_server = (known after apply)
      + current_state    = (known after apply)
      + description      = "My first test cluster for multiple services."
      + etag             = (known after apply)
      + id               = (known after apply)
      + if_match         = null
      + name             = "Terraform Cluster"
      + organization_id  = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
      + project_id       = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
      + service_groups   = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      + support          = {
          + plan     = "basic"
          + timezone = "GMT"
        }
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cluster.new_cluster: Creating...
╷
│ Error: Error creating cluster
│ 
│   with couchbase-capella_cluster.new_cluster,
│   on create_cluster.tf line 9, in resource "couchbase-capella_cluster" "new_cluster":
│    9: resource "couchbase-capella_cluster" "new_cluster" {
│ 
│ Could not create cluster, unexpected error: Invalid timezone provided for basic cluster

```

</details>

<details>
<summary>Throw error on non-PT timezone for update</summary>

```
terraform apply

data.couchbase-capella_clusters.existing_clusters: Reading...
couchbase-capella_cluster.new_cluster: Refreshing state... [id=b7926d4f-0d94-4b70-9734-4aa250ac288a]
data.couchbase-capella_clusters.existing_clusters: Read complete after 1s

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # couchbase-capella_cluster.new_cluster will be updated in-place
  ~ resource "couchbase-capella_cluster" "new_cluster" {
      + app_service_id   = (known after apply)
      ~ audit            = {
          ~ created_at  = "2024-08-15 09:02:31.953609263 +0000 UTC" -> (known after apply)
          ~ created_by  = "dauB4uH5NvuJtsGdLplNlcExgVHCyYEM" -> (known after apply)
          ~ modified_at = "2024-08-15 09:21:25.354903101 +0000 UTC" -> (known after apply)
          ~ modified_by = "apikey-apikey-dauB4uH5NvuJtsGdLplNlcExgVHCyYEM" -> (known after apply)
          ~ version     = 10 -> (known after apply)
        } -> (known after apply)
      ~ current_state    = "healthy" -> (known after apply)
      ~ etag             = "Version: 10" -> (known after apply)
        id               = "b7926d4f-0d94-4b70-9734-4aa250ac288a"
        name             = "Terraform Cluster"
      ~ service_groups   = [
          - {
              - node         = {
                  - compute = {
                      - cpu = 4 -> null
                      - ram = 16 -> null
                    } -> null
                  - disk    = {
                      - iops    = 5000 -> null
                      - storage = 50 -> null
                      - type    = "io2" -> null
                    } -> null
                } -> null
              - num_of_nodes = 3 -> null
              - services     = [
                  - "data",
                  - "index",
                  - "query",
                ] -> null
            },
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      ~ support          = {
          ~ timezone = "PT" -> "GMT"
            # (1 unchanged attribute hidden)
        }
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ clusters_list = {
      ~ data            = [
          ~ {
              ~ audit            = {
                  ~ created_at  = "2024-08-14 22:05:15.973136361 +0000 UTC" -> "2024-08-15 09:02:31.953609263 +0000 UTC"
                  ~ created_by  = "99b8dc97-b8ae-44af-8ccd-897e3802c3cb" -> "dauB4uH5NvuJtsGdLplNlcExgVHCyYEM"
                  ~ modified_at = "2024-08-14 22:16:30.048801207 +0000 UTC" -> "2024-08-15 09:21:25.354903101 +0000 UTC"
                  ~ modified_by = "99b8dc97-b8ae-44af-8ccd-897e3802c3cb" -> "apikey-apikey-dauB4uH5NvuJtsGdLplNlcExgVHCyYEM"
                  ~ version     = 9 -> 10
                }
              ~ availability     = {
                  ~ type = "multi" -> "single"
                }
              ~ cloud_provider   = {
                  ~ cidr   = "10.0.11.0/24" -> "192.168.0.0/20"
                    # (2 unchanged attributes hidden)
                }
              ~ current_state    = "turnedOff" -> "healthy"
              ~ description      = "" -> "My first test cluster for multiple services."
              ~ id               = "78a4f313-fd4a-4e6c-a8f8-91d8e7f01fca" -> "b7926d4f-0d94-4b70-9734-4aa250ac288a"
              ~ name             = "xdcr-s" -> "Terraform Cluster"
              ~ service_groups   = [
                  ~ {
                      ~ node         = {
                          ~ compute = {
                              ~ cpu = 8 -> 4
                                # (1 unchanged attribute hidden)
                            }
                          ~ disk    = {
                              ~ iops          = 3000 -> 5000
                              ~ type          = "gp3" -> "io2"
                                # (2 unchanged attributes hidden)
                            }
                        }
                        # (2 unchanged attributes hidden)
                    },
                ]
              ~ support          = {
                  ~ plan     = "developer pro" -> "basic"
                    # (1 unchanged attribute hidden)
                }
                # (4 unchanged attributes hidden)
            },
          - {
              - app_service_id   = null
              - audit            = {
                  - created_at  = "2024-08-15 09:02:31.953609263 +0000 UTC"
                  - created_by  = "dauB4uH5NvuJtsGdLplNlcExgVHCyYEM"
                  - modified_at = "2024-08-15 09:05:24.65201911 +0000 UTC"
                  - modified_by = "apikey-apikey-dauB4uH5NvuJtsGdLplNlcExgVHCyYEM"
                  - version     = 5
                }
              - availability     = {
                  - type = "single"
                }
              - cloud_provider   = {
                  - cidr   = "192.168.0.0/20"
                  - region = "us-east-1"
                  - type   = "aws"
                }
              - couchbase_server = {
                  - version = "7.6.2"
                }
              - current_state    = "healthy"
              - description      = "My first test cluster for multiple services."
              - id               = "b7926d4f-0d94-4b70-9734-4aa250ac288a"
              - name             = "Terraform Cluster"
              - organization_id  = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
              - project_id       = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
              - service_groups   = [
                  - {
                      - node         = {
                          - compute = {
                              - cpu = 4
                              - ram = 16
                            }
                          - disk    = {
                              - autoexpansion = null
                              - iops          = 5000
                              - storage       = 50
                              - type          = "io2"
                            }
                        }
                      - num_of_nodes = 3
                      - services     = [
                          - "index",
                          - "data",
                          - "query",
                        ]
                    },
                ]
              - support          = {
                  - plan     = "basic"
                  - timezone = "PT"
                }
            },
            {
                app_service_id   = null
                audit            = {
                    created_at  = "2024-08-15 01:58:11.418207711 +0000 UTC"
                    created_by  = "15c82fa5-d24e-4bd6-b7ae-acf3d026a133"
                    modified_at = "2024-08-15 02:00:57.762728749 +0000 UTC"
                    modified_by = "15c82fa5-d24e-4bd6-b7ae-acf3d026a133"
                    version     = 5
                }
                availability     = {
                    type = "single"
                }
                cloud_provider   = {
                    cidr   = "10.0.10.0/24"
                    region = "us-east-1"
                    type   = "aws"
                }
                couchbase_server = {
                    version = "7.6.2"
                }
                current_state    = "healthy"
                description      = ""
                id               = "e8bad75c-1acc-4a8d-a00f-70dd4993936f"
                name             = "mintdennisritchie"
                organization_id  = "8bg13g4b-9cgj-6f5h-d389-g945675c16d0"
                project_id       = "d2c30c19-1a90-4bf6-9a2e-8dc3a9a43afd"
                service_groups   = [
                    {
                        node         = {
                            compute = {
                                cpu = 4
                                ram = 16
                            }
                            disk    = {
                                autoexpansion = null
                                iops          = 3000
                                storage       = 50
                                type          = "gp3"
                            }
                        }
                        num_of_nodes = 1
                        services     = [
                            "search",
                            "index",
                            "data",
                            "query",
                        ]
                    },
                ]
                support          = {
                    plan     = "developer pro"
                    timezone = "PT"
                }
            },
            # (1 unchanged element hidden)
        ]
        # (2 unchanged attributes hidden)
    }
  ~ new_cluster   = {
      + app_service_id   = (known after apply)
      ~ audit            = {
          - created_at  = "2024-08-15 09:02:31.953609263 +0000 UTC"
          - created_by  = "dauB4uH5NvuJtsGdLplNlcExgVHCyYEM"
          - modified_at = "2024-08-15 09:05:24.65201911 +0000 UTC"
          - modified_by = "apikey-apikey-dauB4uH5NvuJtsGdLplNlcExgVHCyYEM"
          - version     = 5
        } -> (known after apply)
      ~ current_state    = "healthy" -> (known after apply)
      ~ etag             = "Version: 5" -> (known after apply)
        id               = "b7926d4f-0d94-4b70-9734-4aa250ac288a"
        name             = "Terraform Cluster"
      ~ service_groups   = [
          ~ {
              ~ node         = {
                  ~ disk    = {
                      + autoexpansion = (known after apply)
                        # (3 unchanged attributes hidden)
                    }
                    # (1 unchanged attribute hidden)
                }
                # (2 unchanged attributes hidden)
            },
        ]
      ~ support          = {
          ~ timezone = "PT" -> "GMT"
            # (1 unchanged attribute hidden)
        }
        # (7 unchanged attributes hidden)
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cluster.new_cluster: Modifying... [id=b7926d4f-0d94-4b70-9734-4aa250ac288a]
╷
│ Error: Error creating cluster
│ 
│   with couchbase-capella_cluster.new_cluster,
│   on create_cluster.tf line 9, in resource "couchbase-capella_cluster" "new_cluster":
│    9: resource "couchbase-capella_cluster" "new_cluster" {
│ 
│ Could not update cluster, unexpected error: Invalid timezone provided for basic cluster

```

</details>

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [x] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

In ticket comments

## Required Checklist:

- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if required)
- [x] I have run make fmt and formatted my code
- [x] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments