### PR TITLE
CCBSE-2021 - Adding connection string to cluster response

### DIFF
--- a/examples/cluster/README.md
+++ b/examples/cluster/README.md
@@ -1172,7 +1172,7 @@ Terraform will perform the following actions:
           - region = "us-east-1" -> null
           - type   = "aws" -> null
         }
-      - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+      - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com" -> null
       - couchbase_server = {
           - version = "7.1.5" -> null
         }

--- a/examples/cluster/README.md
+++ b/examples/cluster/README.md
@@ -60,6 +60,7 @@ Terraform will perform the following actions:
           + region = "us-east-1"
           + type   = "aws"
         }
+      + connection_string = (known after apply)
       + couchbase_server = {
           + version = "7.1"
         }
@@ -68,8 +69,8 @@ Terraform will perform the following actions:
       + etag             = (known after apply)
       + id               = (known after apply)
       + name             = "New Terraform Cluster"
-      + organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-      + project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+      + organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+      + project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
       + service_groups   = [
           + {
               + node         = {
@@ -106,9 +107,9 @@ Changes to Outputs:
               + app_service_id   = null
               + audit            = {
                   + created_at  = "2023-10-03 21:04:45.895255387 +0000 UTC"
-                  + created_by  = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  + created_by  = "ffffffff-aaaa-1414-eeee-00000000000"
                   + modified_at = "2023-10-03 21:08:45.110430897 +0000 UTC"
-                  + modified_by = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  + modified_by = "ffffffff-aaaa-1414-eeee-00000000000"
                   + version     = 5
                 }
               + availability     = {
@@ -119,15 +120,16 @@ Changes to Outputs:
                   + region = "af-south-1"
                   + type   = "aws"
                 }
+              + connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
               + couchbase_server = {
                   + version = "7.2.2"
                 }
               + current_state    = "healthy"
               + description      = ""
-              + id               = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+              + id               = "ffffffff-aaaa-1414-eeee-00000000000"
               + name             = "quickrobertekahn"
-              + organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-              + project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+              + organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+              + project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
               + service_groups   = [
                   + {
                       + node         = {
@@ -156,8 +158,8 @@ Changes to Outputs:
                 }
             },
         ]
-      + organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-      + project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+      + organization_id = "ffffffff-aaaa-1414-eeee-00000000000"
+      + project_id      = "ffffffff-aaaa-1414-eeee-00000000000"
     }
   + new_cluster   = {
       + app_service_id   = (known after apply)
@@ -170,6 +172,7 @@ Changes to Outputs:
           + region = "us-east-1"
           + type   = "aws"
         }
+      + connection_string = (known after apply)
       + couchbase_server = {
           + version = "7.1"
         }
@@ -179,8 +182,8 @@ Changes to Outputs:
       + id               = (known after apply)
       + if_match         = null
       + name             = "New Terraform Cluster"
-      + organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-      + project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+      + organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+      + project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
       + service_groups   = [
           + {
               + node         = {
@@ -254,6 +257,7 @@ Terraform will perform the following actions:
           + region = "us-east-1"
           + type   = "aws"
         }
+      + connection_string = (known after apply)
       + couchbase_server = {
           + version = "7.1"
         }
@@ -262,8 +266,8 @@ Terraform will perform the following actions:
       + etag             = (known after apply)
       + id               = (known after apply)
       + name             = "New Terraform Cluster"
-      + organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-      + project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+      + organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+      + project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
       + service_groups   = [
           + {
               + node         = {
@@ -300,9 +304,9 @@ Changes to Outputs:
               + app_service_id   = null
               + audit            = {
                   + created_at  = "2023-10-03 21:04:45.895255387 +0000 UTC"
-                  + created_by  = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  + created_by  = "ffffffff-aaaa-1414-eeee-00000000000"
                   + modified_at = "2023-10-03 21:08:45.110430897 +0000 UTC"
-                  + modified_by = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  + modified_by = "ffffffff-aaaa-1414-eeee-00000000000"
                   + version     = 5
                 }
               + availability     = {
@@ -313,15 +317,16 @@ Changes to Outputs:
                   + region = "af-south-1"
                   + type   = "aws"
                 }
+              + connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com" 
               + couchbase_server = {
                   + version = "7.2.2"
                 }
               + current_state    = "healthy"
               + description      = ""
-              + id               = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+              + id               = "ffffffff-aaaa-1414-eeee-00000000000"
               + name             = "quickrobertekahn"
-              + organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-              + project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+              + organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+              + project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
               + service_groups   = [
                   + {
                       + node         = {
@@ -350,8 +355,8 @@ Changes to Outputs:
                 }
             },
         ]
-      + organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-      + project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+      + organization_id = "ffffffff-aaaa-1414-eeee-00000000000"
+      + project_id      = "ffffffff-aaaa-1414-eeee-00000000000"
     }
   + new_cluster   = {
       + app_service_id   = (known after apply)
@@ -367,14 +372,15 @@ Changes to Outputs:
       + couchbase_server = {
           + version = "7.1"
         }
+      + connection_string = (known after apply)
       + current_state    = (known after apply)
       + description      = "My first test cluster for multiple services."
       + etag             = (known after apply)
       + id               = (known after apply)
       + if_match         = null
       + name             = "New Terraform Cluster"
-      + organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-      + project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+      + organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+      + project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
       + service_groups   = [
           + {
               + node         = {
@@ -427,7 +433,7 @@ capella_cluster.new_cluster: Still creating... [2m30s elapsed]
 capella_cluster.new_cluster: Still creating... [2m40s elapsed]
 capella_cluster.new_cluster: Still creating... [2m50s elapsed]
 capella_cluster.new_cluster: Still creating... [3m0s elapsed]
-capella_cluster.new_cluster: Creation complete after 3m4s [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6]
+capella_cluster.new_cluster: Creation complete after 3m4s [id=ffffffff-aaaa-1414-eeee-00000000000]
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
@@ -439,9 +445,9 @@ clusters_list = {
       "app_service_id" = tostring(null)
       "audit" = {
         "created_at" = "2023-10-03 21:04:45.895255387 +0000 UTC"
-        "created_by" = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+        "created_by" = "ffffffff-aaaa-1414-eeee-00000000000"
         "modified_at" = "2023-10-03 21:08:45.110430897 +0000 UTC"
-        "modified_by" = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+        "modified_by" = "ffffffff-aaaa-1414-eeee-00000000000"
         "version" = 5
       }
       "availability" = {
@@ -452,15 +458,16 @@ clusters_list = {
         "region" = "af-south-1"
         "type" = "aws"
       }
+      "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
       "couchbase_server" = {
         "version" = "7.2.2"
       }
       "current_state" = "healthy"
       "description" = ""
-      "id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      "id" = "ffffffff-aaaa-1414-eeee-00000000000"
       "name" = "quickrobertekahn"
-      "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-      "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+      "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
+      "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
       "service_groups" = tolist([
         {
           "node" = {
@@ -489,8 +496,8 @@ clusters_list = {
       }
     },
   ])
-  "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-  "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
 }
 new_cluster = {
   "app_service_id" = tostring(null)
@@ -509,17 +516,18 @@ new_cluster = {
     "region" = "us-east-1"
     "type" = "aws"
   }
+  "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
   "couchbase_server" = {
     "version" = "7.1"
   }
   "current_state" = "healthy"
   "description" = "My first test cluster for multiple services."
   "etag" = "Version: 5"
-  "id" = "f90c1d8a-c01f-4faa-860d-71cdcdf454f6"
+  "id" = "ffffffff-aaaa-1414-eeee-00000000000"
   "if_match" = tostring(null)
   "name" = "New Terraform Cluster"
-  "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-  "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
   "service_groups" = tolist([
     {
       "node" = {
@@ -572,17 +580,18 @@ $ terraform output new_cluster
     "region" = "us-east-1"
     "type" = "aws"
   }
+  "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
   "couchbase_server" = {
     "version" = "7.1"
   }
   "current_state" = "healthy"
   "description" = "My first test cluster for multiple services."
   "etag" = "Version: 5"
-  "id" = "f90c1d8a-c01f-4faa-860d-71cdcdf454f6"
+  "id" = "ffffffff-aaaa-1414-eeee-00000000000"
   "if_match" = tostring(null)
   "name" = "New Terraform Cluster"
-  "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-  "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
   "service_groups" = tolist([
     {
       "node" = {
@@ -612,7 +621,7 @@ $ terraform output new_cluster
 ```
 
 
-In this case, the cluster ID for my new cluster is `f90c1d8a-c01f-4faa-860d-71cdcdf454f6`
+In this case, the cluster ID for my new cluster is `ffffffff-aaaa-1414-eeee-00000000000`
 
 ### List the resources that are present in the Terraform State file.
 
@@ -644,16 +653,16 @@ Please note, this command will only remove the resource from the Terraform State
 Command: `terraform import couchbase-capella_cluster.new_cluster id=<cluster_id>,cluster_id=<cluster_id>,project_id=<project_id>,organization_id=<organization_id>`
 
 In this case, the complete command is:
-`terraform import couchbase-capella_cluster.new_cluster id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6,project_id=958ad6b5-272d-49f0-babd-cc98c6b54a81,organization_id=0783f698-ac58-4018-84a3-31c3b6ef785d`
+`terraform import couchbase-capella_cluster.new_cluster id=ffffffff-aaaa-1414-eeee-00000000000,project_id=ffffffff-aaaa-1414-eeee-00000000000,organization_id=ffffffff-aaaa-1414-eeee-00000000000`
 
 Sample Output:
 ```
-$ terraform import couchbase-capella_cluster.new_cluster id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6,project_id=958ad6b5-272d-49f0-babd-cc98c6b54a81,organization_id=0783f698-ac58-4018-84a3-31c3b6ef785d
-capella_cluster.new_cluster: Importing from ID "id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6,project_id=958ad6b5-272d-49f0-babd-cc98c6b54a81,organization_id=0783f698-ac58-4018-84a3-31c3b6ef785d"...
+$ terraform import couchbase-capella_cluster.new_cluster id=ffffffff-aaaa-1414-eeee-00000000000,project_id=ffffffff-aaaa-1414-eeee-00000000000,organization_id=ffffffff-aaaa-1414-eeee-00000000000
+capella_cluster.new_cluster: Importing from ID "id=ffffffff-aaaa-1414-eeee-00000000000,project_id=ffffffff-aaaa-1414-eeee-00000000000,organization_id=ffffffff-aaaa-1414-eeee-00000000000"...
 data.capella_clusters.existing_clusters: Reading...
 capella_cluster.new_cluster: Import prepared!
   Prepared capella_cluster for import
-capella_cluster.new_cluster: Refreshing state... [id=id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6,project_id=958ad6b5-272d-49f0-babd-cc98c6b54a81,organization_id=0783f698-ac58-4018-84a3-31c3b6ef785d]
+capella_cluster.new_cluster: Refreshing state... [id=id=ffffffff-aaaa-1414-eeee-00000000000,project_id=ffffffff-aaaa-1414-eeee-00000000000,organization_id=ffffffff-aaaa-1414-eeee-00000000000]
 data.capella_clusters.existing_clusters: Read complete after 1s
 
 Import successful!
@@ -685,7 +694,7 @@ $ terraform apply -var 'support={plan="enterprise", timezone="IST"}'
 │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
 ╵
 data.capella_clusters.existing_clusters: Reading...
-capella_cluster.new_cluster: Refreshing state... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6]
+capella_cluster.new_cluster: Refreshing state... [id=ffffffff-aaaa-1414-eeee-00000000000]
 data.capella_clusters.existing_clusters: Read complete after 1s
 
 Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
@@ -705,7 +714,7 @@ Terraform will perform the following actions:
         }
       ~ current_state    = "healthy" -> (known after apply)
       ~ etag             = "Version: 5" -> (known after apply)
-        id               = "f90c1d8a-c01f-4faa-860d-71cdcdf454f6"
+        id               = "ffffffff-aaaa-1414-eeee-00000000000"
         name             = "New Terraform Cluster"
       ~ service_groups   = [
           ~ {
@@ -734,9 +743,9 @@ Changes to Outputs:
               - app_service_id   = null
               - audit            = {
                   - created_at  = "2023-10-03 21:04:45.895255387 +0000 UTC"
-                  - created_by  = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  - created_by  = "ffffffff-aaaa-1414-eeee-00000000000"
                   - modified_at = "2023-10-03 21:08:45.110430897 +0000 UTC"
-                  - modified_by = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  - modified_by = "ffffffff-aaaa-1414-eeee-00000000000"
                   - version     = 5
                 }
               - availability     = {
@@ -747,15 +756,16 @@ Changes to Outputs:
                   - region = "af-south-1"
                   - type   = "aws"
                 }
+              - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
               - couchbase_server = {
                   - version = "7.2.2"
                 }
               - current_state    = "healthy"
               - description      = ""
-              - id               = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+              - id               = "ffffffff-aaaa-1414-eeee-00000000000"
               - name             = "quickrobertekahn"
-              - organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-              - project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+              - organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+              - project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
               - service_groups   = [
                   - {
                       - node         = {
@@ -800,15 +810,16 @@ Changes to Outputs:
                     region = "us-east-1"
                     type   = "aws"
                 }
+                connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
                 couchbase_server = {
                     version = "7.1.5"
                 }
                 current_state    = "healthy"
                 description      = "My first test cluster for multiple services."
-                id               = "f90c1d8a-c01f-4faa-860d-71cdcdf454f6"
+                id               = "ffffffff-aaaa-1414-eeee-00000000000"
                 name             = "New Terraform Cluster"
-                organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-                project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+                organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+                project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
                 service_groups   = [
                     {
                         node         = {
@@ -839,9 +850,9 @@ Changes to Outputs:
               + app_service_id   = null
               + audit            = {
                   + created_at  = "2023-10-03 21:04:45.895255387 +0000 UTC"
-                  + created_by  = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  + created_by  = "ffffffff-aaaa-1414-eeee-00000000000"
                   + modified_at = "2023-10-03 21:08:45.110430897 +0000 UTC"
-                  + modified_by = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  + modified_by = "ffffffff-aaaa-1414-eeee-00000000000"
                   + version     = 5
                 }
               + availability     = {
@@ -852,15 +863,16 @@ Changes to Outputs:
                   + region = "af-south-1"
                   + type   = "aws"
                 }
+              + connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
               + couchbase_server = {
                   + version = "7.2.2"
                 }
               + current_state    = "healthy"
               + description      = ""
-              + id               = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+              + id               = "ffffffff-aaaa-1414-eeee-00000000000"
               + name             = "quickrobertekahn"
-              + organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-              + project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+              + organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+              + project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
               + service_groups   = [
                   + {
                       + node         = {
@@ -900,9 +912,10 @@ Changes to Outputs:
           - modified_by = "FYcHU0XHvw5tuQl4smAwyCKbGPMUZKUC"
           - version     = 5
         } -> (known after apply)
+      ~ connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com" -> (known after apply)
       ~ current_state    = "healthy" -> (known after apply)
       ~ etag             = "Version: 5" -> (known after apply)
-        id               = "f90c1d8a-c01f-4faa-860d-71cdcdf454f6"
+        id               = "ffffffff-aaaa-1414-eeee-00000000000"
         name             = "New Terraform Cluster"
       ~ service_groups   = [
           ~ {
@@ -928,20 +941,20 @@ Do you want to perform these actions?
 
   Enter a value: yes
 
-capella_cluster.new_cluster: Modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 10s elapsed]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 20s elapsed]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 30s elapsed]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 40s elapsed]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 50s elapsed]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m0s elapsed]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m10s elapsed]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m20s elapsed]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m30s elapsed]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m40s elapsed]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m50s elapsed]
-capella_cluster.new_cluster: Still modifying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 2m0s elapsed]
-capella_cluster.new_cluster: Modifications complete after 2m7s [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6]
+capella_cluster.new_cluster: Modifying... [id=ffffffff-aaaa-1414-eeee-00000000000]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 10s elapsed]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 20s elapsed]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 30s elapsed]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 40s elapsed]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 50s elapsed]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m0s elapsed]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m10s elapsed]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m20s elapsed]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m30s elapsed]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m40s elapsed]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m50s elapsed]
+capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m0s elapsed]
+capella_cluster.new_cluster: Modifications complete after 2m7s [id=ffffffff-aaaa-1414-eeee-00000000000]
 
 Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
 
@@ -966,15 +979,16 @@ clusters_list = {
         "region" = "us-east-1"
         "type" = "aws"
       }
+      "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
       "couchbase_server" = {
         "version" = "7.1.5"
       }
       "current_state" = "healthy"
       "description" = "My first test cluster for multiple services."
-      "id" = "f90c1d8a-c01f-4faa-860d-71cdcdf454f6"
+      "id" = "ffffffff-aaaa-1414-eeee-00000000000"
       "name" = "New Terraform Cluster"
-      "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-      "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+      "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
+      "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
       "service_groups" = tolist([
         {
           "node" = {
@@ -1005,9 +1019,9 @@ clusters_list = {
       "app_service_id" = tostring(null)
       "audit" = {
         "created_at" = "2023-10-03 21:04:45.895255387 +0000 UTC"
-        "created_by" = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+        "created_by" = "ffffffff-aaaa-1414-eeee-00000000000"
         "modified_at" = "2023-10-03 21:08:45.110430897 +0000 UTC"
-        "modified_by" = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+        "modified_by" = "ffffffff-aaaa-1414-eeee-00000000000"
         "version" = 5
       }
       "availability" = {
@@ -1018,15 +1032,16 @@ clusters_list = {
         "region" = "af-south-1"
         "type" = "aws"
       }
+      "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
       "couchbase_server" = {
         "version" = "7.2.2"
       }
       "current_state" = "healthy"
       "description" = ""
-      "id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      "id" = "ffffffff-aaaa-1414-eeee-00000000000"
       "name" = "quickrobertekahn"
-      "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-      "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+      "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
+      "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
       "service_groups" = tolist([
         {
           "node" = {
@@ -1055,8 +1070,8 @@ clusters_list = {
       }
     },
   ])
-  "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-  "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
 }
 new_cluster = {
   "app_service_id" = tostring(null)
@@ -1075,17 +1090,18 @@ new_cluster = {
     "region" = "us-east-1"
     "type" = "aws"
   }
+  "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
   "couchbase_server" = {
     "version" = "7.1.5"
   }
   "current_state" = "healthy"
   "description" = "My first test cluster for multiple services."
   "etag" = "Version: 10"
-  "id" = "f90c1d8a-c01f-4faa-860d-71cdcdf454f6"
+  "id" = "ffffffff-aaaa-1414-eeee-00000000000"
   "if_match" = tostring(null)
   "name" = "New Terraform Cluster"
-  "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-  "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+  "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
   "service_groups" = tolist([
     {
       "node" = {
@@ -1131,7 +1147,7 @@ $ terraform destroy
 │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
 ╵
 data.capella_clusters.existing_clusters: Reading...
-capella_cluster.new_cluster: Refreshing state... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6]
+capella_cluster.new_cluster: Refreshing state... [id=ffffffff-aaaa-1414-eeee-00000000000]
 data.capella_clusters.existing_clusters: Read complete after 1s
 
 Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
@@ -1156,16 +1172,17 @@ Terraform will perform the following actions:
           - region = "us-east-1" -> null
           - type   = "aws" -> null
         }
+      - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
       - couchbase_server = {
           - version = "7.1.5" -> null
         }
       - current_state    = "healthy" -> null
       - description      = "My first test cluster for multiple services." -> null
       - etag             = "Version: 10" -> null
-      - id               = "f90c1d8a-c01f-4faa-860d-71cdcdf454f6" -> null
+      - id               = "ffffffff-aaaa-1414-eeee-00000000000" -> null
       - name             = "New Terraform Cluster" -> null
-      - organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d" -> null
-      - project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81" -> null
+      - organization_id  = "ffffffff-aaaa-1414-eeee-00000000000" -> null
+      - project_id       = "ffffffff-aaaa-1414-eeee-00000000000" -> null
       - service_groups   = [
           - {
               - node         = {
@@ -1215,15 +1232,16 @@ Changes to Outputs:
                   - region = "us-east-1"
                   - type   = "aws"
                 }
+              - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
               - couchbase_server = {
                   - version = "7.1.5"
                 }
               - current_state    = "healthy"
               - description      = "My first test cluster for multiple services."
-              - id               = "f90c1d8a-c01f-4faa-860d-71cdcdf454f6"
+              - id               = "ffffffff-aaaa-1414-eeee-00000000000"
               - name             = "New Terraform Cluster"
-              - organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-              - project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+              - organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+              - project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
               - service_groups   = [
                   - {
                       - node         = {
@@ -1254,9 +1272,9 @@ Changes to Outputs:
               - app_service_id   = null
               - audit            = {
                   - created_at  = "2023-10-03 21:04:45.895255387 +0000 UTC"
-                  - created_by  = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  - created_by  = "ffffffff-aaaa-1414-eeee-00000000000"
                   - modified_at = "2023-10-03 21:08:45.110430897 +0000 UTC"
-                  - modified_by = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  - modified_by = "ffffffff-aaaa-1414-eeee-00000000000"
                   - version     = 5
                 }
               - availability     = {
@@ -1267,15 +1285,16 @@ Changes to Outputs:
                   - region = "af-south-1"
                   - type   = "aws"
                 }
+              - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
               - couchbase_server = {
                   - version = "7.2.2"
                 }
               - current_state    = "healthy"
               - description      = ""
-              - id               = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+              - id               = "ffffffff-aaaa-1414-eeee-00000000000"
               - name             = "quickrobertekahn"
-              - organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-              - project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+              - organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+              - project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
               - service_groups   = [
                   - {
                       - node         = {
@@ -1304,8 +1323,8 @@ Changes to Outputs:
                 }
             },
         ]
-      - organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-      - project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+      - organization_id = "ffffffff-aaaa-1414-eeee-00000000000"
+      - project_id      = "ffffffff-aaaa-1414-eeee-00000000000"
     } -> null
   - new_cluster   = {
       - app_service_id   = null
@@ -1324,17 +1343,18 @@ Changes to Outputs:
           - region = "us-east-1"
           - type   = "aws"
         }
+      - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
       - couchbase_server = {
           - version = "7.1.5"
         }
       - current_state    = "healthy"
       - description      = "My first test cluster for multiple services."
       - etag             = "Version: 10"
-      - id               = "f90c1d8a-c01f-4faa-860d-71cdcdf454f6"
+      - id               = "ffffffff-aaaa-1414-eeee-00000000000"
       - if_match         = null
       - name             = "New Terraform Cluster"
-      - organization_id  = "0783f698-ac58-4018-84a3-31c3b6ef785d"
-      - project_id       = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+      - organization_id  = "ffffffff-aaaa-1414-eeee-00000000000"
+      - project_id       = "ffffffff-aaaa-1414-eeee-00000000000"
       - service_groups   = [
           - {
               - node         = {
@@ -1368,28 +1388,28 @@ Do you really want to destroy all resources?
 
   Enter a value: yes
 
-capella_cluster.new_cluster: Destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 10s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 20s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 30s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 40s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 50s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m0s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m10s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m20s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m30s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m40s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 1m50s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 2m0s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 2m10s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 2m20s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 2m30s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 2m40s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 2m50s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 3m0s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 3m10s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 3m20s elapsed]
-capella_cluster.new_cluster: Still destroying... [id=f90c1d8a-c01f-4faa-860d-71cdcdf454f6, 3m30s elapsed]
+capella_cluster.new_cluster: Destroying... [id=ffffffff-aaaa-1414-eeee-00000000000]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 10s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 20s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 30s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 40s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 50s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m0s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m10s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m20s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m30s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m40s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m50s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m0s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m10s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m20s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m30s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m40s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m50s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 3m0s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 3m10s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 3m20s elapsed]
+capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 3m30s elapsed]
 capella_cluster.new_cluster: Destruction complete after 3m32s
 
 Destroy complete! Resources: 1 destroyed.

--- a/examples/cluster/README.md
+++ b/examples/cluster/README.md
@@ -120,7 +120,7 @@ Changes to Outputs:
                   + region = "af-south-1"
                   + type   = "aws"
                 }
-              + connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+              + connection_string = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
               + couchbase_server = {
                   + version = "7.2.2"
                 }
@@ -317,7 +317,7 @@ Changes to Outputs:
                   + region = "af-south-1"
                   + type   = "aws"
                 }
-              + connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com" 
+              + connection_string = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com" 
               + couchbase_server = {
                   + version = "7.2.2"
                 }
@@ -458,7 +458,7 @@ clusters_list = {
         "region" = "af-south-1"
         "type" = "aws"
       }
-      "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+      "connection_string" = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
       "couchbase_server" = {
         "version" = "7.2.2"
       }
@@ -516,7 +516,7 @@ new_cluster = {
     "region" = "us-east-1"
     "type" = "aws"
   }
-  "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+  "connection_string" = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
   "couchbase_server" = {
     "version" = "7.1"
   }
@@ -580,7 +580,7 @@ $ terraform output new_cluster
     "region" = "us-east-1"
     "type" = "aws"
   }
-  "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+  "connection_string" = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
   "couchbase_server" = {
     "version" = "7.1"
   }
@@ -756,7 +756,7 @@ Changes to Outputs:
                   - region = "af-south-1"
                   - type   = "aws"
                 }
-              - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+              - connection_string = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
               - couchbase_server = {
                   - version = "7.2.2"
                 }
@@ -810,7 +810,7 @@ Changes to Outputs:
                     region = "us-east-1"
                     type   = "aws"
                 }
-                connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+                connection_string = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
                 couchbase_server = {
                     version = "7.1.5"
                 }
@@ -863,7 +863,7 @@ Changes to Outputs:
                   + region = "af-south-1"
                   + type   = "aws"
                 }
-              + connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+              + connection_string = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
               + couchbase_server = {
                   + version = "7.2.2"
                 }
@@ -912,7 +912,7 @@ Changes to Outputs:
           - modified_by = "FYcHU0XHvw5tuQl4smAwyCKbGPMUZKUC"
           - version     = 5
         } -> (known after apply)
-      ~ connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com" -> (known after apply)
+      ~ connection_string = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com" -> (known after apply)
       ~ current_state    = "healthy" -> (known after apply)
       ~ etag             = "Version: 5" -> (known after apply)
         id               = "ffffffff-aaaa-1414-eeee-00000000000"
@@ -979,7 +979,7 @@ clusters_list = {
         "region" = "us-east-1"
         "type" = "aws"
       }
-      "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+      "connection_string" = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
       "couchbase_server" = {
         "version" = "7.1.5"
       }
@@ -1032,7 +1032,7 @@ clusters_list = {
         "region" = "af-south-1"
         "type" = "aws"
       }
-      "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+      "connection_string" = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
       "couchbase_server" = {
         "version" = "7.2.2"
       }
@@ -1090,7 +1090,7 @@ new_cluster = {
     "region" = "us-east-1"
     "type" = "aws"
   }
-  "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+  "connection_string" = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
   "couchbase_server" = {
     "version" = "7.1.5"
   }
@@ -1172,7 +1172,7 @@ Terraform will perform the following actions:
           - region = "us-east-1" -> null
           - type   = "aws" -> null
         }
-      - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com" -> null
+      - connection_string = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com" -> null
       - couchbase_server = {
           - version = "7.1.5" -> null
         }
@@ -1232,7 +1232,7 @@ Changes to Outputs:
                   - region = "us-east-1"
                   - type   = "aws"
                 }
-              - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+              - connection_string = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
               - couchbase_server = {
                   - version = "7.1.5"
                 }
@@ -1285,7 +1285,7 @@ Changes to Outputs:
                   - region = "af-south-1"
                   - type   = "aws"
                 }
-              - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+              - connection_string = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
               - couchbase_server = {
                   - version = "7.2.2"
                 }
@@ -1343,7 +1343,7 @@ Changes to Outputs:
           - region = "us-east-1"
           - type   = "aws"
         }
-      - connection_string = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+      - connection_string = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
       - couchbase_server = {
           - version = "7.1.5"
         }

--- a/examples/getting_started/README.md
+++ b/examples/getting_started/README.md
@@ -171,6 +171,7 @@ Terraform will perform the following actions:
           + type   = "aws"
         }
       + configuration_type = (known after apply)
+      + connection_string  = (known after apply)
       + couchbase_server   = (known after apply)
       + current_state      = (known after apply)
       + description        = "My first test cluster for multiple services."
@@ -517,6 +518,7 @@ Changes to Outputs:
           + type   = "aws"
         }
       + configuration_type = (known after apply)
+      + connection_string  = (known after apply)
       + couchbase_server   = (known after apply)
       + current_state      = (known after apply)
       + description        = "My first test cluster for multiple services."
@@ -919,6 +921,7 @@ Terraform will perform the following actions:
           + type   = "aws"
         }
       + configuration_type = (known after apply)
+      + connection_string  = (known after apply)
       + couchbase_server   = (known after apply)
       + current_state      = (known after apply)
       + description        = "My first test cluster for multiple services."
@@ -1288,6 +1291,7 @@ Changes to Outputs:
           + type   = "aws"
         }
       + configuration_type = (known after apply)
+      + connection_string  = (known after apply)
       + couchbase_server   = (known after apply)
       + current_state      = (known after apply)
       + description        = "My first test cluster for multiple services."
@@ -1760,6 +1764,7 @@ cluster = {
     "type" = "aws"
   }
   "configuration_type" = "multiNode"
+  "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
   "couchbase_server" = {
     "version" = "7.2"
   }
@@ -2133,6 +2138,7 @@ cluster = {
     "type" = "aws"
   }
   "configuration_type" = "multiNode"
+  "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
   "couchbase_server" = {
     "version" = "7.2"
   }
@@ -2583,6 +2589,7 @@ Terraform will perform the following actions:
           - type   = "aws" -> null
         } -> null
       - configuration_type = "multiNode" -> null
+      - connection_string  = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com" -> null
       - couchbase_server   = {
           - version = "7.2" -> null
         } -> null
@@ -3026,6 +3033,7 @@ Changes to Outputs:
           - type   = "aws"
         }
       - configuration_type = "multiNode"
+      - connection_string  = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
       - couchbase_server   = {
           - version = "7.2"
         }

--- a/examples/getting_started/README.md
+++ b/examples/getting_started/README.md
@@ -1764,7 +1764,7 @@ cluster = {
     "type" = "aws"
   }
   "configuration_type" = "multiNode"
-  "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+  "connection_string" = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
   "couchbase_server" = {
     "version" = "7.2"
   }
@@ -2138,7 +2138,7 @@ cluster = {
     "type" = "aws"
   }
   "configuration_type" = "multiNode"
-  "connection_string" = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+  "connection_string" = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
   "couchbase_server" = {
     "version" = "7.2"
   }
@@ -2589,7 +2589,7 @@ Terraform will perform the following actions:
           - type   = "aws" -> null
         } -> null
       - configuration_type = "multiNode" -> null
-      - connection_string  = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com" -> null
+      - connection_string  = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com" -> null
       - couchbase_server   = {
           - version = "7.2" -> null
         } -> null
@@ -3033,7 +3033,7 @@ Changes to Outputs:
           - type   = "aws"
         }
       - configuration_type = "multiNode"
-      - connection_string  = "couchbases://cb.irxmynm6vekhe5.cloud.couchbase.com"
+      - connection_string  = "couchbases://cb.xxxxxxxxxxxxxx.cloud.couchbase.com"
       - couchbase_server   = {
           - version = "7.2"
         }

--- a/internal/api/cluster/cluster.go
+++ b/internal/api/cluster/cluster.go
@@ -85,6 +85,9 @@ type GetClusterResponse struct {
 	// AppServiceId is the ID of the linked app service.
 	AppServiceId *uuid.UUID `json:"appServiceId,omitempty"`
 
+	// ConnectionString specifies the Capella database endpoint for your client connection.
+	ConnectionString string `json:"connectionString"`
+
 	// CloudProvider is the cloud provider where the cluster will be hosted.
 	// To learn more, see:
 	// [AWS] https://docs.couchbase.com/cloud/reference/aws.html

--- a/internal/datasources/cluster_schema.go
+++ b/internal/datasources/cluster_schema.go
@@ -13,11 +13,12 @@ func ClusterSchema() schema.Schema {
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"id":              computedStringAttribute,
-						"organization_id": computedStringAttribute,
-						"project_id":      computedStringAttribute,
-						"name":            computedStringAttribute,
-						"description":     computedStringAttribute,
+						"id":                computedStringAttribute,
+						"organization_id":   computedStringAttribute,
+						"project_id":        computedStringAttribute,
+						"name":              computedStringAttribute,
+						"description":       computedStringAttribute,
+						"connection_string": computedStringAttribute,
 						"cloud_provider": schema.SingleNestedAttribute{
 							Computed: true,
 							Attributes: map[string]schema.Attribute{

--- a/internal/resources/acceptance_tests/cluster_acceptance_test.go
+++ b/internal/resources/acceptance_tests/cluster_acceptance_test.go
@@ -75,7 +75,7 @@ func TestAccClusterResourceWithOnlyReqFieldAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "support.timezone", "PT"),
 
 					//When the cluster is created for the first time, the ETag of the created cluster is 5
-					resource.TestCheckResourceAttr(resourceReference, "etag", "Version: 5"),
+					//resource.TestCheckResourceAttr(resourceReference, "etag", "Version: 5"),
 				),
 			},
 			//// ImportState testing

--- a/internal/resources/acceptance_tests/cluster_acceptance_test.go
+++ b/internal/resources/acceptance_tests/cluster_acceptance_test.go
@@ -75,7 +75,7 @@ func TestAccClusterResourceWithOnlyReqFieldAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "support.timezone", "PT"),
 
 					//When the cluster is created for the first time, the ETag of the created cluster is 5
-					//resource.TestCheckResourceAttr(resourceReference, "etag", "Version: 5"),
+					resource.TestCheckResourceAttr(resourceReference, "etag", "Version: 5"),
 				),
 			},
 			//// ImportState testing

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -781,6 +781,7 @@ func initializePendingClusterWithPlanAndId(plan providerschema.Cluster, id strin
 		plan.CouchbaseServer = types.ObjectNull(providerschema.CouchbaseServer{}.AttributeTypes())
 	}
 	plan.AppServiceId = types.StringNull()
+	plan.ConnectionString = types.StringNull()
 	plan.Audit = types.ObjectNull(providerschema.CouchbaseAuditData{}.AttributeTypes())
 	plan.Etag = types.StringNull()
 

--- a/internal/resources/cluster_schema.go
+++ b/internal/resources/cluster_schema.go
@@ -91,9 +91,10 @@ func ClusterSchema() schema.Schema {
 					"timezone": stringAttribute([]string{required}),
 				},
 			},
-			"current_state":  stringAttribute([]string{computed}),
-			"app_service_id": stringAttribute([]string{computed}),
-			"audit":          computedAuditAttribute(),
+			"current_state":     stringAttribute([]string{computed}),
+			"connection_string": stringAttribute([]string{computed}),
+			"app_service_id":    stringAttribute([]string{computed}),
+			"audit":             computedAuditAttribute(),
 			// if_match is only required during update call
 			"if_match": stringAttribute([]string{optional}),
 			"etag":     stringAttribute([]string{computed}),

--- a/internal/schema/cluster.go
+++ b/internal/schema/cluster.go
@@ -117,17 +117,22 @@ type Support struct {
 
 // Cluster defines the response as received from V4 Capella Public API when asked to create a new cluster.
 type Cluster struct {
+	// Availability zone type, either 'single' or 'multi'.
 	Availability *Availability `tfsdk:"availability"`
-	Support      *Support      `tfsdk:"support"`
+
+	// Support defines the support plan and timezone for this particular cluster.
+	Support *Support `tfsdk:"support"`
 
 	// CloudProvider The cloud provider where the cluster will be hosted.
 	// To learn more, see [Amazon Web Services](https://docs.couchbase.com/cloud/reference/aws.html).
-	CloudProvider  *CloudProvider `tfsdk:"cloud_provider"`
-	ProjectId      types.String   `tfsdk:"project_id"`
-	Id             types.String   `tfsdk:"id"`
-	OrganizationId types.String   `tfsdk:"organization_id"`
-	Audit          types.Object   `tfsdk:"audit"`
+	CloudProvider *CloudProvider `tfsdk:"cloud_provider"`
 
+	ProjectId      types.String `tfsdk:"project_id"`
+	Id             types.String `tfsdk:"id"`
+	OrganizationId types.String `tfsdk:"organization_id"`
+	Audit          types.Object `tfsdk:"audit"`
+
+	// CouchbaseServer is the version of the Couchbase Server to be installed in the cluster.
 	CouchbaseServer types.Object `tfsdk:"couchbase_server"`
 
 	// Description of the cluster (up to 1024 characters).
@@ -142,9 +147,12 @@ type Cluster struct {
 	// ConnectionString specifies the Capella database endpoint for your client connection.
 	ConnectionString types.String `tfsdk:"connection_string"`
 
+	// CurrentState tells the status of the cluster - if it's healthy or degraded.
 	CurrentState types.String `tfsdk:"current_state"`
-	Etag         types.String `tfsdk:"etag"`
-	IfMatch      types.String `tfsdk:"if_match"`
+
+	// Etag represents the version of the document
+	Etag    types.String `tfsdk:"etag"`
+	IfMatch types.String `tfsdk:"if_match"`
 
 	// ServiceGroups is the couchbase service groups to be run. At least one service group must contain the data service.
 	ServiceGroups []ServiceGroup `tfsdk:"service_groups"`

--- a/internal/schema/cluster.go
+++ b/internal/schema/cluster.go
@@ -138,6 +138,10 @@ type Cluster struct {
 
 	// AppServiceId is the ID of the linked app service.
 	AppServiceId types.String `tfsdk:"app_service_id"`
+
+	// ConnectionString specifies the Capella database endpoint for your client connection.
+	ConnectionString types.String `tfsdk:"connection_string"`
+
 	CurrentState types.String `tfsdk:"current_state"`
 	Etag         types.String `tfsdk:"etag"`
 	IfMatch      types.String `tfsdk:"if_match"`
@@ -186,9 +190,10 @@ func NewCluster(ctx context.Context, cluster *clusterapi.GetClusterResponse, org
 			Plan:     types.StringValue(string(cluster.Support.Plan)),
 			Timezone: types.StringValue(string(cluster.Support.Timezone)),
 		},
-		CurrentState: types.StringValue(string(cluster.CurrentState)),
-		Audit:        auditObject,
-		Etag:         types.StringValue(cluster.Etag),
+		ConnectionString: types.StringValue(cluster.ConnectionString),
+		CurrentState:     types.StringValue(string(cluster.CurrentState)),
+		Audit:            auditObject,
+		Etag:             types.StringValue(cluster.Etag),
 	}
 
 	if cluster.CouchbaseServer.Version != nil {
@@ -305,19 +310,20 @@ type Clusters struct {
 
 // ClusterData defines attributes for a single cluster when fetched from the V4 Capella Public API.
 type ClusterData struct {
-	Availability    *Availability    `tfsdk:"availability"`
-	Support         *Support         `tfsdk:"support"`
-	CouchbaseServer *CouchbaseServer `tfsdk:"couchbase_server"`
-	CloudProvider   *CloudProvider   `tfsdk:"cloud_provider"`
-	OrganizationId  types.String     `tfsdk:"organization_id"`
-	ProjectId       types.String     `tfsdk:"project_id"`
-	Id              types.String     `tfsdk:"id"`
-	Audit           types.Object     `tfsdk:"audit"`
-	Description     types.String     `tfsdk:"description"`
-	Name            types.String     `tfsdk:"name"`
-	AppServiceId    types.String     `tfsdk:"app_service_id"`
-	CurrentState    types.String     `tfsdk:"current_state"`
-	ServiceGroups   []ServiceGroup   `tfsdk:"service_groups"`
+	Availability     *Availability    `tfsdk:"availability"`
+	Support          *Support         `tfsdk:"support"`
+	CouchbaseServer  *CouchbaseServer `tfsdk:"couchbase_server"`
+	CloudProvider    *CloudProvider   `tfsdk:"cloud_provider"`
+	OrganizationId   types.String     `tfsdk:"organization_id"`
+	ProjectId        types.String     `tfsdk:"project_id"`
+	Id               types.String     `tfsdk:"id"`
+	Audit            types.Object     `tfsdk:"audit"`
+	Description      types.String     `tfsdk:"description"`
+	Name             types.String     `tfsdk:"name"`
+	AppServiceId     types.String     `tfsdk:"app_service_id"`
+	ConnectionString types.String     `tfsdk:"connection_string"`
+	CurrentState     types.String     `tfsdk:"current_state"`
+	ServiceGroups    []ServiceGroup   `tfsdk:"service_groups"`
 }
 
 // NewClusterData creates a new cluster data object.
@@ -340,8 +346,9 @@ func NewClusterData(cluster *clusterapi.GetClusterResponse, organizationId, proj
 			Plan:     types.StringValue(string(cluster.Support.Plan)),
 			Timezone: types.StringValue(string(cluster.Support.Timezone)),
 		},
-		CurrentState: types.StringValue(string(cluster.CurrentState)),
-		Audit:        auditObject,
+		ConnectionString: types.StringValue(cluster.ConnectionString),
+		CurrentState:     types.StringValue(string(cluster.CurrentState)),
+		Audit:            auditObject,
 	}
 
 	if cluster.CouchbaseServer.Version != nil {


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [CCBSE-2021](https://jira.issues.couchbase.com/browse/CCBSE-2021)

## Description

Adding `connectionString` to cluster response as per customer requirement.

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

**CREATE and GET -**

terraform plan-

```
terraform plan   
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/paulomee.de/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.couchbase-capella_clusters.existing_clusters: Reading...
data.couchbase-capella_clusters.existing_clusters: Read complete after 0s

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_cluster.new_cluster will be created
  + resource "couchbase-capella_cluster" "new_cluster" {
      + app_service_id    = (known after apply)
      + audit             = (known after apply)
      + availability      = {
          + type = "multi"
        }
      + cloud_provider    = {
          + cidr   = "10.4.0.0/23"
          + region = "us-east-1"
          + type   = "aws"
        }
      + connection_string = (known after apply)
      + couchbase_server  = (known after apply)
      + current_state     = (known after apply)
      + description       = "My first test cluster for multiple services."
      + etag              = (known after apply)
      + id                = (known after apply)
      + name              = "New Terraform Cluster"
      + organization_id   = "ffffffff-aaaa-1414-eeee-0000000000"
      + project_id        = "ffffffff-aaaa-1414-eeee-0000000000"
      + service_groups    = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      + support           = {
          + plan     = "developer pro"
          + timezone = "PT"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + cluster_id    = (known after apply)
  + clusters_list = {
      + data            = null
      + organization_id = "ffffffff-aaaa-1414-eeee-0000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-0000000000"
    }
  + new_cluster   = {
      + app_service_id    = (known after apply)
      + audit             = (known after apply)
      + availability      = {
          + type = "multi"
        }
      + cloud_provider    = {
          + cidr   = "10.4.0.0/23"
          + region = "us-east-1"
          + type   = "aws"
        }
      + connection_string = (known after apply)
      + couchbase_server  = (known after apply)
      + current_state     = (known after apply)
      + description       = "My first test cluster for multiple services."
      + etag              = (known after apply)
      + id                = (known after apply)
      + if_match          = null
      + name              = "New Terraform Cluster"
      + organization_id   = "ffffffff-aaaa-1414-eeee-0000000000"
      + project_id        = "ffffffff-aaaa-1414-eeee-0000000000"
      + service_groups    = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      + support           = {
          + plan     = "developer pro"
          + timezone = "PT"
        }
    }

```

terraform apply-

```
terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/paulomee.de/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.couchbase-capella_clusters.existing_clusters: Reading...
data.couchbase-capella_clusters.existing_clusters: Read complete after 0s

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_cluster.new_cluster will be created
  + resource "couchbase-capella_cluster" "new_cluster" {
      + app_service_id    = (known after apply)
      + audit             = (known after apply)
      + availability      = {
          + type = "multi"
        }
      + cloud_provider    = {
          + cidr   = "10.4.0.0/23"
          + region = "us-east-1"
          + type   = "aws"
        }
      + connection_string = (known after apply)
      + couchbase_server  = (known after apply)
      + current_state     = (known after apply)
      + description       = "My first test cluster for multiple services."
      + etag              = (known after apply)
      + id                = (known after apply)
      + name              = "New Terraform Cluster"
      + organization_id   = "ffffffff-aaaa-1414-eeee-00000000000"
      + project_id        = "ffffffff-aaaa-1414-eeee-00000000000"
      + service_groups    = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      + support           = {
          + plan     = "developer pro"
          + timezone = "PT"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + cluster_id    = (known after apply)
  + clusters_list = {
      + data            = null
      + organization_id = "ffffffff-aaaa-1414-eeee-00000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-00000000000"
    }
  + new_cluster   = {
      + app_service_id    = (known after apply)
      + audit             = (known after apply)
      + availability      = {
          + type = "multi"
        }
      + cloud_provider    = {
          + cidr   = "10.4.0.0/23"
          + region = "us-east-1"
          + type   = "aws"
        }
      + connection_string = (known after apply)
      + couchbase_server  = (known after apply)
      + current_state     = (known after apply)
      + description       = "My first test cluster for multiple services."
      + etag              = (known after apply)
      + id                = (known after apply)
      + if_match          = null
      + name              = "New Terraform Cluster"
      + organization_id   = "ffffffff-aaaa-1414-eeee-00000000000"
      + project_id        = "ffffffff-aaaa-1414-eeee-00000000000"
      + service_groups    = [
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      + support           = {
          + plan     = "developer pro"
          + timezone = "PT"
        }
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cluster.new_cluster: Creating...
couchbase-capella_cluster.new_cluster: Still creating... [10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [1m50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m10s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m20s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m30s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m40s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [2m50s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [3m0s elapsed]
couchbase-capella_cluster.new_cluster: Still creating... [3m10s elapsed]
couchbase-capella_cluster.new_cluster: Creation complete after 3m10s [id=ffffffff-aaaa-1414-eeee-00000000000]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

cluster_id = "ffffffff-aaaa-1414-eeee-00000000000"
clusters_list = {
  "data" = tolist(null) /* of object */
  "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
}
new_cluster = {
  "app_service_id" = tostring(null)
  "audit" = {
    "created_at" = "2024-08-26 23:12:55.741799846 +0000 UTC"
    "created_by" = "ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
    "modified_at" = "2024-08-26 23:16:05.875521753 +0000 UTC"
    "modified_by" = "apikey-ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
    "version" = 4
  }
  "availability" = {
    "type" = "multi"
  }
  "cloud_provider" = {
    "cidr" = "10.4.0.0/23"
    "region" = "us-east-1"
    "type" = "aws"
  }
  "connection_string" = "cb.h6gsykjqynh7npf.aws-guardians.nonprod-project-avengers.com"
  "couchbase_server" = {
    "version" = "7.6"
  }
  "current_state" = "healthy"
  "description" = "My first test cluster for multiple services."
  "etag" = "Version: 4"
  "id" = "ffffffff-aaaa-1414-eeee-00000000000"
  "if_match" = tostring(null)
  "name" = "New Terraform Cluster"
  "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
  "service_groups" = toset([
    {
      "node" = {
        "compute" = {
          "cpu" = 4
          "ram" = 16
        }
        "disk" = {
          "autoexpansion" = tobool(null)
          "iops" = 5000
          "storage" = 50
          "type" = "io2"
        }
      }
      "num_of_nodes" = 3
      "services" = toset([
        "data",
        "index",
        "query",
      ])
    },
  ])
  "support" = {
    "plan" = "developer pro"
    "timezone" = "PT"
  }
}

```

**UPDATE-**
```
terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/paulomee.de/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.couchbase-capella_clusters.existing_clusters: Reading...
couchbase-capella_cluster.new_cluster: Refreshing state... [id=ffffffff-aaaa-1414-eeee-00000000000]
data.couchbase-capella_clusters.existing_clusters: Read complete after 0s

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have affected this plan:

  # couchbase-capella_cluster.new_cluster has changed
  ~ resource "couchbase-capella_cluster" "new_cluster" {
      ~ audit             = {
          ~ modified_at = "2024-08-26 23:16:05.875521753 +0000 UTC" -> "2024-08-26 23:16:06.753801629 +0000 UTC"
          ~ modified_by = "apikey-ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB" -> "apikey-apikey-ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
          ~ version     = 4 -> 5
            # (2 unchanged attributes hidden)
        }
      ~ etag              = "Version: 4" -> "Version: 5"
        id                = "ffffffff-aaaa-1414-eeee-00000000000"
        name              = "New Terraform Cluster"
        # (10 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # couchbase-capella_cluster.new_cluster will be updated in-place
  ~ resource "couchbase-capella_cluster" "new_cluster" {
      + app_service_id    = (known after apply)
      ~ audit             = {
          ~ created_at  = "2024-08-26 23:12:55.741799846 +0000 UTC" -> (known after apply)
          ~ created_by  = "ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB" -> (known after apply)
          ~ modified_at = "2024-08-26 23:16:06.753801629 +0000 UTC" -> (known after apply)
          ~ modified_by = "apikey-apikey-ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB" -> (known after apply)
          ~ version     = 5 -> (known after apply)
        } -> (known after apply)
      ~ connection_string = "cb.h6gsykjqynh7npf.aws-guardians.nonprod-project-avengers.com" -> (known after apply)
      ~ current_state     = "healthy" -> (known after apply)
      ~ etag              = "Version: 5" -> (known after apply)
        id                = "ffffffff-aaaa-1414-eeee-00000000000"
      ~ name              = "New Terraform Cluster" -> "New Terraform Cluster 2"
      ~ service_groups    = [
          - {
              - node         = {
                  - compute = {
                      - cpu = 4 -> null
                      - ram = 16 -> null
                    } -> null
                  - disk    = {
                      - iops    = 5000 -> null
                      - storage = 50 -> null
                      - type    = "io2" -> null
                    } -> null
                } -> null
              - num_of_nodes = 3 -> null
              - services     = [
                  - "data",
                  - "index",
                  - "query",
                ] -> null
            },
          + {
              + node         = {
                  + compute = {
                      + cpu = 4
                      + ram = 16
                    }
                  + disk    = {
                      + autoexpansion = (known after apply)
                      + iops          = 5000
                      + storage       = 50
                      + type          = "io2"
                    }
                }
              + num_of_nodes = 3
              + services     = [
                  + "data",
                  + "index",
                  + "query",
                ]
            },
        ]
      ~ support           = {
          ~ plan     = "developer pro" -> "enterprise"
          ~ timezone = "PT" -> "ET"
        }
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ clusters_list = {
      ~ data            = null -> [
          + {
              + app_service_id    = null
              + audit             = {
                  + created_at  = "2024-08-26 23:12:55.741799846 +0000 UTC"
                  + created_by  = "ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
                  + modified_at = "2024-08-26 23:16:06.753801629 +0000 UTC"
                  + modified_by = "apikey-apikey-ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
                  + version     = 5
                }
              + availability      = {
                  + type = "multi"
                }
              + cloud_provider    = {
                  + cidr   = "10.4.0.0/23"
                  + region = "us-east-1"
                  + type   = "aws"
                }
              + connection_string = "cb.h6gsykjqynh7npf.aws-guardians.nonprod-project-avengers.com"
              + couchbase_server  = {
                  + version = "7.6.2"
                }
              + current_state     = "healthy"
              + description       = "My first test cluster for multiple services."
              + id                = "ffffffff-aaaa-1414-eeee-00000000000"
              + name              = "New Terraform Cluster"
              + organization_id   = "ffffffff-aaaa-1414-eeee-00000000000"
              + project_id        = "ffffffff-aaaa-1414-eeee-00000000000"
              + service_groups    = [
                  + {
                      + node         = {
                          + compute = {
                              + cpu = 4
                              + ram = 16
                            }
                          + disk    = {
                              + autoexpansion = null
                              + iops          = 5000
                              + storage       = 50
                              + type          = "io2"
                            }
                        }
                      + num_of_nodes = 3
                      + services     = [
                          + "index",
                          + "data",
                          + "query",
                        ]
                    },
                ]
              + support           = {
                  + plan     = "developer pro"
                  + timezone = "PT"
                }
            },
        ]
        # (2 unchanged attributes hidden)
    }
  ~ new_cluster   = {
      + app_service_id    = (known after apply)
      ~ audit             = {
          - created_at  = "2024-08-26 23:12:55.741799846 +0000 UTC"
          - created_by  = "ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
          - modified_at = "2024-08-26 23:16:05.875521753 +0000 UTC"
          - modified_by = "apikey-ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
          - version     = 4
        } -> (known after apply)
      ~ connection_string = "cb.h6gsykjqynh7npf.aws-guardians.nonprod-project-avengers.com" -> (known after apply)
      ~ current_state     = "healthy" -> (known after apply)
      ~ etag              = "Version: 4" -> (known after apply)
        id                = "ffffffff-aaaa-1414-eeee-00000000000"
      ~ name              = "New Terraform Cluster" -> "New Terraform Cluster 2"
      ~ service_groups    = [
          ~ {
              ~ node         = {
                  ~ disk    = {
                      + autoexpansion = (known after apply)
                        # (3 unchanged attributes hidden)
                    }
                    # (1 unchanged attribute hidden)
                }
                # (2 unchanged attributes hidden)
            },
        ]
      ~ support           = {
          ~ plan     = "developer pro" -> "enterprise"
          ~ timezone = "PT" -> "ET"
        }
        # (7 unchanged attributes hidden)
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cluster.new_cluster: Modifying... [id=ffffffff-aaaa-1414-eeee-00000000000]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 10s elapsed]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 20s elapsed]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 30s elapsed]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 40s elapsed]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 50s elapsed]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m0s elapsed]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m10s elapsed]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m20s elapsed]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m30s elapsed]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m40s elapsed]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m50s elapsed]
couchbase-capella_cluster.new_cluster: Still modifying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m0s elapsed]
couchbase-capella_cluster.new_cluster: Modifications complete after 2m2s [id=ffffffff-aaaa-1414-eeee-00000000000]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

cluster_id = "ffffffff-aaaa-1414-eeee-00000000000"
clusters_list = {
  "data" = tolist([
    {
      "app_service_id" = tostring(null)
      "audit" = {
        "created_at" = "2024-08-26 23:12:55.741799846 +0000 UTC"
        "created_by" = "ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
        "modified_at" = "2024-08-26 23:16:06.753801629 +0000 UTC"
        "modified_by" = "apikey-apikey-ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
        "version" = 5
      }
      "availability" = {
        "type" = "multi"
      }
      "cloud_provider" = {
        "cidr" = "10.4.0.0/23"
        "region" = "us-east-1"
        "type" = "aws"
      }
      "connection_string" = "cb.h6gsykjqynh7npf.aws-guardians.nonprod-project-avengers.com"
      "couchbase_server" = {
        "version" = "7.6.2"
      }
      "current_state" = "healthy"
      "description" = "My first test cluster for multiple services."
      "id" = "ffffffff-aaaa-1414-eeee-00000000000"
      "name" = "New Terraform Cluster"
      "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
      "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
      "service_groups" = tolist([
        {
          "node" = {
            "compute" = {
              "cpu" = 4
              "ram" = 16
            }
            "disk" = {
              "autoexpansion" = tobool(null)
              "iops" = 5000
              "storage" = 50
              "type" = "io2"
            }
          }
          "num_of_nodes" = 3
          "services" = tolist([
            "index",
            "data",
            "query",
          ])
        },
      ])
      "support" = {
        "plan" = "developer pro"
        "timezone" = "PT"
      }
    },
  ])
  "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
}
new_cluster = {
  "app_service_id" = tostring(null)
  "audit" = {
    "created_at" = "2024-08-26 23:12:55.741799846 +0000 UTC"
    "created_by" = "ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
    "modified_at" = "2024-08-26 23:28:24.412154054 +0000 UTC"
    "modified_by" = "apikey-apikey-ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
    "version" = 10
  }
  "availability" = {
    "type" = "multi"
  }
  "cloud_provider" = {
    "cidr" = "10.4.0.0/23"
    "region" = "us-east-1"
    "type" = "aws"
  }
  "connection_string" = "cb.h6gsykjqynh7npf.aws-guardians.nonprod-project-avengers.com"
  "couchbase_server" = {
    "version" = "7.6"
  }
  "current_state" = "healthy"
  "description" = "My first test cluster for multiple services."
  "etag" = "Version: 10"
  "id" = "ffffffff-aaaa-1414-eeee-00000000000"
  "if_match" = tostring(null)
  "name" = "New Terraform Cluster 2"
  "organization_id" = "ffffffff-aaaa-1414-eeee-00000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-00000000000"
  "service_groups" = toset([
    {
      "node" = {
        "compute" = {
          "cpu" = 4
          "ram" = 16
        }
        "disk" = {
          "autoexpansion" = tobool(null)
          "iops" = 5000
          "storage" = 50
          "type" = "io2"
        }
      }
      "num_of_nodes" = 3
      "services" = toset([
        "data",
        "index",
        "query",
      ])
    },
  ])
  "support" = {
    "plan" = "enterprise"
    "timezone" = "ET"
  }
}

```

<img width="1728" alt="Screen Shot 2024-08-26 at 4 29 41 PM" src="https://github.com/user-attachments/assets/7ca70f7c-6f60-430e-958c-9d745ad81e2a">


**DESTROY-**

```
terraform destroy
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/paulomee.de/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.couchbase-capella_clusters.existing_clusters: Reading...
couchbase-capella_cluster.new_cluster: Refreshing state... [id=ffffffff-aaaa-1414-eeee-00000000000]
data.couchbase-capella_clusters.existing_clusters: Read complete after 0s

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # couchbase-capella_cluster.new_cluster will be destroyed
  - resource "couchbase-capella_cluster" "new_cluster" {
      - audit             = {
          - created_at  = "2024-08-26 23:12:55.741799846 +0000 UTC" -> null
          - created_by  = "ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB" -> null
          - modified_at = "2024-08-26 23:28:24.412154054 +0000 UTC" -> null
          - modified_by = "apikey-apikey-ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB" -> null
          - version     = 10 -> null
        } -> null
      - availability      = {
          - type = "multi" -> null
        } -> null
      - cloud_provider    = {
          - cidr   = "10.4.0.0/23" -> null
          - region = "us-east-1" -> null
          - type   = "aws" -> null
        } -> null
      - connection_string = "cb.h6gsykjqynh7npf.aws-guardians.nonprod-project-avengers.com" -> null
      - couchbase_server  = {
          - version = "7.6" -> null
        } -> null
      - current_state     = "healthy" -> null
      - description       = "My first test cluster for multiple services." -> null
      - etag              = "Version: 10" -> null
      - id                = "ffffffff-aaaa-1414-eeee-00000000000" -> null
      - name              = "New Terraform Cluster 2" -> null
      - organization_id   = "ffffffff-aaaa-1414-eeee-00000000000" -> null
      - project_id        = "ffffffff-aaaa-1414-eeee-00000000000" -> null
      - service_groups    = [
          - {
              - node         = {
                  - compute = {
                      - cpu = 4 -> null
                      - ram = 16 -> null
                    } -> null
                  - disk    = {
                      - iops    = 5000 -> null
                      - storage = 50 -> null
                      - type    = "io2" -> null
                    } -> null
                } -> null
              - num_of_nodes = 3 -> null
              - services     = [
                  - "data",
                  - "index",
                  - "query",
                ] -> null
            },
        ] -> null
      - support           = {
          - plan     = "enterprise" -> null
          - timezone = "ET" -> null
        } -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - cluster_id    = "ffffffff-aaaa-1414-eeee-00000000000" -> null
  - clusters_list = {
      - data            = [
          - {
              - app_service_id    = null
              - audit             = {
                  - created_at  = "2024-08-26 23:12:55.741799846 +0000 UTC"
                  - created_by  = "ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
                  - modified_at = "2024-08-26 23:28:24.412154054 +0000 UTC"
                  - modified_by = "apikey-apikey-ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
                  - version     = 10
                }
              - availability      = {
                  - type = "multi"
                }
              - cloud_provider    = {
                  - cidr   = "10.4.0.0/23"
                  - region = "us-east-1"
                  - type   = "aws"
                }
              - connection_string = "cb.h6gsykjqynh7npf.aws-guardians.nonprod-project-avengers.com"
              - couchbase_server  = {
                  - version = "7.6.2"
                }
              - current_state     = "healthy"
              - description       = "My first test cluster for multiple services."
              - id                = "ffffffff-aaaa-1414-eeee-00000000000"
              - name              = "New Terraform Cluster 2"
              - organization_id   = "ffffffff-aaaa-1414-eeee-00000000000"
              - project_id        = "ffffffff-aaaa-1414-eeee-00000000000"
              - service_groups    = [
                  - {
                      - node         = {
                          - compute = {
                              - cpu = 4
                              - ram = 16
                            }
                          - disk    = {
                              - autoexpansion = null
                              - iops          = 5000
                              - storage       = 50
                              - type          = "io2"
                            }
                        }
                      - num_of_nodes = 3
                      - services     = [
                          - "index",
                          - "data",
                          - "query",
                        ]
                    },
                ]
              - support           = {
                  - plan     = "enterprise"
                  - timezone = "ET"
                }
            },
        ]
      - organization_id = "ffffffff-aaaa-1414-eeee-00000000000"
      - project_id      = "ffffffff-aaaa-1414-eeee-00000000000"
    } -> null
  - new_cluster   = {
      - app_service_id    = null
      - audit             = {
          - created_at  = "2024-08-26 23:12:55.741799846 +0000 UTC"
          - created_by  = "ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
          - modified_at = "2024-08-26 23:28:24.412154054 +0000 UTC"
          - modified_by = "apikey-apikey-ZJYLruoLZdi37mJv6mB5PlGFmWE2hTWB"
          - version     = 10
        }
      - availability      = {
          - type = "multi"
        }
      - cloud_provider    = {
          - cidr   = "10.4.0.0/23"
          - region = "us-east-1"
          - type   = "aws"
        }
      - connection_string = "cb.h6gsykjqynh7npf.aws-guardians.nonprod-project-avengers.com"
      - couchbase_server  = {
          - version = "7.6"
        }
      - current_state     = "healthy"
      - description       = "My first test cluster for multiple services."
      - etag              = "Version: 10"
      - id                = "ffffffff-aaaa-1414-eeee-00000000000"
      - if_match          = null
      - name              = "New Terraform Cluster 2"
      - organization_id   = "ffffffff-aaaa-1414-eeee-00000000000"
      - project_id        = "ffffffff-aaaa-1414-eeee-00000000000"
      - service_groups    = [
          - {
              - node         = {
                  - compute = {
                      - cpu = 4
                      - ram = 16
                    }
                  - disk    = {
                      - autoexpansion = null
                      - iops          = 5000
                      - storage       = 50
                      - type          = "io2"
                    }
                }
              - num_of_nodes = 3
              - services     = [
                  - "data",
                  - "index",
                  - "query",
                ]
            },
        ]
      - support           = {
          - plan     = "enterprise"
          - timezone = "ET"
        }
    } -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

couchbase-capella_cluster.new_cluster: Destroying... [id=ffffffff-aaaa-1414-eeee-00000000000]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 10s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 20s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 30s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 40s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 50s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m0s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m10s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m20s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m30s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m40s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 1m50s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m0s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m10s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m20s elapsed]
couchbase-capella_cluster.new_cluster: Still destroying... [id=ffffffff-aaaa-1414-eeee-00000000000, 2m30s elapsed]
couchbase-capella_cluster.new_cluster: Destruction complete after 2m37s

Destroy complete! Resources: 1 destroyed.


```

<img width="1727" alt="Screen Shot 2024-08-26 at 4 34 55 PM" src="https://github.com/user-attachments/assets/41e861b7-895e-46af-87b3-58425e4bcda7">


</details>

## Required Checklist:

- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if required)
- [x] I have run make fmt and formatted my code
- [x] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments