### PR TITLE
feat: Allows setting the provider host and authorisation_token via CAPELLA prefixed environment variables

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,36 +21,15 @@ This API key is then used for authenticating the Terraform Provider against Couc
 
 
 **IMPORTANT**  
-Although in examples below, the API key secret is specified as a environmental variable and hardcoded in a config file, it is recommend that the API secret credentials be stored in a remote secrets manager such as Hashicorp Vault or AWS Secrets Manager that the Terraform Provider can then retrieve and use for authentication.
+Although in examples below, the API key secret is specified as an environmental variable and hardcoded in a config file, it is recommended that the API secret credentials be stored in a remote secrets manager such as Hashicorp Vault or AWS Secrets Manager that the Terraform Provider can then retrieve and use for authentication.
 
 
 ### Terraform Environment Variables
 
-Environment variables can be set by terraform by creating and adding terraform.template.tfvars
-```terraform
-auth_token = "<v4-api-key-secret>"
-organization_id = "<replace with organization id>"
-```
+The provider configuration block accepts the following arguments. In most cases it is recommended to set them via the indicated environment variables in order to keep credential information out of the configuration.
 
-A variables.tf should also be added to define the variables for terraform.
-```terraform
-variable "organization_id" {
-  description = "Capella Organization ID"
-}
-
-variable "auth_token" {
-  description = "Authentication API Key"
-}
-```
-
-Set the environment variables by using the following notation:
-```terraform
-resource "couchbase-capella_project" "example" {
-  organization_id = var.organization_id
-  name = var.project_name
-  description = "A Capella Project that will host many Capella clusters."
-}
-```
+* `host` - Allows you to specify the host for the capella API. This can be useful if you are behind a reverse proxy. May be set vai the `CAPELLA_HOST` environment variable. If not provided will default to "https://cloudapi.cloud.couchbase.com"
+* `authentication_token` - A valid [V4 REST API Key](https://docs.couchbase.com/cloud/management-api-guide/management-api-start.html#understand-management-api-keys) for authenticating with the Couchbase Capella API. May be set via the `CAPELLA_AUTH_TOKEN` environment variable.
 
 ## Create and manage resources using terraform
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
@@ -59,7 +60,7 @@ func (p *capellaProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 				Description: "Capella Public API HTTPS Host URL",
 			},
 			capellaAuthenticationTokenField: schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
 				Description: "Capella API Token that serves as an authentication mechanism.",
 			},
@@ -82,9 +83,18 @@ func (p *capellaProvider) Configure(ctx context.Context, req provider.ConfigureR
 	// If practitioner provided a configuration value for any of the
 	// attributes, it must be a known value.
 
-	// if the host URL is not provided, connect to the production Capella API host url by default.
+	// if the host URL is not provided, check for an ENV_VAR, otherwise connect to the production Capella API host url by default.
 	if config.Host.IsNull() {
-		config.Host = types.StringValue(defaultAPIHostURL)
+		envHost, exists := os.LookupEnv("CAPELLA_HOST")
+		if exists {
+			config.Host = types.StringValue(envHost)
+		} else {
+			config.Host = types.StringValue(defaultAPIHostURL)
+		}
+	}
+
+	if config.AuthenticationToken.IsNull() {
+		config.AuthenticationToken = types.StringValue(os.Getenv("CAPELLA_AUTHENTICATION_TOKEN"))
 	}
 
 	if config.AuthenticationToken.IsUnknown() {
@@ -122,7 +132,7 @@ func (p *capellaProvider) Configure(ctx context.Context, req provider.ConfigureR
 			path.Root(capellaAuthenticationTokenField),
 			"Missing Capella Authentication Token",
 			"The provider cannot create the Capella API client as there is a missing or empty value for the capella authentication token. "+
-				"Set the password value in the configuration or use the TF_VAR_auth_token environment variable. "+
+				"Set the password value in the configuration or use the CAPELLA_AUTHENTICATION_TOKEN environment variable. "+
 				"If either is already set, ensure the value is not empty.",
 		)
 	}

--- a/internal/schema/cluster.go
+++ b/internal/schema/cluster.go
@@ -327,21 +327,21 @@ type Clusters struct {
 
 // ClusterData defines attributes for a single cluster when fetched from the V4 Capella Public API.
 type ClusterData struct {
-	Availability     *Availability    `tfsdk:"availability"`
-	Support          *Support         `tfsdk:"support"`
-	CouchbaseServer  *CouchbaseServer `tfsdk:"couchbase_server"`
-	CloudProvider    *CloudProvider   `tfsdk:"cloud_provider"`
-	OrganizationId   types.String     `tfsdk:"organization_id"`
-	ProjectId        types.String     `tfsdk:"project_id"`
-	Id               types.String     `tfsdk:"id"`
-	Audit            types.Object     `tfsdk:"audit"`
-	Description      types.String     `tfsdk:"description"`
+	Availability               *Availability    `tfsdk:"availability"`
+	Support                    *Support         `tfsdk:"support"`
+	CouchbaseServer            *CouchbaseServer `tfsdk:"couchbase_server"`
+	CloudProvider              *CloudProvider   `tfsdk:"cloud_provider"`
+	OrganizationId             types.String     `tfsdk:"organization_id"`
+	ProjectId                  types.String     `tfsdk:"project_id"`
+	Id                         types.String     `tfsdk:"id"`
+	Audit                      types.Object     `tfsdk:"audit"`
+	Description                types.String     `tfsdk:"description"`
 	EnablePrivateDNSResolution types.Bool       `tfsdk:"enable_private_dns_resolution"`
-	Name             types.String     `tfsdk:"name"`
-	AppServiceId     types.String     `tfsdk:"app_service_id"`
-	ConnectionString types.String     `tfsdk:"connection_string"`
-	CurrentState     types.String     `tfsdk:"current_state"`
-	ServiceGroups    []ServiceGroup   `tfsdk:"service_groups"`
+	Name                       types.String     `tfsdk:"name"`
+	AppServiceId               types.String     `tfsdk:"app_service_id"`
+	ConnectionString           types.String     `tfsdk:"connection_string"`
+	CurrentState               types.String     `tfsdk:"current_state"`
+	ServiceGroups              []ServiceGroup   `tfsdk:"service_groups"`
 }
 
 // NewClusterData creates a new cluster data object.


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-XXXXX
* Resolves #238 

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
<!-- What does this change do? Why is it needed? -->
Updates the provider to allow setting of the `host` and `authorisation_token` as environment variables prefixed with `CAPELLA_` and removes `authorisation_token` as a required attribute in the configuration block as it can now be provided from an environment variable

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [X] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

**Example terraform code**
```hcl
terraform {
  required_providers {
    couchbase-capella = {
      source = "couchbasecloud/couchbase-capella"
    }
  }
}

data "couchbase-capella_projects" "this" {
  organization_id = "e5456751-XXXXXXXXXXXXXX-aecb859d7db0"
}

output "clusters_list" {
  value = "Number of current projects: ${length(data.couchbase-capella_projects.this.data)}"
}
```

**Execution**
```bash
$ export CAPELLA_AUTHENTICATION_TOKEN=UTZFcXXXXXXXXXXXXXXXXXXXXXXXGV0WQ==
$ terraform apply --auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in C:\Users\CDoyle\go\bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.couchbase-capella_projects.this: Reading...
data.couchbase-capella_projects.this: Read complete after 0s

Changes to Outputs:
  + clusters_list = "Number of current projects: 1"

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

clusters_list = "Number of current projects: 1"
```

Without using a provider block in the terraform code and setting only the `CAPELLA_AUTHORISATION_TOKEN` the provider still successfully interacts with the API and retrieves project details.
</details>

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code
- [X] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments

The make fmt has formatted the `internal/schema/cluster.go` There is no functional change here other than the go formatter passing the spaces.