### PR TITLE
App services cidr

### DIFF
--- a/examples/app_services_cidr/README.md
+++ b/examples/app_services_cidr/README.md
@@ -1,0 +1,598 @@
+# Capella allowedcidrs Example
+
+This example shows how to create and manage App Service Allowed CIDRs in Capella.
+
+This creates a new Allowed CIDR in the selected Capella App Service and lists existing Allowed CIDRs in the App Service. It uses the App Service ID to create and list Allowed CIDRs.
+
+To run, configure your Couchbase Capella provider as described in README in the root of this project.
+
+# Example Walkthrough
+
+In this example, we are going to do the following.
+
+1. CREATE: Create a new allowedcidr in Capella as stated in the `create_allowedcidr.tf` file.
+2. LIST: List existing allowedcidrs in Capella as stated in the `list_allowedcidrs.tf` file.
+3. IMPORT: Import an allowedcidr that exists in Capella but not in the terraform state file.
+4. DELETE: Delete the newly created allowedcidr from Capella.
+
+If you check the `terraform.template.tfvars` file - Make sure you copy the file to `terraform.tfvars` and update the values of the variables as per the correct organization access.
+
+## CREATE & LIST
+### View the plan for the resources that Terraform will create
+
+Command: `terraform plan`
+
+Sample Output:
+```
+$ terraform plan
+╷
+│ Warning: Provider development overrides are in effect
+│ 
+│ The following provider development overrides are set in the CLI configuration:
+│  - hashicorp.com/couchbasecloud/capella in /Users/$USER/workspace/terraform-provider-capella
+│ 
+│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
+│ published releases.
+╵
+data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
+data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 0s
+
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # capella_app_services_cidr.new_allowedcidr will be created
+  + resource "capella_app_services_cidr" "new_allowedcidr" {
+      + audit           = {
+          + created_at  = (known after apply)
+          + created_by  = (known after apply)
+          + modified_at = (known after apply)
+          + modified_by = (known after apply)
+          + version     = (known after apply)
+        }
+      + cidr            = "10.0.0.0/16"
+      + cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      + comment         = "Allow access from another VPC"
+      + expires_at      = "2023-11-14T21:49:58.465Z"
+      + id              = (known after apply)
+      + organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+      + project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + allowedcidrs_list = {
+      + cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      + data            = [
+          + {
+              + audit           = {
+                  + created_at  = "2023-10-04 02:44:17.216362615 +0000 UTC"
+                  + created_by  = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  + modified_at = "2023-10-04 02:44:17.216362615 +0000 UTC"
+                  + modified_by = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  + version     = 1
+                }
+              + cidr            = "23.121.17.137/32"
+              + cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+              + comment         = ""
+              + expires_at      = null
+              + id              = "bbaf68d3-6e8a-433e-aa78-d12a79da4911"
+              + if_match        = null
+              + organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+              + project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+            },
+        ]
+      + organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+      + project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+    }
+  + new_allowedcidr   = {
+      + audit           = (known after apply)
+      + cidr            = "10.0.0.0/16"
+      + cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      + comment         = "Allow access from another VPC"
+      + expires_at      = "2023-11-14T21:49:58.465Z"
+      + id              = (known after apply)
+      + if_match        = null
+      + organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+      + project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+    }
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
+```
+
+### Apply the Plan, in order to create a new allowedcidr
+
+Command: `terraform apply`
+
+Sample Output:
+```
+$ terraform apply
+╷
+│ Warning: Provider development overrides are in effect
+│ 
+│ The following provider development overrides are set in the CLI configuration:
+│  - hashicorp.com/couchbasecloud/capella in /Users/$USER/workspace/terraform-provider-capella
+│ 
+│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
+│ published releases.
+╵
+data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
+data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 0s
+
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # capella_app_services_cidr.new_allowedcidr will be created
+  + resource "capella_app_services_cidr" "new_allowedcidr" {
+      + audit           = {
+          + created_at  = (known after apply)
+          + created_by  = (known after apply)
+          + modified_at = (known after apply)
+          + modified_by = (known after apply)
+          + version     = (known after apply)
+        }
+      + cidr            = "10.0.0.0/16"
+      + cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      + comment         = "Allow access from another VPC"
+      + expires_at      = "2023-11-14T21:49:58.465Z"
+      + id              = (known after apply)
+      + organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+      + project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + allowedcidrs_list = {
+      + cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      + app_service_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      + data            = [
+          + {
+              + audit           = {
+                  + created_at  = "2023-10-04 02:44:17.216362615 +0000 UTC"
+                  + created_by  = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  + modified_at = "2023-10-04 02:44:17.216362615 +0000 UTC"
+                  + modified_by = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  + version     = 1
+                }
+              + cidr            = "23.121.17.137/32"
+              + cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+              + comment         = ""
+              + expires_at      = null
+              + id              = "bbaf68d3-6e8a-433e-aa78-d12a79da4911"
+              + if_match        = null
+              + organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+              + project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+            },
+        ]
+      + organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+      + project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+    }
+  + new_allowedcidr   = {
+      + audit           = (known after apply)
+      + cidr            = "10.0.0.0/16"
+      + cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      + comment         = "Allow access from another VPC"
+      + expires_at      = "2023-11-14T21:49:58.465Z"
+      + id              = (known after apply)
+      + if_match        = null
+      + organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+      + project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+    }
+
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value: yes
+
+capella_app_services_cidr.new_allowedcidr: Creating...
+capella_app_services_cidr.new_allowedcidr: Creation complete after 8s [id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+allowedcidrs_list = {
+  "cluster_id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+  "data" = tolist([
+    {
+      "audit" = {
+        "created_at" = "2023-10-04 02:44:17.216362615 +0000 UTC"
+        "created_by" = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+        "modified_at" = "2023-10-04 02:44:17.216362615 +0000 UTC"
+        "modified_by" = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+        "version" = 1
+      }
+      "cidr" = "23.121.17.137/32"
+      "cluster_id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      "comment" = ""
+      "expires_at" = tostring(null)
+      "id" = "bbaf68d3-6e8a-433e-aa78-d12a79da4911"
+      "if_match" = tostring(null)
+      "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+      "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+    },
+  ])
+  "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+  "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+}
+new_allowedcidr = {
+  "audit" = {
+    "created_at" = "2023-10-04 02:44:46.31810374 +0000 UTC"
+    "created_by" = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+    "modified_at" = "2023-10-04 02:44:46.31810374 +0000 UTC"
+    "modified_by" = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+    "version" = 1
+  }
+  "cidr" = "10.0.0.0/16"
+  "cluster_id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+  "comment" = "Allow access from another VPC"
+  "expires_at" = "2023-11-14T21:49:58.465Z"
+  "id" = "854cbdf0-8ae3-4a42-9227-59c52a5ab4f2"
+  "if_match" = tostring(null)
+  "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+  "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+}
+```
+
+### Note the allowedcidr ID for the new allowedcidr
+Command: `terraform output new_allowedcidr`
+
+Sample Output:
+```
+$ terraform output new_allowedcidr
+{
+  "audit" = {
+    "created_at" = "2023-10-04 02:44:46.31810374 +0000 UTC"
+    "created_by" = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+    "modified_at" = "2023-10-04 02:44:46.31810374 +0000 UTC"
+    "modified_by" = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+    "version" = 1
+  }
+  "cidr" = "10.0.0.0/16"
+  "cluster_id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+  "comment" = "Allow access from another VPC"
+  "expires_at" = "2023-11-14T21:49:58.465Z"
+  "id" = "854cbdf0-8ae3-4a42-9227-59c52a5ab4f2"
+  "if_match" = tostring(null)
+  "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+  "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+}
+```
+
+In this case, the allowedcidr ID for my new allowedcidr is `854cbdf0-8ae3-4a42-9227-59c52a5ab4f2`
+
+### List the resources that are present in the Terraform State file.
+
+Command: `terraform state list`
+
+Sample Output:
+```
+$ terraform state list
+data.couchbase-capella_app_services_cidrs.existing_allowedcidrs
+couchbase-capella_app_services_cidr.new_allowedcidr
+```
+
+## IMPORT
+### Remove the resource `new_allowedcidr` from the Terraform State file
+
+Command: `terraform state rm couchbase-capella_app_services_cidr.new_allowedcidr`
+
+Sample Output:
+```
+$ terraform state rm couchbase-capella_app_services_cidr.new_allowedcidr
+Removed couchbase-capella_app_services_cidr.new_allowedcidr
+Successfully removed 1 resource instance(s).
+```
+
+Please note, this command will only remove the resource from the Terraform State file, but in reality, the resource exists in Capella.
+
+### Now, let's import the resource in Terraform
+
+Command: `terraform import couchbase-capella_app_services_cidr.new_allowedcidr id=<allowedcidr_id>,cluster_id=<cluster_id>,project_id=<project_id>,organization_id=<organization_id>`
+
+In this case, the complete command is:
+`terraform import couchbase-capella_app_services_cidr.new_allowedcidr id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2,cluster_id=f499a9e6-e5a1-4f3e-95a7-941a41d046e6,project_id=958ad6b5-272d-49f0-babd-cc98c6b54a81,organization_id=0783f698-ac58-4018-84a3-31c3b6ef785d`
+
+Sample Output:
+```
+$ terraform import couchbase-capella_app_services_cidr.new_allowedcidr id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2,cluster_id=f499a9e6-e5a1-4f3e-95a7-941a41d046e6,project_id=958ad6b5-272d-49f0-babd-cc98c6b54a81,organization_id=0783f698-ac58-4018-84a3-31c3b6ef785d
+capella_app_services_cidr.new_allowedcidr: Importing from ID "id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2,cluster_id=f499a9e6-e5a1-4f3e-95a7-941a41d046e6,project_id=958ad6b5-272d-49f0-babd-cc98c6b54a81,organization_id=0783f698-ac58-4018-84a3-31c3b6ef785d"...
+data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
+capella_app_services_cidr.new_allowedcidr: Import prepared!
+  Prepared capella_app_services_cidr for import
+capella_app_services_cidr.new_allowedcidr: Refreshing state... [id=id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2,cluster_id=f499a9e6-e5a1-4f3e-95a7-941a41d046e6,project_id=958ad6b5-272d-49f0-babd-cc98c6b54a81,organization_id=0783f698-ac58-4018-84a3-31c3b6ef785d]
+data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 1s
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+Here, we pass the IDs as a single comma-separated string.
+The first ID in the string is the allowedcidr ID i.e. the ID of the resource that we want to import.
+The second ID is the cluster ID i.e. the ID of the cluster to which the allowedcidr belongs.
+The third ID is the project ID i.e. the ID of the project to which the cluster belongs.
+The fourth ID is the organization ID i.e. the ID of the organization to which the project belongs.
+
+### Let's run a terraform plan to confirm that the import was successful and no resource states were impacted
+
+Command: `terraform plan`
+
+Sample Output:
+```
+$ terraform plan
+╷
+│ Warning: Provider development overrides are in effect
+│ 
+│ The following provider development overrides are set in the CLI configuration:
+│  - hashicorp.com/couchbasecloud/capella in /Users/$USER/workspace/terraform-provider-capella
+│ 
+│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
+│ published releases.
+╵
+data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
+capella_app_services_cidr.new_allowedcidr: Refreshing state... [id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2]
+data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 1s
+
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
+```
+
+## UPDATE
+### Let us edit the terraform.tfvars file to change the allowedcidr configuration settings.
+
+Command: `terraform apply -var 'allowedcidr={durability_level="majority",name="new_terraform_allowedcidr"}'`
+
+Sample Output:
+```
+$ terraform apply -var comment="updated allowedcidr comment"
+╷
+│ Warning: Provider development overrides are in effect
+│ 
+│ The following provider development overrides are set in the CLI configuration:
+│  - hashicorp.com/couchbasecloud/capella in /Users/$USER/workspace/terraform-provider-capella
+│ 
+│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
+│ published releases.
+╵
+data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
+capella_app_services_cidr.new_allowedcidr: Refreshing state... [id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2]
+data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 1s
+
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+-/+ destroy and then create replacement
+
+Terraform will perform the following actions:
+
+  # capella_app_services_cidr.new_allowedcidr must be replaced
+-/+ resource "capella_app_services_cidr" "new_allowedcidr" {
+      ~ audit           = {
+          ~ created_at  = "2023-10-04 02:44:46.31810374 +0000 UTC" -> (known after apply)
+          ~ created_by  = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD" -> (known after apply)
+          ~ modified_at = "2023-10-04 02:44:46.31810374 +0000 UTC" -> (known after apply)
+          ~ modified_by = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD" -> (known after apply)
+          ~ version     = 1 -> (known after apply)
+        }
+      ~ comment         = "Allow access from another VPC" -> "updated allowedcidr comment" # forces replacement
+      ~ id              = "854cbdf0-8ae3-4a42-9227-59c52a5ab4f2" -> (known after apply)
+        # (5 unchanged attributes hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+Changes to Outputs:
+  ~ new_allowedcidr = {
+      ~ audit           = {
+          - created_at  = "2023-10-04 02:44:46.31810374 +0000 UTC"
+          - created_by  = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+          - modified_at = "2023-10-04 02:44:46.31810374 +0000 UTC"
+          - modified_by = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+          - version     = 1
+        } -> (known after apply)
+      ~ comment         = "Allow access from another VPC" -> "updated allowedcidr comment"
+      ~ id              = "854cbdf0-8ae3-4a42-9227-59c52a5ab4f2" -> (known after apply)
+        # (6 unchanged elements hidden)
+    }
+
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value: yes
+
+capella_app_services_cidr.new_allowedcidr: Destroying... [id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2]
+capella_app_services_cidr.new_allowedcidr: Destruction complete after 3s
+capella_app_services_cidr.new_allowedcidr: Creating...
+capella_app_services_cidr.new_allowedcidr: Creation complete after 2s [id=358387f9-9780-4419-9ca6-b5e8a3b457dc]
+
+Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
+
+Outputs:
+
+allowedcidrs_list = {
+  "cluster_id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+  "data" = tolist([
+    {
+      "audit" = {
+        "created_at" = "2023-10-04 02:44:46.31810374 +0000 UTC"
+        "created_by" = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+        "modified_at" = "2023-10-04 02:44:46.31810374 +0000 UTC"
+        "modified_by" = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+        "version" = 1
+      }
+      "cidr" = "10.0.0.0/16"
+      "cluster_id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      "comment" = "Allow access from another VPC"
+      "expires_at" = "2023-11-14T21:49:58.465Z"
+      "id" = "854cbdf0-8ae3-4a42-9227-59c52a5ab4f2"
+      "if_match" = tostring(null)
+      "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+      "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+    },
+    {
+      "audit" = {
+        "created_at" = "2023-10-04 02:44:17.216362615 +0000 UTC"
+        "created_by" = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+        "modified_at" = "2023-10-04 02:44:17.216362615 +0000 UTC"
+        "modified_by" = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+        "version" = 1
+      }
+      "cidr" = "23.121.17.137/32"
+      "cluster_id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      "comment" = ""
+      "expires_at" = tostring(null)
+      "id" = "bbaf68d3-6e8a-433e-aa78-d12a79da4911"
+      "if_match" = tostring(null)
+      "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+      "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+    },
+  ])
+  "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+  "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+}
+new_allowedcidr = {
+  "audit" = {
+    "created_at" = "2023-10-04 02:49:31.491935751 +0000 UTC"
+    "created_by" = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+    "modified_at" = "2023-10-04 02:49:31.491935751 +0000 UTC"
+    "modified_by" = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+    "version" = 1
+  }
+  "cidr" = "10.0.0.0/16"
+  "cluster_id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+  "comment" = "updated allowedcidr comment"
+  "expires_at" = "2023-11-14T21:49:58.465Z"
+  "id" = "358387f9-9780-4419-9ca6-b5e8a3b457dc"
+  "if_match" = tostring(null)
+  "organization_id" = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+  "project_id" = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+}
+```
+
+## DESTROY
+### Finally, destroy the resources created by Terraform
+
+Command: `terraform destroy`
+
+Sample Output:
+```
+$ terraform destroy
+╷
+│ Warning: Provider development overrides are in effect
+│ 
+│ The following provider development overrides are set in the CLI configuration:
+│  - hashicorp.com/couchbasecloud/capella in /Users/$USER/workspace/terraform-provider-capella
+│ 
+│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
+│ published releases.
+╵
+data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
+capella_app_services_cidr.new_allowedcidr: Refreshing state... [id=358387f9-9780-4419-9ca6-b5e8a3b457dc]
+data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 0s
+
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+  - destroy
+
+Terraform will perform the following actions:
+
+  # capella_app_services_cidr.new_allowedcidr will be destroyed
+  - resource "capella_app_services_cidr" "new_allowedcidr" {
+      - audit           = {
+          - created_at  = "2023-10-04 02:49:31.491935751 +0000 UTC" -> null
+          - created_by  = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD" -> null
+          - modified_at = "2023-10-04 02:49:31.491935751 +0000 UTC" -> null
+          - modified_by = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD" -> null
+          - version     = 1 -> null
+        }
+      - cidr            = "10.0.0.0/16" -> null
+      - cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6" -> null
+      - comment         = "updated allowedcidr comment" -> null
+      - expires_at      = "2023-11-14T21:49:58.465Z" -> null
+      - id              = "358387f9-9780-4419-9ca6-b5e8a3b457dc" -> null
+      - organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d" -> null
+      - project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81" -> null
+    }
+
+Plan: 0 to add, 0 to change, 1 to destroy.
+
+Changes to Outputs:
+  - allowedcidrs_list = {
+      - cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      - data            = [
+          - {
+              - audit           = {
+                  - created_at  = "2023-10-04 02:49:31.491935751 +0000 UTC"
+                  - created_by  = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+                  - modified_at = "2023-10-04 02:49:31.491935751 +0000 UTC"
+                  - modified_by = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+                  - version     = 1
+                }
+              - cidr            = "10.0.0.0/16"
+              - cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+              - comment         = "updated allowedcidr comment"
+              - expires_at      = "2023-11-14T21:49:58.465Z"
+              - id              = "358387f9-9780-4419-9ca6-b5e8a3b457dc"
+              - if_match        = null
+              - organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+              - project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+            },
+          - {
+              - audit           = {
+                  - created_at  = "2023-10-04 02:44:17.216362615 +0000 UTC"
+                  - created_by  = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  - modified_at = "2023-10-04 02:44:17.216362615 +0000 UTC"
+                  - modified_by = "7dfc7b93-a71b-4a2e-b5a7-4255ab29cab9"
+                  - version     = 1
+                }
+              - cidr            = "23.121.17.137/32"
+              - cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+              - comment         = ""
+              - expires_at      = null
+              - id              = "bbaf68d3-6e8a-433e-aa78-d12a79da4911"
+              - if_match        = null
+              - organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+              - project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+            },
+        ]
+      - organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+      - project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+    } -> null
+  - new_allowedcidr   = {
+      - audit           = {
+          - created_at  = "2023-10-04 02:49:31.491935751 +0000 UTC"
+          - created_by  = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+          - modified_at = "2023-10-04 02:49:31.491935751 +0000 UTC"
+          - modified_by = "osxKeibDiShFFyyqAVNvqWRaWryXBxBD"
+          - version     = 1
+        }
+      - cidr            = "10.0.0.0/16"
+      - cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
+      - comment         = "updated allowedcidr comment"
+      - expires_at      = "2023-11-14T21:49:58.465Z"
+      - id              = "358387f9-9780-4419-9ca6-b5e8a3b457dc"
+      - if_match        = null
+      - organization_id = "0783f698-ac58-4018-84a3-31c3b6ef785d"
+      - project_id      = "958ad6b5-272d-49f0-babd-cc98c6b54a81"
+    } -> null
+
+Do you really want to destroy all resources?
+  Terraform will destroy all your managed infrastructure, as shown above.
+  There is no undo. Only 'yes' will be accepted to confirm.
+
+  Enter a value: yes
+
+capella_app_services_cidr.new_allowedcidr: Destroying... [id=358387f9-9780-4419-9ca6-b5e8a3b457dc]
+capella_app_services_cidr.new_allowedcidr: Destruction complete after 2s
+
+Destroy complete! Resources: 1 destroyed.
+```

--- a/examples/app_services_cidr/README.md
+++ b/examples/app_services_cidr/README.md
@@ -1,8 +1,8 @@
-# Capella allowedcidrs Example
+# Capella allowedcidr Example
 
-This example shows how to create and manage App Service Allowed CIDRs in Capella.
+This example shows how to create and manage App Service Allowed CIDR in Capella.
 
-This creates a new Allowed CIDR in the selected Capella App Service and lists existing Allowed CIDRs in the App Service. It uses the App Service ID to create and list Allowed CIDRs.
+This creates a new Allowed CIDR in the selected Capella App Service and lists existing Allowed CIDR in the App Service. It uses the App Service ID to create and list Allowed CIDR.
 
 To run, configure your Couchbase Capella provider as described in README in the root of this project.
 
@@ -11,7 +11,7 @@ To run, configure your Couchbase Capella provider as described in README in the 
 In this example, we are going to do the following.
 
 1. CREATE: Create a new allowedcidr in Capella as stated in the `create_allowedcidr.tf` file.
-2. LIST: List existing allowedcidrs in Capella as stated in the `list_allowedcidrs.tf` file.
+2. LIST: List existing allowedcidr in Capella as stated in the `list_allowedcidr.tf` file.
 3. IMPORT: Import an allowedcidr that exists in Capella but not in the terraform state file.
 4. DELETE: Delete the newly created allowedcidr from Capella.
 
@@ -34,8 +34,8 @@ $ terraform plan
 │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
 │ published releases.
 ╵
-data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
-data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 0s
+data.capella_app_services_cidr.existing_allowedcidr: Reading...
+data.capella_app_services_cidr.existing_allowedcidr: Read complete after 0s
 
 Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
   + create
@@ -63,7 +63,7 @@ Terraform will perform the following actions:
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-  + allowedcidrs_list = {
+  + allowedcidr_list = {
       + cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
       + data            = [
           + {
@@ -120,8 +120,8 @@ $ terraform apply
 │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
 │ published releases.
 ╵
-data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
-data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 0s
+data.capella_app_services_cidr.existing_allowedcidr: Reading...
+data.capella_app_services_cidr.existing_allowedcidr: Read complete after 0s
 
 Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
   + create
@@ -149,7 +149,7 @@ Terraform will perform the following actions:
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-  + allowedcidrs_list = {
+  + allowedcidr_list = {
       + cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
       + app_service_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
       + data            = [
@@ -199,7 +199,7 @@ Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
 Outputs:
 
-allowedcidrs_list = {
+allowedcidr_list = {
   "cluster_id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
   "data" = tolist([
     {
@@ -276,7 +276,7 @@ Command: `terraform state list`
 Sample Output:
 ```
 $ terraform state list
-data.couchbase-capella_app_services_cidrs.existing_allowedcidrs
+data.couchbase-capella_app_services_cidr.existing_allowedcidr
 couchbase-capella_app_services_cidr.new_allowedcidr
 ```
 
@@ -305,11 +305,11 @@ Sample Output:
 ```
 $ terraform import couchbase-capella_app_services_cidr.new_allowedcidr id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2,cluster_id=f499a9e6-e5a1-4f3e-95a7-941a41d046e6,project_id=958ad6b5-272d-49f0-babd-cc98c6b54a81,organization_id=0783f698-ac58-4018-84a3-31c3b6ef785d
 capella_app_services_cidr.new_allowedcidr: Importing from ID "id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2,cluster_id=f499a9e6-e5a1-4f3e-95a7-941a41d046e6,project_id=958ad6b5-272d-49f0-babd-cc98c6b54a81,organization_id=0783f698-ac58-4018-84a3-31c3b6ef785d"...
-data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
+data.capella_app_services_cidr.existing_allowedcidr: Reading...
 capella_app_services_cidr.new_allowedcidr: Import prepared!
   Prepared capella_app_services_cidr for import
 capella_app_services_cidr.new_allowedcidr: Refreshing state... [id=id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2,cluster_id=f499a9e6-e5a1-4f3e-95a7-941a41d046e6,project_id=958ad6b5-272d-49f0-babd-cc98c6b54a81,organization_id=0783f698-ac58-4018-84a3-31c3b6ef785d]
-data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 1s
+data.capella_app_services_cidr.existing_allowedcidr: Read complete after 1s
 
 Import successful!
 
@@ -339,9 +339,9 @@ $ terraform plan
 │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
 │ published releases.
 ╵
-data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
+data.capella_app_services_cidr.existing_allowedcidr: Reading...
 capella_app_services_cidr.new_allowedcidr: Refreshing state... [id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2]
-data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 1s
+data.capella_app_services_cidr.existing_allowedcidr: Read complete after 1s
 
 No changes. Your infrastructure matches the configuration.
 
@@ -365,9 +365,9 @@ $ terraform apply -var comment="updated allowedcidr comment"
 │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
 │ published releases.
 ╵
-data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
+data.capella_app_services_cidr.existing_allowedcidr: Reading...
 capella_app_services_cidr.new_allowedcidr: Refreshing state... [id=854cbdf0-8ae3-4a42-9227-59c52a5ab4f2]
-data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 1s
+data.capella_app_services_cidr.existing_allowedcidr: Read complete after 1s
 
 Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
 -/+ destroy and then create replacement
@@ -419,7 +419,7 @@ Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
 
 Outputs:
 
-allowedcidrs_list = {
+allowedcidr_list = {
   "cluster_id" = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
   "data" = tolist([
     {
@@ -496,9 +496,9 @@ $ terraform destroy
 │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
 │ published releases.
 ╵
-data.capella_app_services_cidrs.existing_allowedcidrs: Reading...
+data.capella_app_services_cidr.existing_allowedcidr: Reading...
 capella_app_services_cidr.new_allowedcidr: Refreshing state... [id=358387f9-9780-4419-9ca6-b5e8a3b457dc]
-data.capella_app_services_cidrs.existing_allowedcidrs: Read complete after 0s
+data.capella_app_services_cidr.existing_allowedcidr: Read complete after 0s
 
 Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
   - destroy
@@ -526,7 +526,7 @@ Terraform will perform the following actions:
 Plan: 0 to add, 0 to change, 1 to destroy.
 
 Changes to Outputs:
-  - allowedcidrs_list = {
+  - allowedcidr_list = {
       - cluster_id      = "f499a9e6-e5a1-4f3e-95a7-941a41d046e6"
       - data            = [
           - {

--- a/examples/app_services_cidr/create_allowlist.tf
+++ b/examples/app_services_cidr/create_allowlist.tf
@@ -1,0 +1,17 @@
+output "new_allowlist" {
+  value = couchbase-capella_app_services_cidr.new_allowlist
+}
+
+output "allowlist_id" {
+  value = couchbase-capella_app_services_cidr.new_allowlist.id
+}
+
+resource "couchbase-capella_app_services_cidr" "new_allowlist" {
+  organization_id = var.organization_id
+  project_id      = var.project_id
+  cluster_id      = var.cluster_id
+  app_service_id   = var.app_service_id
+  cidr            = var.app_services_cidr.cidr
+  comment         = var.app_services_cidr.comment
+  expires_at      = var.app_services_cidr.expires_at
+} 

--- a/examples/app_services_cidr/list_allowlists.tf
+++ b/examples/app_services_cidr/list_allowlists.tf
@@ -1,0 +1,9 @@
+output "allowlists_list" {
+  value = data.couchbase-capella_app_services_cidr.existing_allowlists
+}
+
+data "couchbase-capella_app_services_cidr" "existing_allowlists" {
+  organization_id = var.organization_id
+  project_id      = var.project_id
+  cluster_id      = var.cluster_id
+}

--- a/examples/app_services_cidr/main.tf
+++ b/examples/app_services_cidr/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    couchbase-capella = {
+      source = "couchbasecloud/couchbase-capella"
+    }
+  }
+}
+
+provider "couchbase-capella" {
+  authentication_token = var.auth_token
+}

--- a/examples/app_services_cidr/terraform.template.tfvars
+++ b/examples/app_services_cidr/terraform.template.tfvars
@@ -1,0 +1,10 @@
+auth_token      = "<v4-api-key-secret>"
+organization_id = "<organization_id>"
+project_id      = "<project_id>"
+cluster_id      = "<cluster_id>"
+app_service_id = "<app_service_id>"
+app_services_cidr = {
+  cidr       = "10.0.0.0/16"
+  comment    = "Allow access from a public IP"
+  expires_at = "2023-12-30T23:59:59.465Z"
+}

--- a/examples/app_services_cidr/variables.tf
+++ b/examples/app_services_cidr/variables.tf
@@ -1,0 +1,30 @@
+variable "organization_id" {
+  description = "Capella Organization ID"
+}
+
+variable "project_id" {
+  description = "Capella Project ID"
+}
+
+variable "cluster_id" {
+  description = "Capella Cluster ID"
+}
+
+variable "app_service_id" {
+  description = "Capella App Service ID"
+}
+
+variable "auth_token" {
+  description = "Authentication API Key"
+  sensitive   = true
+}
+
+variable "app_services_cidr" {
+  description = "Allowed CIDR configuration options"
+
+  type = object({
+    cidr       = string
+    comment    = optional(string)
+    expires_at = optional(string)
+  })
+}

--- a/examples/resources/couchbase-capella_app_services_cidr/import.sh
+++ b/examples/resources/couchbase-capella_app_services_cidr/import.sh
@@ -1,0 +1,1 @@
+terraform import couchbase-capella_app_services_cidr.new_app_services_cidr id=<appservice_id>,cluster_id=<cluster_id>,project_id=<project_id>,organization_id=<organization_id>,appservice_id=<appservice_id>

--- a/examples/resources/couchbase-capella_app_services_cidr/resource.tf
+++ b/examples/resources/couchbase-capella_app_services_cidr/resource.tf
@@ -1,0 +1,9 @@
+resource "couchbase-capella_app_services_cidr" "new_app_services_cidr"{
+  organization_id = "<organization_id>"
+  project_id      = "<project_id>"
+  cluster_id      = "<cluster_id>"
+  app_service_id = "<app_service_id>"
+  cidr            = "10.0.0.0/16"
+  comment         = "Allow access from a public IP"
+  expires_at      = "2023-12-30T23:59:59.465Z"
+}

--- a/internal/api/app_services_cidr.go
+++ b/internal/api/app_services_cidr.go
@@ -7,3 +7,19 @@ type CreateAllowedCIDRRequest struct {
 
 	ExpiresAt string `json:"expiresAt"`
 }
+
+type AppServiceAllowedCIDRResponse struct {
+	Id string `json:"id"`
+
+	Cidr string `json:"cidr"`
+
+	Comment string `json:"comment,omitempty"`
+
+	ExpiresAt string `json:"expiresAt"`
+
+	Status string `json:"status"`
+
+	Type string `json:"type"`
+
+	Audit CouchbaseAuditData `json:"audit"`
+}

--- a/internal/api/app_services_cidr.go
+++ b/internal/api/app_services_cidr.go
@@ -1,0 +1,9 @@
+package api
+
+type CreateAllowedCIDRRequest struct {
+	Cidr string `json:"cidr"`
+
+	Comment string `json:"comment,omitempty"`
+
+	ExpiresAt string `json:"expiresAt"`
+}

--- a/internal/api/app_services_cidr.go
+++ b/internal/api/app_services_cidr.go
@@ -23,3 +23,6 @@ type AppServiceAllowedCIDRResponse struct {
 
 	Audit CouchbaseAuditData `json:"audit"`
 }
+type ListAppServiceAllowedCIDRResponse struct {
+	Data []AppServiceAllowedCIDRResponse `json:"data"`
+}

--- a/internal/datasources/app_services_cidr.go
+++ b/internal/datasources/app_services_cidr.go
@@ -28,3 +28,7 @@ func (a *AppServiceCidrs) Metadata(
 func (a *AppServiceCidrs) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	// TODO
 }
+
+func (a *AppServiceCidrs) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// TODO
+}

--- a/internal/datasources/app_services_cidr.go
+++ b/internal/datasources/app_services_cidr.go
@@ -7,6 +7,7 @@ import (
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"net/http"
 )
 
@@ -67,10 +68,10 @@ func (a *AppServiceCidrs) Schema(_ context.Context, _ datasource.SchemaRequest, 
 
 // listAllowLists executes calls to the list allowlist endpoint. It handles pagination and
 // returns a slice of individual allowlists responses retrieved from multiple pages.
-func (d *AllowLists) listAllowedCIDRs(ctx context.Context, organizationId, projectId, clusterId, appServiceId string) ([]api.GetAllowListResponse, error) {
+func (a *AppServiceCidrs) listAllowedCIDRs(ctx context.Context, organizationId, projectId, clusterId, appServiceId string) ([]api.AppServiceAllowedCIDRResponse, error) {
 	url := fmt.Sprintf(
 		"%s/v4/organizations/%s/projects/%s/clusters/%s/appservices/%s/allowedcidrs",
-		d.HostURL,
+		a.HostURL,
 		organizationId,
 		projectId,
 		clusterId,
@@ -78,11 +79,86 @@ func (d *AllowLists) listAllowedCIDRs(ctx context.Context, organizationId, proje
 	)
 
 	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
-	return api.GetPaginated[[]api.GetAllowListResponse](ctx, d.Client, d.Token, cfg, api.SortById)
+	return api.GetPaginated[[]api.AppServiceAllowedCIDRResponse](ctx, a.Client, a.Token, cfg, api.SortById)
 }
 
 func (a *AppServiceCidrs) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	// TODO
+	var state providerschema.AppServiceCIDRs
+	diags := req.Config.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate state is not empty
+	organizationId, projectId, clusterId, appServiceId, err := state.Validate()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Capella AllowLists",
+			"Could not read allow lists in cluster "+state.ClusterId.String()+": "+err.Error(),
+		)
+		return
+	}
+
+	response, err := a.listAllowedCIDRs(ctx, organizationId, projectId, clusterId, appServiceId)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Capella App Services",
+			fmt.Sprintf("Could not read app services in organization %s, unexpected error: %s", organizationId, api.ParseError(err)),
+		)
+		return
+	}
+
+	state = a.mapResponseBody(response, &state)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading allowlist",
+			"Could not read allowlist, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	// Set state
+	diags = resp.State.Set(ctx, &state)
+
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// mapResponseBody is used to map the response body from a call to
+// listAllowlists to the allowlists schema that will be used by terraform.
+func (a *AppServiceCidrs) mapResponseBody(
+	allowLists []api.AppServiceAllowedCIDRResponse,
+	state *providerschema.AppServiceCIDRs,
+) providerschema.AppServiceCIDRs {
+	state = &providerschema.AppServiceCIDRs{
+		OrganizationId: types.StringValue(state.OrganizationId.ValueString()),
+		ProjectId:      types.StringValue(state.ProjectId.ValueString()),
+		ClusterId:      types.StringValue(state.ClusterId.ValueString()),
+	}
+	for _, allowList := range allowLists {
+		allowListState := providerschema.AppServiceCIDRData{
+			Id:   types.StringValue(allowList.Id),
+			Cidr: types.StringValue(allowList.Cidr),
+			Audit: providerschema.CouchbaseAuditData{
+				CreatedAt:  types.StringValue(allowList.Audit.CreatedAt.String()),
+				CreatedBy:  types.StringValue(allowList.Audit.CreatedBy),
+				ModifiedAt: types.StringValue(allowList.Audit.ModifiedAt.String()),
+				ModifiedBy: types.StringValue(allowList.Audit.ModifiedBy),
+				Version:    types.Int64Value(int64(allowList.Audit.Version)),
+			},
+		}
+		if allowList.Comment != "" {
+			allowListState.Comment = types.StringValue(allowList.Comment)
+		}
+		if allowList.ExpiresAt != "" {
+			allowListState.ExpiresAt = types.StringValue(allowList.ExpiresAt)
+		}
+		state.Data = append(state.Data, allowListState)
+	}
+	return *state
 }
 
 func (a *AppServiceCidrs) Configure(

--- a/internal/datasources/app_services_cidr.go
+++ b/internal/datasources/app_services_cidr.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	_ datasource.DataSource = (*AppServiceCidrs)(nil)
+	_ datasource.DataSource              = (*AppServiceCidrs)(nil)
 	_ datasource.DataSourceWithConfigure = (*AppServiceCidrs)(nil)
 )
 
@@ -23,4 +23,8 @@ func (a *AppServiceCidrs) Metadata(
 	_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse,
 ) {
 	resp.TypeName = req.ProviderTypeName + "_app_service_cidrs"
+}
+
+func (a *AppServiceCidrs) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	// TODO
 }

--- a/internal/datasources/app_services_cidr.go
+++ b/internal/datasources/app_services_cidr.go
@@ -1,12 +1,13 @@
 package datasources
 
 import (
+	"context"
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 )
 
 var (
-	_ datasource.DataSource              = (*AppServiceCidrs)(nil)
+	_ datasource.DataSource = (*AppServiceCidrs)(nil)
 	_ datasource.DataSourceWithConfigure = (*AppServiceCidrs)(nil)
 )
 
@@ -16,4 +17,10 @@ type AppServiceCidrs struct {
 
 func NewAppServiceCidrs() datasource.DataSource {
 	return &AppServiceCidrs{}
+}
+
+func (a *AppServiceCidrs) Metadata(
+	_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse,
+) {
+	resp.TypeName = req.ProviderTypeName + "_app_service_cidrs"
 }

--- a/internal/datasources/app_services_cidr.go
+++ b/internal/datasources/app_services_cidr.go
@@ -1,0 +1,19 @@
+package datasources
+
+import (
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var (
+	_ datasource.DataSource              = (*AppServiceCidrs)(nil)
+	_ datasource.DataSourceWithConfigure = (*AppServiceCidrs)(nil)
+)
+
+type AppServiceCidrs struct {
+	*providerschema.Data
+}
+
+func NewAppServiceCidrs() datasource.DataSource {
+	return &AppServiceCidrs{}
+}

--- a/internal/datasources/app_services_cidr.go
+++ b/internal/datasources/app_services_cidr.go
@@ -2,8 +2,12 @@ package datasources
 
 import (
 	"context"
+	"fmt"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"net/http"
 )
 
 var (
@@ -26,7 +30,55 @@ func (a *AppServiceCidrs) Metadata(
 }
 
 func (a *AppServiceCidrs) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	// TODO
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Retrieves the allowlists details for a Capella App Service.",
+		Attributes: map[string]schema.Attribute{
+			"data": schema.ListNestedAttribute{
+				MarkdownDescription: "The list of allowed CIDRs on an App Service. ",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The ID of the allowed CIDR.",
+						},
+						"organization_id": computedStringAttribute,
+						"project_id":      computedStringAttribute,
+						"cluster_id":      computedStringAttribute,
+						"cidr": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The trusted CIDR to allow the database connections from.",
+						},
+						"comment": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The trusted CIDR to allow the database connections from.",
+						},
+						"expires_at": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "An RFC3339 timestamp determining when the allowed CIDR will expire. If this field is empty/omitted then the allowed CIDR is permanent and will never automatically expire.",
+						},
+						"audit": computedAuditAttribute,
+					},
+				},
+			},
+		},
+	}
+}
+
+// listAllowLists executes calls to the list allowlist endpoint. It handles pagination and
+// returns a slice of individual allowlists responses retrieved from multiple pages.
+func (d *AllowLists) listAllowedCIDRs(ctx context.Context, organizationId, projectId, clusterId, appServiceId string) ([]api.GetAllowListResponse, error) {
+	url := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/appservices/%s/allowedcidrs",
+		d.HostURL,
+		organizationId,
+		projectId,
+		clusterId,
+		appServiceId,
+	)
+
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	return api.GetPaginated[[]api.GetAllowListResponse](ctx, d.Client, d.Token, cfg, api.SortById)
 }
 
 func (a *AppServiceCidrs) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/internal/datasources/app_services_cidr.go
+++ b/internal/datasources/app_services_cidr.go
@@ -32,3 +32,9 @@ func (a *AppServiceCidrs) Schema(_ context.Context, _ datasource.SchemaRequest, 
 func (a *AppServiceCidrs) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	// TODO
 }
+
+func (a *AppServiceCidrs) Configure(
+	_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse,
+) {
+	// TODO
+}

--- a/internal/datasources/app_services_cidr.go
+++ b/internal/datasources/app_services_cidr.go
@@ -27,12 +27,12 @@ func NewAppServiceCidrs() datasource.DataSource {
 func (a *AppServiceCidrs) Metadata(
 	_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse,
 ) {
-	resp.TypeName = req.ProviderTypeName + "_app_service_cidrs"
+	resp.TypeName = req.ProviderTypeName + "_app_services_cidr"
 }
 
 func (a *AppServiceCidrs) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Retrieves the allowlists details for a Capella App Service.",
+		MarkdownDescription: "Retrieves the allowed CIDRs for a Capella App Service.",
 		Attributes: map[string]schema.Attribute{
 			"data": schema.ListNestedAttribute{
 				MarkdownDescription: "The list of allowed CIDRs on an App Service. ",
@@ -164,5 +164,18 @@ func (a *AppServiceCidrs) mapResponseBody(
 func (a *AppServiceCidrs) Configure(
 	_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse,
 ) {
-	// TODO
+	if req.ProviderData == nil {
+		return
+	}
+
+	data, ok := req.ProviderData.(*providerschema.Data)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *ProviderSourceData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+	a.Data = data
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -24,6 +24,9 @@ var (
 	// ErrClusterIdMissing is returned when an expected Cluster Id was not found after an import.
 	ErrClusterIdMissing = errors.New("cluster ID is missing or was passed incorrectly, please check provider documentation for syntax")
 
+	// ErrAppServiceIdMissing is returned when an expected App Service Id was not found after an import.
+	ErrAppServiceIdMissing = errors.New("app service ID is missing or was passed incorrectly, please check provider documentation for syntax")
+
 	// ErrPeerIdMissing is returned when an expected Peer Id was not found after an import.
 	ErrPeerIdMissing = errors.New("peer ID is missing or was passed incorrectly, please check provider documentation for syntax")
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -69,7 +69,9 @@ func (p *capellaProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 }
 
 // Configure configures the Capella client.
-func (p *capellaProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+func (p *capellaProvider) Configure(
+	ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse,
+) {
 	tflog.Info(ctx, "Configuring the Capella Client")
 
 	// Retrieve provider data from configuration
@@ -205,6 +207,7 @@ func (p *capellaProvider) DataSources(_ context.Context) []func() datasource.Dat
 		datasources.NewGsiMonitor,
 		datasources.NewFreeTierBuckets,
 		datasources.NewFreeTierClusters,
+		datasources.NewAppServiceCidrs,
 	}
 }
 
@@ -238,5 +241,6 @@ func (p *capellaProvider) Resources(_ context.Context) []func() resource.Resourc
 		resources.NewFreeTierBucket,
 		resources.NewFreeTierCluster,
 		resources.NewFreeTierAppService,
+		resources.NewAppServiceCidr,
 	}
 }

--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -33,8 +33,7 @@ func (a *AppServiceCidr) Metadata(_ context.Context, req resource.MetadataReques
 }
 
 func (a *AppServiceCidr) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-
-	// TODO
+	resp.Schema = AllowedCIDRsSchema()
 }
 
 func (a *AppServiceCidr) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -236,8 +235,8 @@ func (a *AppServiceCidr) Read(ctx context.Context, req resource.ReadRequest, res
 	organizationId, projectId, clusterId, appServiceId, allowedCIDRId, err := state.Validate()
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error Reading Capella AllowList",
-			"Could not read Capella allow list: "+err.Error(),
+			"Error Reading App Service Allowed CIDR",
+			"Could not read App Service Allowed CIDR: "+err.Error(),
 		)
 		return
 	}
@@ -252,8 +251,8 @@ func (a *AppServiceCidr) Read(ctx context.Context, req resource.ReadRequest, res
 			return
 		}
 		resp.Diagnostics.AddError(
-			"Error Reading Capella AllowList",
-			"Could not read Capella allowListID "+allowedCIDRId+": "+errString,
+			"Error Reading App Service Allowed CIDR",
+			"Could not read App Service Allowed CIDR "+allowedCIDRId+": "+errString,
 		)
 		return
 	}
@@ -327,8 +326,8 @@ func (a *AppServiceCidr) Delete(ctx context.Context, req resource.DeleteRequest,
 			return
 		}
 		resp.Diagnostics.AddError(
-			"Error Reading Capella AllowList",
-			"Could not read Capella allowListID "+allowedCIDRId+": "+errString,
+			"Error Reading App Service Allowed CIDR",
+			"Could not read App Service Allowed CIDR "+allowedCIDRId+": "+errString,
 		)
 		return
 	}

--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
@@ -27,4 +28,22 @@ func (a *AppServiceCidr) Metadata(_ context.Context, req resource.MetadataReques
 func (a *AppServiceCidr) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 
 	// TODO
+}
+
+func (a *AppServiceCidr) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	data, ok := req.ProviderData.(*providerschema.Data)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *ProviderSourceData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	a.Data = data
 }

--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -108,3 +108,12 @@ func (a *AppServiceCidr) Create(ctx context.Context, req resource.CreateRequest,
 func (a *AppServiceCidr) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	// TODO
 }
+
+func (a *AppServiceCidr) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Couchbase Capella's v4 does not support a PUT endpoint for app services cidr.
+	// This resource can only be created, read and deleted.
+	//
+	// Note: In this situation, terraform apply will default to deleting and executing a new create.
+	// The update implementation should simply be left empty.
+	// https://developer.hashicorp.com/terraform/plugin/framework/resources/update
+}

--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -25,7 +25,7 @@ func NewAppServiceCidr() resource.Resource {
 }
 
 func (a *AppServiceCidr) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_project"
+	resp.TypeName = req.ProviderTypeName + "_app_services_cidr"
 }
 
 func (a *AppServiceCidr) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -99,6 +99,8 @@ func (a *AppServiceCidr) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	// TODO set computed attributes to null
+
 	// TODO get latest status of the CIDR
 
 	// TODO save state
@@ -110,12 +112,7 @@ func (a *AppServiceCidr) Read(ctx context.Context, req resource.ReadRequest, res
 }
 
 func (a *AppServiceCidr) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// Couchbase Capella's v4 does not support a PUT endpoint for app services cidr.
-	// This resource can only be created, read and deleted.
-	//
-	// Note: In this situation, terraform apply will default to deleting and executing a new create.
-	// The update implementation should simply be left empty.
-	// https://developer.hashicorp.com/terraform/plugin/framework/resources/update
+	// TODO return error
 }
 
 func (a *AppServiceCidr) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -121,3 +121,9 @@ func (a *AppServiceCidr) Update(ctx context.Context, req resource.UpdateRequest,
 func (a *AppServiceCidr) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// TODO
 }
+
+func (a *AppServiceCidr) ImportState(
+	ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse,
+) {
+	// TODO
+}

--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -117,3 +117,7 @@ func (a *AppServiceCidr) Update(ctx context.Context, req resource.UpdateRequest,
 	// The update implementation should simply be left empty.
 	// https://developer.hashicorp.com/terraform/plugin/framework/resources/update
 }
+
+func (a *AppServiceCidr) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// TODO
+}

--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -104,3 +104,7 @@ func (a *AppServiceCidr) Create(ctx context.Context, req resource.CreateRequest,
 	// TODO save state
 
 }
+
+func (a *AppServiceCidr) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// TODO
+}

--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -1,0 +1,20 @@
+package resources
+
+import (
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+var (
+	_ resource.Resource                = (*AppServiceCidr)(nil)
+	_ resource.ResourceWithConfigure   = (*AppServiceCidr)(nil)
+	_ resource.ResourceWithImportState = (*AppServiceCidr)(nil)
+)
+
+type AppServiceCidr struct {
+	*providerschema.Data
+}
+
+func NewAppServiceCidr() resource.Resource {
+	return &AppServiceCidr{}
+}

--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"context"
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
@@ -17,4 +18,8 @@ type AppServiceCidr struct {
 
 func NewAppServiceCidr() resource.Resource {
 	return &AppServiceCidr{}
+}
+
+func (a *AppServiceCidr) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_project"
 }

--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -23,3 +23,8 @@ func NewAppServiceCidr() resource.Resource {
 func (a *AppServiceCidr) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_project"
 }
+
+func (a *AppServiceCidr) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+
+	// TODO
+}

--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -145,7 +145,7 @@ func (a *AppServiceCidr) Create(ctx context.Context, req resource.CreateRequest,
 // with the specified plan and ID. It marks all computed fields as null.
 func initializeAllowedCIDRWithPlanAndId(plan providerschema.AppServiceCIDR, id string) providerschema.AppServiceCIDR {
 	plan.Id = types.StringValue(id)
-	plan.Audit = types.Object{}
+	plan.Audit = types.ObjectNull(providerschema.CouchbaseAuditData{}.AttributeTypes())
 	if plan.Comment.IsNull() || plan.Comment.IsUnknown() {
 		plan.Comment = types.StringNull()
 	}

--- a/internal/resources/app_service_cidr_schema.go
+++ b/internal/resources/app_service_cidr_schema.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+func AllowedCIDRsSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages the IP addresses allowed to connect to App Services on Couchbase Capella.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "The ID of the allowed CIDR.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"organization_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The ID of the Capella organization.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"project_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The ID of the Capella project.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"cluster_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The ID of the Capella cluster.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"app_service_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The ID of the Capella App Service.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"cidr": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The trusted CIDR to allow the database connections from.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"comment": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "A short description of the allowed CIDR.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"expires_at": schema.StringAttribute{
+				Optional: true,
+				MarkdownDescription: "An RFC3339 timestamp determining when the allowed CIDR will expire. " +
+					"If this field is omitted then the allowed CIDR is permanent and will never automatically expire.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"audit": computedAuditAttribute(),
+		},
+	}
+}

--- a/internal/schema/app_service_cidr.go
+++ b/internal/schema/app_service_cidr.go
@@ -1,7 +1,11 @@
 package schema
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import (
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
 
+// AppServiceCIDRs defines the attributes for an individual App service allowed CIDR.
 type AppServiceCIDR struct {
 	OrganizationId types.String `tfsdk:"organization_id"`
 
@@ -12,14 +16,60 @@ type AppServiceCIDR struct {
 	AppServiceId types.String `tfsdk:"app_service_id"`
 
 	Cidr types.String `tfsdk:"cidr"`
-
+	// Id is a GUID4 identifier of the App service CIDR.
 	Comment types.String `tfsdk:"comment"`
-
+	// ExpiresAt is an RFC3339 timestamp determining when the allowed CIDR should expire.
 	ExpiresAt types.String `tfsdk:"expires_at"`
-
+	// Audit contains the audit information for the App service CIDR.
 	Audit types.Object `tfsdk:"audit"`
+	// Id is the ID is the unique UUID generated when an allowed cidr is created.
+	Id types.String `tfsdk:"id"`
 }
 
-// TODO
+// AppServiceCIDRs defines the attributes for an individual App service allowed CIDR.
+type AppServiceCIDRData struct {
+	// Id is the ID is the unique UUID generated when an allowed cidr is created.
+	Id types.String `tfsdk:"id"`
+
+	Cidr types.String `tfsdk:"cidr"`
+	// Id is a GUID4 identifier of the App service CIDR.
+	Comment types.String `tfsdk:"comment"`
+	// ExpiresAt is an RFC3339 timestamp determining when the allowed CIDR should expire.
+	ExpiresAt types.String `tfsdk:"expires_at"`
+	// Audit contains the audit information for the App service CIDR.
+	Audit CouchbaseAuditData `tfsdk:"audit"`
+}
+
+// AppServiceCIDRs defines the attributes as received from the
+// V4 Capella Public API when asked to list App service allowed CIDRs.
 type AppServiceCIDRs struct {
+	// OrganizationId is the organizationId of the capella.
+	OrganizationId types.String `tfsdk:"organization_id"`
+
+	// ProjectId is the GUID4 identifier for the project.
+	ProjectId types.String `tfsdk:"project_id"`
+
+	// ClusterId is the GUID4 identifier for the Cluster.
+	ClusterId types.String `tfsdk:"cluster_id"`
+
+	// AppServiceId is the GUID4 identifier for the App Service.
+	AppServiceId types.String `tfsdk:"app_service_id"`
+
+	// Data contains the list of resources.
+	Data []AppServiceCIDRData `tfsdk:"data"`
+}
+
+// Validate is used to verify that all the fields in the datasource
+// have been populated.
+func (a *AppServiceCIDRs) Validate() (clusterId, projectId, organizationId, appserviceId string, err error) {
+	if a.OrganizationId.IsNull() {
+		return "", "", "", "", errors.ErrOrganizationIdMissing
+	}
+	if a.ProjectId.IsNull() {
+		return "", "", "", "", errors.ErrProjectIdMissing
+	}
+	if a.ClusterId.IsNull() {
+		return "", "", "", "", errors.ErrClusterIdMissing
+	}
+	return a.ClusterId.ValueString(), a.ProjectId.ValueString(), a.OrganizationId.ValueString(), a.AppServiceId.ValueString(), nil
 }

--- a/internal/schema/app_service_cidr.go
+++ b/internal/schema/app_service_cidr.go
@@ -1,0 +1,21 @@
+package schema
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+type AppServiceCIDR struct {
+	OrganizationId types.String `tfsdk:"organization_id"`
+
+	ProjectId types.String `tfsdk:"project_id"`
+
+	ClusterId types.String `tfsdk:"cluster_id"`
+
+	AppServiceId types.String `tfsdk:"app_service_id"`
+
+	Cidr types.String `tfsdk:"cidr"`
+
+	Comment types.String `tfsdk:"comment"`
+
+	ExpiresAt types.String `tfsdk:"expires_at"`
+
+	Audit types.Object `tfsdk:"audit"`
+}

--- a/internal/schema/app_service_cidr.go
+++ b/internal/schema/app_service_cidr.go
@@ -1,8 +1,9 @@
 package schema
 
 import (
-	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
 )
 
 // AppServiceCIDRs defines the attributes for an individual App service allowed CIDR.
@@ -20,8 +21,8 @@ type AppServiceCIDR struct {
 	Comment types.String `tfsdk:"comment"`
 	// ExpiresAt is an RFC3339 timestamp determining when the allowed CIDR should expire.
 	ExpiresAt types.String `tfsdk:"expires_at"`
-	// Audit contains the audit information for the App service CIDR.
-	Audit CouchbaseAuditData `tfsdk:"audit"`
+	// Audit contains the audit information for the App service CIDR. It is of types.Object type to avoid conversion error for a nested field.
+	Audit types.Object `tfsdk:"audit"`
 	// Id is the ID is the unique UUID generated when an allowed cidr is created.
 	Id types.String `tfsdk:"id"`
 }
@@ -36,8 +37,8 @@ type AppServiceCIDRData struct {
 	Comment types.String `tfsdk:"comment"`
 	// ExpiresAt is an RFC3339 timestamp determining when the allowed CIDR should expire.
 	ExpiresAt types.String `tfsdk:"expires_at"`
-	// Audit contains the audit information for the App service CIDR.
-	Audit CouchbaseAuditData `tfsdk:"audit"`
+	// Audit contains the audit information for the App service CIDR. It is of types.Object type to avoid conversion error for a nested field.
+	Audit types.Object `tfsdk:"audit"`
 }
 
 // AppServiceCIDRs defines the attributes as received from the
@@ -76,7 +77,7 @@ func (a *AppServiceCIDRs) Validate() (clusterId, projectId, organizationId, apps
 
 // Validate is used to verify that all the fields in the datasource
 // have been populated.
-func (a *AppServiceCIDR) Validate() (clusterId, projectId, organizationId, appserviceId, allowedCIDRId string, err error) {
+func (a *AppServiceCIDR) Validate() (organizationId, projectId, clusterId, appserviceId, allowedCIDRId string, err error) {
 	if a.OrganizationId.IsNull() {
 		return "", "", "", "", "", errors.ErrOrganizationIdMissing
 	}
@@ -92,5 +93,5 @@ func (a *AppServiceCIDR) Validate() (clusterId, projectId, organizationId, appse
 	if a.Id.IsNull() {
 		return "", "", "", "", "", errors.ErrAllowListIdMissing
 	}
-	return a.ClusterId.ValueString(), a.ProjectId.ValueString(), a.OrganizationId.ValueString(), a.AppServiceId.ValueString(), a.Id.ValueString(), nil
+	return a.OrganizationId.ValueString(), a.ProjectId.ValueString(), a.ClusterId.ValueString(), a.AppServiceId.ValueString(), a.Id.ValueString(), nil
 }

--- a/internal/schema/app_service_cidr.go
+++ b/internal/schema/app_service_cidr.go
@@ -19,3 +19,7 @@ type AppServiceCIDR struct {
 
 	Audit types.Object `tfsdk:"audit"`
 }
+
+// TODO
+type AppServiceCIDRs struct {
+}

--- a/internal/schema/app_service_cidr.go
+++ b/internal/schema/app_service_cidr.go
@@ -21,7 +21,7 @@ type AppServiceCIDR struct {
 	// ExpiresAt is an RFC3339 timestamp determining when the allowed CIDR should expire.
 	ExpiresAt types.String `tfsdk:"expires_at"`
 	// Audit contains the audit information for the App service CIDR.
-	Audit types.Object `tfsdk:"audit"`
+	Audit CouchbaseAuditData `tfsdk:"audit"`
 	// Id is the ID is the unique UUID generated when an allowed cidr is created.
 	Id types.String `tfsdk:"id"`
 }
@@ -72,4 +72,25 @@ func (a *AppServiceCIDRs) Validate() (clusterId, projectId, organizationId, apps
 		return "", "", "", "", errors.ErrClusterIdMissing
 	}
 	return a.ClusterId.ValueString(), a.ProjectId.ValueString(), a.OrganizationId.ValueString(), a.AppServiceId.ValueString(), nil
+}
+
+// Validate is used to verify that all the fields in the datasource
+// have been populated.
+func (a *AppServiceCIDR) Validate() (clusterId, projectId, organizationId, appserviceId, allowedCIDRId string, err error) {
+	if a.OrganizationId.IsNull() {
+		return "", "", "", "", "", errors.ErrOrganizationIdMissing
+	}
+	if a.ProjectId.IsNull() {
+		return "", "", "", "", "", errors.ErrProjectIdMissing
+	}
+	if a.ClusterId.IsNull() {
+		return "", "", "", "", "", errors.ErrClusterIdMissing
+	}
+	if a.AppServiceId.IsNull() {
+		return "", "", "", "", "", errors.ErrAppServiceIdMissing
+	}
+	if a.Id.IsNull() {
+		return "", "", "", "", "", errors.ErrAllowListIdMissing
+	}
+	return a.ClusterId.ValueString(), a.ProjectId.ValueString(), a.OrganizationId.ValueString(), a.AppServiceId.ValueString(), a.Id.ValueString(), nil
 }


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-102981

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
<!-- What does this change do? Why is it needed? -->

Add App Services Allowed CIDRS resource and datasource

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Required Checklist:

- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if required)
- [ ] I have run make fmt and formatted my code
- [ ] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments

Validation

 $ terraform plan                                
```
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Applications/gh_2.14.6_macOS_amd64/bin/terraform-provider-couchbase-capella/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_app_services_cidr.test will be created
  + resource "couchbase-capella_app_services_cidr" "test" {
      + app_service_id  = "043504df-5243-4b22-9857-8d3c0c9ea5b9"
      + audit           = (known after apply)
      + cidr            = "192.10.1.1/0"
      + cluster_id      = "f85211cc-7dd0-45a7-af3b-9f5043756edc"
      + comment         = "This CIDR allows access from all IP addresses for the new project."
      + expires_at      = "2025-12-31T23:59:59Z"
      + id              = (known after apply)
      + organization_id = "6af08c0a-8cab-4c1c-b257-b521575c16d0"
      + project_id      = "c1fade1a-9f27-4a3c-af73-d1b2301890e3"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + new_allowedcidr = {
      + app_service_id  = "043504df-5243-4b22-9857-8d3c0c9ea5b9"
      + audit           = (known after apply)
      + cidr            = "192.10.1.1/0"
      + cluster_id      = "f85211cc-7dd0-45a7-af3b-9f5043756edc"
      + comment         = "This CIDR allows access from all IP addresses for the new project."
      + expires_at      = "2025-12-31T23:59:59Z"
      + id              = (known after apply)
      + organization_id = "6af08c0a-8cab-4c1c-b257-b521575c16d0"
      + project_id      = "c1fade1a-9f27-4a3c-af73-d1b2301890e3"
    }

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.


```

 $ terraform apply                                                                                                                                                                                                                        ```
1 ↵
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Applications/gh_2.14.6_macOS_amd64/bin/terraform-provider-couchbase-capella/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_app_services_cidr.test will be created
  + resource "couchbase-capella_app_services_cidr" "test" {
      + app_service_id  = "043504df-5243-4b22-9857-8d3c0c9ea5b9"
      + audit           = (known after apply)
      + cidr            = "192.10.1.1/0"
      + cluster_id      = "f85211cc-7dd0-45a7-af3b-9f5043756edc"
      + comment         = "This CIDR allows access from all IP addresses for the new project."
      + expires_at      = "2025-12-31T23:59:59Z"
      + id              = (known after apply)
      + organization_id = "6af08c0a-8cab-4c1c-b257-b521575c16d0"
      + project_id      = "c1fade1a-9f27-4a3c-af73-d1b2301890e3"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + new_allowedcidr = {
      + app_service_id  = "043504df-5243-4b22-9857-8d3c0c9ea5b9"
      + audit           = (known after apply)
      + cidr            = "192.10.1.1/0"
      + cluster_id      = "f85211cc-7dd0-45a7-af3b-9f5043756edc"
      + comment         = "This CIDR allows access from all IP addresses for the new project."
      + expires_at      = "2025-12-31T23:59:59Z"
      + id              = (known after apply)
      + organization_id = "6af08c0a-8cab-4c1c-b257-b521575c16d0"
      + project_id      = "c1fade1a-9f27-4a3c-af73-d1b2301890e3"
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_app_services_cidr.test: Creating...
couchbase-capella_app_services_cidr.test: Creation complete after 2s [id=f6ce3df2-9625-4c18-ae4e-1d0533ec74db]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

new_allowedcidr = {
  "app_service_id" = "043504df-5243-4b22-9857-8d3c0c9ea5b9"
  "audit" = {
    "created_at" = "2025-06-09 16:31:45.464002731 +0000 UTC"
    "created_by" = "pjuH8M2k661v2CbolSDbd27iQMOZrGEO"
    "modified_at" = "2025-06-09 16:31:45.464002731 +0000 UTC"
    "modified_by" = "pjuH8M2k661v2CbolSDbd27iQMOZrGEO"
    "version" = 1
  }
  "cidr" = "192.10.1.1/0"
  "cluster_id" = "f85211cc-7dd0-45a7-af3b-9f5043756edc"
  "comment" = "This CIDR allows access from all IP addresses for the new project."
  "expires_at" = "2025-12-31T23:59:59Z"
  "id" = "f6ce3df2-9625-4c18-ae4e-1d0533ec74db"
  "organization_id" = "6af08c0a-8cab-4c1c-b257-b521575c16d0"
  "project_id" = "c1fade1a-9f27-4a3c-af73-d1b2301890e3"
}

```

 $ terraform destroy
```
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Applications/gh_2.14.6_macOS_amd64/bin/terraform-provider-couchbase-capella/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
couchbase-capella_app_services_cidr.test: Refreshing state... [id=f6ce3df2-9625-4c18-ae4e-1d0533ec74db]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # couchbase-capella_app_services_cidr.test will be destroyed
  - resource "couchbase-capella_app_services_cidr" "test" {
      - app_service_id  = "043504df-5243-4b22-9857-8d3c0c9ea5b9" -> null
      - audit           = {
          - created_at  = "2025-06-09 16:31:45.464002731 +0000 UTC" -> null
          - created_by  = "pjuH8M2k661v2CbolSDbd27iQMOZrGEO" -> null
          - modified_at = "2025-06-09 16:31:45.464002731 +0000 UTC" -> null
          - modified_by = "pjuH8M2k661v2CbolSDbd27iQMOZrGEO" -> null
          - version     = 1 -> null
        } -> null
      - cidr            = "192.10.1.1/0" -> null
      - cluster_id      = "f85211cc-7dd0-45a7-af3b-9f5043756edc" -> null
      - comment         = "This CIDR allows access from all IP addresses for the new project." -> null
      - expires_at      = "2025-12-31T23:59:59Z" -> null
      - id              = "f6ce3df2-9625-4c18-ae4e-1d0533ec74db" -> null
      - organization_id = "6af08c0a-8cab-4c1c-b257-b521575c16d0" -> null
      - project_id      = "c1fade1a-9f27-4a3c-af73-d1b2301890e3" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - new_allowedcidr = {
      - app_service_id  = "043504df-5243-4b22-9857-8d3c0c9ea5b9"
      - audit           = {
          - created_at  = "2025-06-09 16:31:45.464002731 +0000 UTC"
          - created_by  = "pjuH8M2k661v2CbolSDbd27iQMOZrGEO"
          - modified_at = "2025-06-09 16:31:45.464002731 +0000 UTC"
          - modified_by = "pjuH8M2k661v2CbolSDbd27iQMOZrGEO"
          - version     = 1
        }
      - cidr            = "192.10.1.1/0"
      - cluster_id      = "f85211cc-7dd0-45a7-af3b-9f5043756edc"
      - comment         = "This CIDR allows access from all IP addresses for the new project."
      - expires_at      = "2025-12-31T23:59:59Z"
      - id              = "f6ce3df2-9625-4c18-ae4e-1d0533ec74db"
      - organization_id = "6af08c0a-8cab-4c1c-b257-b521575c16d0"
      - project_id      = "c1fade1a-9f27-4a3c-af73-d1b2301890e3"
    } -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

couchbase-capella_app_services_cidr.test: Destroying... [id=f6ce3df2-9625-4c18-ae4e-1d0533ec74db]
couchbase-capella_app_services_cidr.test: Destruction complete after 2s


```