### PR TITLE
[AV-102723] Initialize num_replica to null

### DIFF
--- a/acceptance_tests/gsi_accpetance_test.go
+++ b/acceptance_tests/gsi_accpetance_test.go
@@ -9,33 +9,53 @@ import (
 )
 
 func TestAccGSI(t *testing.T) {
-	resourceType := "couchbase-capella_query_indexes"
+	const resourceType = "couchbase-capella_query_indexes"
 	primaryIndexResourceName := randomStringWithPrefix("tf_acc_gsi_")
-	secondaryIndexResourceName := randomStringWithPrefix("tf_acc_gsi_")
 	primaryIndexResourceReference := fmt.Sprintf("%s.%s", resourceType, primaryIndexResourceName)
-	secondaryIndexResourceReference := fmt.Sprintf("%s.%s", resourceType, secondaryIndexResourceName)
+	gsiResourceIdx1 := fmt.Sprintf("%s.%s", resourceType, "idx1")
+	gsiResourceIdx2 := fmt.Sprintf("%s.%s", resourceType, "idx2")
+	gsiResourceIdx3 := fmt.Sprintf("%s.%s", resourceType, "idx3")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCreateGSINonDeferredIndexConfig(secondaryIndexResourceName),
+				Config: testAccCreateGSINonDeferredIndexConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(secondaryIndexResourceReference, "organization_id", globalOrgId),
-					resource.TestCheckResourceAttr(secondaryIndexResourceReference, "project_id", globalProjectId),
-					resource.TestCheckResourceAttr(secondaryIndexResourceReference, "cluster_id", globalClusterId),
-					resource.TestCheckResourceAttr(secondaryIndexResourceReference, "bucket_name", globalBucketName),
-					resource.TestCheckResourceAttr(secondaryIndexResourceReference, "scope_name", globalScopeName),
-					resource.TestCheckResourceAttr(secondaryIndexResourceReference, "collection_name", globalCollectionName),
-					resource.TestCheckResourceAttr(secondaryIndexResourceReference, "index_name", "index1"),
-					resource.TestCheckResourceAttr(secondaryIndexResourceReference, "index_keys.0", "c1"),
-					resource.TestCheckResourceAttr(secondaryIndexResourceReference, "where", "geo.alt > 1000"),
-					resource.TestCheckResourceAttr(secondaryIndexResourceReference, "with.num_replica", "1"),
+					resource.TestCheckResourceAttr(gsiResourceIdx1, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(gsiResourceIdx1, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(gsiResourceIdx1, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(gsiResourceIdx1, "bucket_name", globalBucketName),
+					resource.TestCheckResourceAttr(gsiResourceIdx1, "scope_name", globalScopeName),
+					resource.TestCheckResourceAttr(gsiResourceIdx1, "collection_name", globalCollectionName),
+					resource.TestCheckResourceAttr(gsiResourceIdx1, "index_name", "idx1"),
+					resource.TestCheckResourceAttr(gsiResourceIdx1, "index_keys.0", "c1"),
+					resource.TestCheckResourceAttr(gsiResourceIdx1, "where", "geo.alt > 1000"),
+
+					resource.TestCheckResourceAttr(gsiResourceIdx2, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(gsiResourceIdx2, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(gsiResourceIdx2, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(gsiResourceIdx2, "bucket_name", globalBucketName),
+					resource.TestCheckResourceAttr(gsiResourceIdx2, "scope_name", globalScopeName),
+					resource.TestCheckResourceAttr(gsiResourceIdx2, "collection_name", globalCollectionName),
+					resource.TestCheckResourceAttr(gsiResourceIdx2, "index_name", "idx2"),
+					resource.TestCheckResourceAttr(gsiResourceIdx2, "index_keys.0", "c2"),
+					resource.TestCheckResourceAttr(gsiResourceIdx2, "where", "geo.alt > 2000"),
+
+					resource.TestCheckResourceAttr(gsiResourceIdx3, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(gsiResourceIdx3, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(gsiResourceIdx3, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(gsiResourceIdx3, "bucket_name", globalBucketName),
+					resource.TestCheckResourceAttr(gsiResourceIdx3, "scope_name", globalScopeName),
+					resource.TestCheckResourceAttr(gsiResourceIdx3, "collection_name", globalCollectionName),
+					resource.TestCheckResourceAttr(gsiResourceIdx3, "index_name", "idx3"),
+					resource.TestCheckResourceAttr(gsiResourceIdx3, "index_keys.0", "c3"),
+					resource.TestCheckResourceAttr(gsiResourceIdx3, "where", "geo.alt > 3000"),
 				),
 			},
 			{
-				ResourceName:      secondaryIndexResourceReference,
-				ImportStateIdFunc: generateGsiImportIdForResource(secondaryIndexResourceReference),
+				ResourceName:      gsiResourceIdx1,
+				ImportStateIdFunc: generateGsiImportIdForResource(gsiResourceIdx1),
 				ImportState:       true,
 			},
 			{
@@ -55,22 +75,52 @@ func TestAccGSI(t *testing.T) {
 	})
 }
 
-func testAccCreateGSINonDeferredIndexConfig(resourceName string) string {
+func testAccCreateGSINonDeferredIndexConfig() string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "couchbase-capella_query_indexes" "%[8]s" {
+resource "couchbase-capella_query_indexes" "idx1" {
   organization_id = "%[2]s"
   project_id      = "%[3]s"
   cluster_id      = "%[4]s"
   bucket_name     = "%[5]s"
   scope_name      = "%[6]s"
   collection_name = "%[7]s"
-  index_name      = "index1"
+  index_name      = "idx1"
   index_keys      = ["c1"]
   where = "geo.alt > 1000"
   with = {
-        num_replica = 1
+        defer_build = false
+  }
+}
+
+resource "couchbase-capella_query_indexes" "idx2" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  bucket_name     = "%[5]s"
+  scope_name      = "%[6]s"
+  collection_name = "%[7]s"
+  index_name      = "idx2"
+  index_keys      = ["c2"]
+  where = "geo.alt > 2000"
+  with = {
+        defer_build = false
+  }
+}
+
+resource "couchbase-capella_query_indexes" "idx3" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  bucket_name     = "%[5]s"
+  scope_name      = "%[6]s"
+  collection_name = "%[7]s"
+  index_name      = "idx3"
+  index_keys      = ["c3"]
+  where = "geo.alt > 3000"
+  with = {
+        defer_build = false
   }
 }
 `, globalProviderBlock,
@@ -80,7 +130,7 @@ resource "couchbase-capella_query_indexes" "%[8]s" {
 		globalBucketName,
 		globalScopeName,
 		globalCollectionName,
-		resourceName)
+	)
 }
 
 func testAccCreatePrimaryIndexConfig(resourceName string) string {

--- a/examples/getting_started/gsi.tf
+++ b/examples/getting_started/gsi.tf
@@ -1,4 +1,4 @@
-resource "couchbase-capella_query_indexes" "idx" {
+resource "couchbase-capella_query_indexes" "idx1" {
   organization_id = var.organization_id
   project_id      = couchbase-capella_project.new_project.id
   cluster_id      = couchbase-capella_cluster.new_cluster.id
@@ -7,17 +7,47 @@ resource "couchbase-capella_query_indexes" "idx" {
   scope_name      = couchbase-capella_scope.new_scope.scope_name
   collection_name = couchbase-capella_collection.new_collection.collection_name
 
-  index_name = var.index_name
+  index_name = "idx1"
   index_keys = var.index_keys
   where      = var.where
 
   with = {
     defer_build   = var.with.defer_build
-    num_replica   = var.with.num_replica
-    num_partition = var.with.num_partition
   }
 }
 
-output "idx" {
-  value = couchbase-capella_query_indexes.idx
+resource "couchbase-capella_query_indexes" "idx2" {
+  organization_id = var.organization_id
+  project_id      = couchbase-capella_project.new_project.id
+  cluster_id      = couchbase-capella_cluster.new_cluster.id
+
+  bucket_name     = couchbase-capella_bucket.new_bucket.name
+  scope_name      = couchbase-capella_scope.new_scope.scope_name
+  collection_name = couchbase-capella_collection.new_collection.collection_name
+
+  index_name = "idx2"
+  index_keys = var.index_keys
+  where      = var.where
+
+  with = {
+    defer_build   = var.with.defer_build
+  }
+}
+
+resource "couchbase-capella_query_indexes" "idx3" {
+  organization_id = var.organization_id
+  project_id      = couchbase-capella_project.new_project.id
+  cluster_id      = couchbase-capella_cluster.new_cluster.id
+
+  bucket_name     = couchbase-capella_bucket.new_bucket.name
+  scope_name      = couchbase-capella_scope.new_scope.scope_name
+  collection_name = couchbase-capella_collection.new_collection.collection_name
+
+  index_name = "idx3"
+  index_keys = var.index_keys
+  where      = var.where
+
+  with = {
+    defer_build   = var.with.defer_build
+  }
 }

--- a/examples/getting_started/terraform.template.tfvars
+++ b/examples/getting_started/terraform.template.tfvars
@@ -192,11 +192,9 @@ aws_config = {
   cidr       = "10.0.0.0/16"
 }
 
-index_name = "idx1"
 index_keys = ["id", "age", "name"]
 where      = "dept = 'sales'"
 
 with = {
   defer_build = false
-  num_replica = 1
 }

--- a/examples/getting_started/variables.tf
+++ b/examples/getting_started/variables.tf
@@ -242,10 +242,6 @@ variable "aws_config" {
   })
 }
 
-variable "index_name" {
-  description = "index Name"
-}
-
 variable "index_keys" {
   description = "index keys"
 }

--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -56,9 +56,9 @@ func (g *GSI) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 		return
 	}
 
-	// initialize computed attributes
+	// initialize computed attributes to null.
 	if plan.With != nil {
-		if plan.With.NumReplica.IsNull() {
+		if plan.With.NumReplica.IsNull() || plan.With.NumReplica.IsUnknown() {
 			plan.With.NumReplica = types.Int64Null()
 		}
 	}

--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -64,6 +64,12 @@ func (g *GSI) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	}
 	plan.Status = types.StringNull()
 
+	diags := resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	var ddl string
 	var indexName string
 
@@ -227,10 +233,6 @@ This will automatically be retried in the background.  Please run "terraform app
 				plan.CollectionName.ValueString(),
 			),
 		)
-
-		// save to state file so that refresh can work.
-		// this is preferrable to import as there can be many indexes in this state.
-		resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 
 		return
 


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-102723](https://jira.issues.couchbase.com/browse/AV-102723)

## Description

When creating multiple non-deferred indexes in parallel, indexer service will create the first request it receives and retry the other indexes.  The problem is for those retried indexes, a computed attribute `num_replica` is still left with unknown value.   

```
│ Error: Provider returned invalid result object after apply
│ 
│ After the apply operation, the provider still indicated an unknown value for couchbase-capella_query_indexes.idx1.with.num_replica. All values must be known after apply, so
│ this is always a bug in the provider and should be reported in the provider's own repository. Terraform will still save the other known object values in the state.
```

Terraform client expects it to have some value after apply.  To fix this issue, this attribute is initialized to null in the provider.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [X] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
 
```
terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/$USER/GolandProjects/terraform-provider-couchbase-capella/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_query_indexes.new_indexes["idx1"] will be created
  + resource "couchbase-capella_query_indexes" "new_indexes" {
      + bucket_name     = "test"
      + cluster_id      = "ffffffff-aaaa-1414-eeee-00000000000"
      + collection_name = "test"
      + index_keys      = [
          + "field1",
        ]
      + index_name      = "idx1"
      + organization_id = "ffffffff-aaaa-1414-eeee-00000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-00000000000"
      + scope_name      = "test"
      + status          = (known after apply)
      + with            = {
          + defer_build = false
          + num_replica = (known after apply)
        }
    }

  # couchbase-capella_query_indexes.new_indexes["idx2"] will be created
  + resource "couchbase-capella_query_indexes" "new_indexes" {
      + bucket_name     = "test"
      + cluster_id      = "ffffffff-aaaa-1414-eeee-00000000000"
      + collection_name = "test"
      + index_keys      = [
          + "field2",
        ]
      + index_name      = "idx2"
      + organization_id = "ffffffff-aaaa-1414-eeee-00000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-00000000000"
      + scope_name      = "test"
      + status          = (known after apply)
      + with            = {
          + defer_build = false
          + num_replica = (known after apply)
        }
    }

  # couchbase-capella_query_indexes.new_indexes["idx3"] will be created
  + resource "couchbase-capella_query_indexes" "new_indexes" {
      + bucket_name     = "test"
      + cluster_id      = "ffffffff-aaaa-1414-eeee-00000000000"
      + collection_name = "test"
      + index_keys      = [
          + "field3",
        ]
      + index_name      = "idx3"
      + organization_id = "ffffffff-aaaa-1414-eeee-00000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-00000000000"
      + scope_name      = "test"
      + status          = (known after apply)
      + with            = {
          + defer_build = false
          + num_replica = (known after apply)
        }
    }

  # couchbase-capella_query_indexes.new_indexes["idx4"] will be created
  + resource "couchbase-capella_query_indexes" "new_indexes" {
      + bucket_name     = "test"
      + cluster_id      = "ffffffff-aaaa-1414-eeee-00000000000"
      + collection_name = "test"
      + index_keys      = [
          + "field5",
        ]
      + index_name      = "idx4"
      + organization_id = "ffffffff-aaaa-1414-eeee-00000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-00000000000"
      + scope_name      = "test"
      + status          = (known after apply)
      + with            = {
          + defer_build = false
          + num_replica = (known after apply)
        }
    }

  # couchbase-capella_query_indexes.new_indexes["idx5"] will be created
  + resource "couchbase-capella_query_indexes" "new_indexes" {
      + bucket_name     = "test"
      + cluster_id      = "ffffffff-aaaa-1414-eeee-00000000000"
      + collection_name = "test"
      + index_keys      = [
          + "field5",
        ]
      + index_name      = "idx5"
      + organization_id = "ffffffff-aaaa-1414-eeee-00000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-00000000000"
      + scope_name      = "test"
      + status          = (known after apply)
      + with            = {
          + defer_build = false
          + num_replica = (known after apply)
        }
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_query_indexes.new_indexes["idx1"]: Creating...
couchbase-capella_query_indexes.new_indexes["idx5"]: Creating...
couchbase-capella_query_indexes.new_indexes["idx2"]: Creating...
couchbase-capella_query_indexes.new_indexes["idx4"]: Creating...
couchbase-capella_query_indexes.new_indexes["idx3"]: Creating...
couchbase-capella_query_indexes.new_indexes["idx2"]: Creation complete after 2s
couchbase-capella_query_indexes.new_indexes["idx3"]: Creation complete after 2s
couchbase-capella_query_indexes.new_indexes["idx1"]: Creation complete after 3s
couchbase-capella_query_indexes.new_indexes["idx5"]: Creation complete after 3s
couchbase-capella_query_indexes.new_indexes["idx4"]: Creation complete after 4s
╷
│ Warning: Another index creation is currently in progress
│ 
│   with couchbase-capella_query_indexes.new_indexes["idx2"],
│   on config.tf line 12, in resource "couchbase-capella_query_indexes" "new_indexes":
│   12: resource "couchbase-capella_query_indexes" "new_indexes" {
│ 
│ Could not create index idx2 in test.test.test as there is another index creation already in progress.
│ This will automatically be retried in the background.  Please run "terraform apply --refresh-only" after some time.
│ 
│ (and 4 more similar warnings elsewhere)
╵

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
```

</details>

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code
- [X] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments