### PR TITLE
[AV-107162] Do not allow setting autoexpansion for AWS/GCP

### DIFF
--- a/acceptance_tests/cluster_acceptance_test.go
+++ b/acceptance_tests/cluster_acceptance_test.go
@@ -277,8 +277,8 @@ func TestAccClusterResourceForGCPWithIOPSFieldPopulatedInvalidScenario(t *testin
 }
 
 // TestAccClusterResourceForAwsWithAutoexpansion tests a failure scenario where the autoexpansion field is set
-// for an AWS cluster.  
-func TestAccClusterResourceForAwsWithAutoexpansion(t *testing.T) {
+// for an AWS cluster.
+func TestAccClusterResourceForAwsWithAutoexpansionInvalid(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_")
 	cidr := "10.249.250.0/23"
 
@@ -286,7 +286,7 @@ func TestAccClusterResourceForAwsWithAutoexpansion(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccClusterResourceConfigAwsWithAutoexpansion(resourceName, cidr),
+				Config:      testAccClusterResourceConfigAwsWithAutoexpansionInvalidConfig(resourceName, cidr),
 				ExpectError: regexp.MustCompile(`(?i)Autoexpansion cannot be set`),
 			},
 		},
@@ -591,7 +591,7 @@ resource "couchbase-capella_cluster" "%[4]s" {
 
 // testAccClusterResourceConfigAwsWithAutoexpansion generates a Terraform script for testing an acceptance test scenario
 // where a cluster resource is created with the AWS cloud provider and auto-expansion enabled for the disk.
-func testAccClusterResourceConfigAwsWithAutoexpansion(resourceName, cidr string) string {
+func testAccClusterResourceConfigAwsWithAutoexpansionInvalidConfig(resourceName, cidr string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -616,7 +616,7 @@ resource "couchbase-capella_cluster" "%[4]s" {
           storage = 50
           type    = "gp3"
           iops    = 3000
-		  auto_expansion = true
+		  autoexpansion = true
         }
       }
       num_of_nodes = 1

--- a/acceptance_tests/cluster_acceptance_test.go
+++ b/acceptance_tests/cluster_acceptance_test.go
@@ -276,6 +276,8 @@ func TestAccClusterResourceForGCPWithIOPSFieldPopulatedInvalidScenario(t *testin
 	})
 }
 
+// TestAccClusterResourceForAwsWithAutoexpansion tests a failure scenario where the autoexpansion field is set
+// for an AWS cluster.  
 func TestAccClusterResourceForAwsWithAutoexpansion(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_")
 	cidr := "10.249.250.0/23"
@@ -587,6 +589,8 @@ resource "couchbase-capella_cluster" "%[4]s" {
 `, globalProviderBlock, globalOrgId, globalProjectId, resourceName, cidr)
 }
 
+// testAccClusterResourceConfigAwsWithAutoexpansion generates a Terraform script for testing an acceptance test scenario
+// where a cluster resource is created with the AWS cloud provider and auto-expansion enabled for the disk.
 func testAccClusterResourceConfigAwsWithAutoexpansion(resourceName, cidr string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -569,14 +569,18 @@ func (r *Cluster) Delete(ctx context.Context, req resource.DeleteRequest, resp *
 }
 
 // ImportState imports a remote cluster that is not created by Terraform.
-func (c *Cluster) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (c *Cluster) ImportState(
+	ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse,
+) {
 	// Retrieve import ID and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 // getCluster retrieves cluster information from the specified organization and project
 // using the provided cluster ID by open-api call.
-func (c *Cluster) getCluster(ctx context.Context, organizationId, projectId, clusterId string) (*clusterapi.GetClusterResponse, error) {
+func (c *Cluster) getCluster(
+	ctx context.Context, organizationId, projectId, clusterId string,
+) (*clusterapi.GetClusterResponse, error) {
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s", c.HostURL, organizationId, projectId, clusterId)
 	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
 	response, err := c.Client.ExecuteWithRetry(
@@ -600,7 +604,9 @@ func (c *Cluster) getCluster(ctx context.Context, organizationId, projectId, clu
 }
 
 // retrieveCluster retrieves cluster information for a specified organization, project, and cluster ID.
-func (c *Cluster) retrieveCluster(ctx context.Context, organizationId, projectId, clusterId string) (*providerschema.Cluster, error) {
+func (c *Cluster) retrieveCluster(
+	ctx context.Context, organizationId, projectId, clusterId string,
+) (*providerschema.Cluster, error) {
 	clusterResp, err := c.getCluster(ctx, organizationId, projectId, clusterId)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", errors.ErrNotFound, err)
@@ -829,6 +835,22 @@ func (c *Cluster) validateCreateCluster(plan providerschema.Cluster) error {
 		return errors.ErrIfMatchCannotBeSetWhileCreate
 	}
 
+	csp := plan.CloudProvider.Type.ValueString()
+	switch csp {
+	case string(clusterapi.Aws), string(clusterapi.Gcp), string(clusterapi.Azure):
+		// continue
+	default:
+		return fmt.Errorf("invalid cloud provider type %s, must be either aws, gcp or azure", csp)
+	}
+
+	if plan.CloudProvider.Type.ValueString() != string(clusterapi.Azure) {
+		for _, sg := range plan.ServiceGroups {
+			if !sg.Node.Disk.Autoexpansion.IsNull() || !sg.Node.Disk.Autoexpansion.IsUnknown() {
+				return fmt.Errorf("invalid configuration: Autoexpansion cannot be set for %s cloud provider", plan.CloudProvider.Type.ValueString())
+			}
+		}
+	}
+
 	return c.validateClusterAttributesTrimmed(plan)
 }
 
@@ -843,7 +865,9 @@ func (c *Cluster) validateClusterAttributesTrimmed(plan providerschema.Cluster) 
 }
 
 // this function converts types.Object field to couchbaseServer field.
-func getCouchbaseServer(ctx context.Context, config tfsdk.Config, diags *diag.Diagnostics) *providerschema.CouchbaseServer {
+func getCouchbaseServer(
+	ctx context.Context, config tfsdk.Config, diags *diag.Diagnostics,
+) *providerschema.CouchbaseServer {
 	var couchbaseServer *providerschema.CouchbaseServer
 	diags.Append(config.GetAttribute(ctx, path.Root("couchbase_server"), &couchbaseServer)...)
 	tflog.Info(ctx, fmt.Sprintf("couchbase_server: %+v", couchbaseServer))

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -845,8 +845,9 @@ func (c *Cluster) validateCreateCluster(plan providerschema.Cluster) error {
 
 	if csp != string(clusterapi.Azure) {
 		for _, sg := range plan.ServiceGroups {
+			// check if autoexpansion is set for AWS or GCP.
 			if !sg.Node.Disk.Autoexpansion.IsNull() && !sg.Node.Disk.Autoexpansion.IsUnknown() {
-				return fmt.Errorf("invalid configuration: Autoexpansion cannot be set for %s cloud provider", plan.CloudProvider.Type.ValueString())
+				return fmt.Errorf("invalid configuration: Autoexpansion cannot be set for %s cloud provider", csp)
 			}
 		}
 	}

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -843,9 +843,9 @@ func (c *Cluster) validateCreateCluster(plan providerschema.Cluster) error {
 		return fmt.Errorf("invalid cloud provider type %s, must be either aws, gcp or azure", csp)
 	}
 
-	if plan.CloudProvider.Type.ValueString() != string(clusterapi.Azure) {
+	if csp != string(clusterapi.Azure) {
 		for _, sg := range plan.ServiceGroups {
-			if !sg.Node.Disk.Autoexpansion.IsNull() || !sg.Node.Disk.Autoexpansion.IsUnknown() {
+			if !sg.Node.Disk.Autoexpansion.IsNull() && !sg.Node.Disk.Autoexpansion.IsUnknown() {
 				return fmt.Errorf("invalid configuration: Autoexpansion cannot be set for %s cloud provider", plan.CloudProvider.Type.ValueString())
 			}
 		}

--- a/internal/resources/cluster_schema.go
+++ b/internal/resources/cluster_schema.go
@@ -95,7 +95,7 @@ func ClusterSchema() schema.Schema {
 										"iops": WithDescription(int64Attribute(optional, computed),
 											"The number of IOPS for the disk. Only applicable for certain disk types."),
 										"autoexpansion": WithDescription(boolAttribute(optional, computed),
-											"Enable or disable automatic disk expansion."),
+											"Enable or disable automatic disk expansion.  This can only be set for Azure."),
 									},
 								},
 							},


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-107162

## Description

`autoexpansion` is only valid for azure.  do not allow setting this for aws/gcp.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [X] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  
validation in https://jira.issues.couchbase.com/browse/AV-107162?focusedCommentId=1239520

</details>

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code
- [X] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments