### PR TITLE
AV-97053 | correctly get default primary index name

### DIFF
--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -61,6 +61,7 @@ func (g *GSI) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	plan.With.NumReplica = types.Int64Null()
 
 	var ddl string
+	var indexName string
 
 	// create build index statement.
 	if !plan.BuildIndexes.IsNull() {
@@ -122,7 +123,6 @@ func (g *GSI) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	} else {
 		// create primary index statement.
 		if plan.IsPrimary.ValueBool() {
-			var indexName string
 			if !plan.IndexName.IsNull() {
 				indexName = plan.IndexName.ValueString()
 			} else {
@@ -251,7 +251,7 @@ This will automatically be retried in the background.  Please run "terraform app
 			state.BucketName.ValueString(),
 			state.ScopeName.ValueString(),
 			state.CollectionName.ValueString(),
-			state.IndexName.ValueString(),
+			indexName,
 		)
 		if err != nil {
 			resp.Diagnostics.AddError(


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-97053](https://jira.issues.couchbase.com/browse/AV-97053)

## Description

For primary indexes, users can give a custom name or use the default.  If using the default, provider cannot get the index name from the plan, as user did not configure it.  Instead the index name comes from the provider itself.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

```
terraform apply -auto-approve
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/$USER/GolandProjects/terraform-provider-couchbase-capella/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_query_indexes.idx will be created
  + resource "couchbase-capella_query_indexes" "idx" {
      + bucket_name     = "test"
      + cluster_id      = <cluster_id>
      + collection_name = "test"
      + is_primary      = true
      + organization_id = <org_id>
      + project_id      = <project_id>
      + scope_name      = "test"
      + status          = (known after apply)
      + with            = {
          + num_replica = (known after apply)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
couchbase-capella_query_indexes.idx: Creating...
couchbase-capella_query_indexes.idx: Creation complete after 3s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

</details>

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code
- [X] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments