### PR TITLE
AV-90385 Azure cluster - ultra and premium chagNes

### DIFF
--- a/examples/cluster/azure/create_cluster.tf
+++ b/examples/cluster/azure/create_cluster.tf
@@ -24,7 +24,9 @@ resource "couchbase-capella_cluster" "new_cluster" {
           ram = var.compute.ram
         }
         disk = {
-          type          = var.disk.type
+          storage = var.disk.storage
+          type      = var.disk.type
+          iops      = var.disk.iops
           autoexpansion = var.disk.autoexpansion
         }
       }

--- a/examples/cluster/azure/variables.tf
+++ b/examples/cluster/azure/variables.tf
@@ -45,7 +45,7 @@ variable "disk" {
   description = "All nodes' disk configuration"
 
   type = object({
-    size          = optional(number)
+    storage          = optional(number)
     type          = string
     iops          = optional(number)
     autoexpansion = optional(bool)

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -210,6 +210,16 @@ func (c *Cluster) Create(ctx context.Context, req resource.CreateRequest, resp *
 		if clusterapi.AreEqual(plan.ServiceGroups[i].Services, serviceGroup.Services) {
 			refreshedState.ServiceGroups[i].Services = plan.ServiceGroups[i].Services
 		}
+
+		// This is for the case when for Azure clusters - Premium disk types, if the user provides the storage and iops values (these values are ignored), then put the value provided in state file,
+		// as otherwise there will be a type mismatch with the actual value - i.e. the default values for premium disks.
+		if refreshedState.CloudProvider.Type == types.StringValue("Azure") {
+			if refreshedState.ServiceGroups[i].Node.Disk.Type != types.StringValue("Ultra") {
+				refreshedState.ServiceGroups[i].Node.Disk.Storage = plan.ServiceGroups[i].Node.Disk.Storage
+				refreshedState.ServiceGroups[i].Node.Disk.IOPS = plan.ServiceGroups[i].Node.Disk.IOPS
+			}
+		}
+
 	}
 
 	// Set state to fully populated data
@@ -423,6 +433,16 @@ func (c *Cluster) Update(ctx context.Context, req resource.UpdateRequest, resp *
 		if clusterapi.AreEqual(plan.ServiceGroups[i].Services, serviceGroup.Services) {
 			currentState.ServiceGroups[i].Services = plan.ServiceGroups[i].Services
 		}
+
+		// for Azure clusters - Premium disk types, if the user provides the storage and iops values (these values are ignored), then put the value provided in state file,
+		// as otherwise there will be a type mismatch with the actual value - i.e. the default values for premium disks.
+		if currentState.CloudProvider.Type == types.StringValue("Azure") {
+			if currentState.ServiceGroups[i].Node.Disk.Type != types.StringValue("Ultra") {
+				currentState.ServiceGroups[i].Node.Disk.Storage = plan.ServiceGroups[i].Node.Disk.Storage
+				currentState.ServiceGroups[i].Node.Disk.IOPS = plan.ServiceGroups[i].Node.Disk.IOPS
+			}
+		}
+
 	}
 
 	// Set state to fully populated data
@@ -655,14 +675,17 @@ func (c *Cluster) morphToApiServiceGroups(plan providerschema.Cluster) ([]cluste
 				Type: clusterapi.DiskAzureType(serviceGroup.Node.Disk.Type.ValueString()),
 			}
 
-			if serviceGroup.Node != nil && !serviceGroup.Node.Disk.Storage.IsNull() && !serviceGroup.Node.Disk.Storage.IsUnknown() {
-				storage := int(serviceGroup.Node.Disk.Storage.ValueInt64())
-				diskAzure.Storage = &storage
-			}
+			// only allow setting storage and iops values for Ultra type disks, not for Premium type disks
+			if diskAzure.Type == "Ultra" {
+				if serviceGroup.Node != nil && !serviceGroup.Node.Disk.Storage.IsNull() && !serviceGroup.Node.Disk.Storage.IsUnknown() {
+					storage := int(serviceGroup.Node.Disk.Storage.ValueInt64())
+					diskAzure.Storage = &storage
+				}
 
-			if serviceGroup.Node != nil && !serviceGroup.Node.Disk.IOPS.IsNull() && !serviceGroup.Node.Disk.Storage.IsUnknown() {
-				iops := int(serviceGroup.Node.Disk.IOPS.ValueInt64())
-				diskAzure.Iops = &iops
+				if serviceGroup.Node != nil && !serviceGroup.Node.Disk.IOPS.IsNull() && !serviceGroup.Node.Disk.Storage.IsUnknown() {
+					iops := int(serviceGroup.Node.Disk.IOPS.ValueInt64())
+					diskAzure.Iops = &iops
+				}
 			}
 
 			if serviceGroup.Node != nil && !serviceGroup.Node.Disk.Autoexpansion.IsNull() {
@@ -673,6 +696,15 @@ func (c *Cluster) morphToApiServiceGroups(plan providerschema.Cluster) ([]cluste
 			if err := node.FromDiskAzure(diskAzure); err != nil {
 				return nil, fmt.Errorf("%s: %w", errors.ErrConvertingServiceGroups, err)
 			}
+
+			//fmt.Printf("************************PAULOMEE Create/Update DISKAzure  %#v \n", diskAzure)
+			//b, _ := json.Marshal(diskAzure)
+			//fmt.Print(string(b))
+			//
+			//fmt.Printf("************************PAULOMEE Create/Update node  %#v \n", node)
+			//b, _ = json.Marshal(node)
+			//fmt.Print(string(b))
+
 			newServiceGroup.Node.Disk = node.Disk
 
 		case string(clusterapi.Gcp):

--- a/internal/resources/cluster_schema.go
+++ b/internal/resources/cluster_schema.go
@@ -60,7 +60,7 @@ func ClusterSchema() schema.Schema {
 								},
 								"disk": schema.SingleNestedAttribute{
 									Description: "The 'storage' and 'IOPS' fields are required for AWS. " +
-										"For Azure, only the 'disktype' field is required, and for Ultra, you can provide all three fields. " +
+										"For Azure, only the 'disktype' field is required, and for Ultra disk type, you can provide all 3 - storage, iops and autoexpansion fields. For Premium type, you can only provide the autoexpansion field, others can't be set." +
 										"In the case of GCP, only 'pd ssd' disk type is available, and you cannot set the 'IOPS' field.",
 									Required: true,
 									Attributes: map[string]schema.Attribute{


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-90385

## Description

1. After this change - https://github.com/couchbasecloud/couchbase-cloud/pull/35815, the condition was removed to throw error when user adds iops and storage for Azure premium-type disks. So now in case the user adds the iops and storage for Premium, they should be ignored, all other types of clusters remain same.
2. Also, the deployment and update of Ultra-type azure clusters were not working from Terraform before. 
3. The update of Ultra -> Premium or Premium -> Ultra was failing.

This change ensures all the above are resolved, the Azure cluster is deployed and can be updated properly for Azure clusters.

TODO:
- Add testing proofs
- Add examples to .tf and Readme for azure cluster

Please include a summary of the fix/feature/change, including any relevant motivation and context.
<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

Will add ss/ recording.

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Required Checklist:

- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if required)
- [ ] I have run make fmt and formatted my code
- [ ] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments