### PR TITLE
AV-97306 | set indexName

### DIFF
--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -146,6 +146,8 @@ func (g *GSI) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 				return
 			}
 
+			indexName = plan.IndexName.ValueString()
+
 			ddl = fmt.Sprintf(
 				"CREATE INDEX `%s` ON `%s`.`%s`.`%s`(%s) ",
 				plan.IndexName.ValueString(),
@@ -256,7 +258,7 @@ This will automatically be retried in the background.  Please run "terraform app
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error reading query index",
-				"Could not read query index "+state.IndexName.ValueString()+": "+err.Error(),
+				"Could not read query index "+indexName+": "+err.Error(),
 			)
 			return
 		}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-97306

## Description

set indexName for secondary index

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

```
terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/$USER/GolandProjects/terraform-provider-couchbase-capella/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_query_indexes.idx will be created
  + resource "couchbase-capella_query_indexes" "idx" {
      + bucket_name     = "test"
      + cluster_id      = <cluster_id>
      + collection_name = "test"
      + index_keys      = [
          + "c1",
        ]
      + index_name      = "index1"
      + organization_id = <org_id>
      + project_id      = <project_id>
      + scope_name      = "test"
      + status          = (known after apply)
      + where           = "geo.alt > 1000"
      + with            = {
          + num_replica = (known after apply)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_query_indexes.idx: Creating...
couchbase-capella_query_indexes.idx: Creation complete after 4s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

</details>

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code
- [X] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments