### PR TITLE
AV-102419: Fix PFT cluster read

### DIFF
--- a/internal/resources/free_tier_cluster_schema.go
+++ b/internal/resources/free_tier_cluster_schema.go
@@ -85,7 +85,7 @@ func FreeTierClusterSchema() schema.Schema {
 							},
 						},
 						"num_of_nodes": WithDescription(int64Attribute(computed), "The number of nodes in the Service Group."),
-						"services":     WithDescription(stringAttribute([]string{computed}), "The services enabled for the Service Group. Should be a comma-separated list of services. For example, 'data,index,query'."),
+						"services":     WithDescription(stringSetAttribute(computed), "The services enabled for the service group. Should be a comma-separated list of services. For example, 'data,index,query'"),
 					},
 				},
 			},


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-102419

## Description

During the document changes the StringSet type for services was changed to string type accidentally and due to which the cluster deployment happens but the provider fails to read the cluster and hence eventually leading to failure in creating state file. This PR is to fix the issue.

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

Testing done for all PFT resources and data sources, Cluster, Bucket, App services
https://docs.google.com/document/d/1Z-_OF8wzKPvASTDoTsRr2vFQAiDGba_gH-b-28KNbhA/edit?tab=t.0
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Required Checklist:

- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if required)
- [ ] I have run make fmt and formatted my code
- [ ] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments