### PR TITLE
AV-97596 | set computed value for replica correctly

### DIFF
--- a/acceptance_tests/globals.go
+++ b/acceptance_tests/globals.go
@@ -14,15 +14,15 @@ var (
 	// these global variables are set by env vars.
 	globalHost  string
 	globalToken string
-	Username    string
-	Password    string
 	globalOrgId string
 
 	// these global variables are set by setup().
-	globalProjectId  string
-	globalClusterId  string
-	globalBucketName = "default"
-	globalBucketId   string
+	globalProjectId      string
+	globalClusterId      string
+	globalBucketName     = "default"
+	globalScopeName      = "_default"
+	globalCollectionName = "_default"
+	globalBucketId       string
 
 	// this global variable is set in TestMain.
 	globalProviderBlock string

--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -57,8 +57,12 @@ func (g *GSI) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	}
 
 	// initialize computed attributes
+	if plan.With != nil {
+		if plan.With.NumReplica.IsNull() {
+			plan.With.NumReplica = types.Int64Null()
+		}
+	}
 	plan.Status = types.StringNull()
-	plan.With.NumReplica = types.Int64Null()
 
 	var ddl string
 	var indexName string
@@ -137,6 +141,7 @@ func (g *GSI) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 				plan.With.DeferBuild.ValueBool(),
 				plan.With.NumReplica.ValueInt64(),
 			)
+
 		} else {
 			// create secondary index statement.
 			var index_keys []string


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-97596

## Description

initialize replica to 0 only if it's not in the plan

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [X] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
 
```
terraform apply -auto-approve
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/$USER/GolandProjects/terraform-provider-couchbase-capella/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_query_indexes.idx will be created
  + resource "couchbase-capella_query_indexes" "idx" {
      + bucket_name     = "test"
      + cluster_id      = <cluster_id>
      + collection_name = "test"
      + index_name      = "primary_index"
      + is_primary      = true
      + organization_id = <org_id>
      + project_id      = <project_id>
      + scope_name      = "test"
      + status          = (known after apply)
      + with            = {
          + num_replica = 1
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
couchbase-capella_query_indexes.idx: Creating...
couchbase-capella_query_indexes.idx: Creation complete after 4s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

</details>

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code
- [X] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments