### PR TITLE
update defineProviderForResponse to pass in object by reference

### DIFF
--- a/internal/resources/network_peer.go
+++ b/internal/resources/network_peer.go
@@ -459,7 +459,7 @@ func (n *NetworkPeer) getNetworkPeer(ctx context.Context, organizationId, projec
 		return nil, fmt.Errorf("%s: %w", errors.ErrUnmarshallingResponse, err)
 	}
 
-	if err := defineProviderForResponse(networkResp); err != nil {
+	if err := defineProviderForResponse(&networkResp); err != nil {
 		return nil, err
 	}
 
@@ -468,7 +468,7 @@ func (n *NetworkPeer) getNetworkPeer(ctx context.Context, organizationId, projec
 
 // defineProviderForResponse sets the provider type in the retrieved network peer as per the fields populated in the provider config.
 // If the provider type is not set through terraform separately in this manner, it will throw error as v4 get doesn't return it, but it's a field in resources.
-func defineProviderForResponse(networkResp network_peer_api.GetNetworkPeeringRecordResponse) error {
+func defineProviderForResponse(networkResp *network_peer_api.GetNetworkPeeringRecordResponse) error {
 	azure, err := networkResp.AsAZURE()
 	if err != nil {
 		return fmt.Errorf("%s: %w", errors.ErrReadingAzureConfig, err)


### PR DESCRIPTION
https://github.com/couchbasecloud/terraform-provider-couchbase-capella/issues/284

Update function defineProviderForResponse in resource/network_peer.go, to pass in networkResp as a reference as opposed to value, so that the update to networkResp.ProviderType will also be reflected to the caller.


<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-XXXXX

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  Test change locally against a our dev cluster in our Capella organization.  The expectation is that there are no changes.
  `Apply complete! Resources: 0 added, 0 changed, 0 destroyed.`
</details>

## Required Checklist:

- [ x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if required)
- [ ] I have run make fmt and formatted my code
- [x] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments