### PR TITLE
[AV-107267] Restrict setting IOPS for GCP clusters

### DIFF
--- a/acceptance_tests/cluster_acceptance_test.go
+++ b/acceptance_tests/cluster_acceptance_test.go
@@ -267,10 +267,9 @@ func TestAccClusterResourceForGCPWithIOPSFieldPopulatedInvalidScenario(t *testin
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
-			// Create and Read testing
 			{
 				Config:      testAccClusterResourceForGCPWithIOPSFieldPopulatedInvalidScenarioConfig(resourceName, cidr),
-				ExpectError: regexp.MustCompile("Could not create cluster, unexpected error: iops for gcp cluster cannot be"),
+				ExpectError: regexp.MustCompile("iops cannot be set for GCP"),
 			},
 		},
 	})

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -263,4 +263,6 @@ var (
 		" state of the app service. Please run `terraform plan` after 4-5 minutes to know the" +
 		" current status of the app service. Additionally, run `terraform apply --refresh-only` to update" +
 		" the state from remote, unexpected error: ")
+
+	ErrCannotSetIopsForGcp = errors.New("iops cannot be set for GCP clusters.")
 )

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -852,6 +852,15 @@ func (c *Cluster) validateCreateCluster(plan providerschema.Cluster) error {
 		}
 	}
 
+	if csp == string(clusterapi.Gcp) {
+		for _, sg := range plan.ServiceGroups {
+			// check if iops is set for GCP.
+			if !sg.Node.Disk.IOPS.IsNull() && !sg.Node.Disk.IOPS.IsUnknown() {
+				return errors.ErrCannotSetIopsForGcp
+			}
+		}
+	}
+
 	return c.validateClusterAttributesTrimmed(plan)
 }
 

--- a/internal/resources/cluster_schema.go
+++ b/internal/resources/cluster_schema.go
@@ -93,7 +93,7 @@ func ClusterSchema() schema.Schema {
 										"storage": WithDescription(int64Attribute(optional, computed),
 											"The size of the disk in GB."),
 										"iops": WithDescription(int64Attribute(optional, computed),
-											"The number of IOPS for the disk. Only applicable for certain disk types."),
+											"The number of IOPS for the disk. Only applicable for AWS and Azure."),
 										"autoexpansion": WithDescription(boolAttribute(optional, computed),
 											"Enable or disable automatic disk expansion.  This can only be set for Azure."),
 									},


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-107267

## Description

do not allow users to set iops on gcp clusters

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [X] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
 
validation in https://jira.issues.couchbase.com/browse/AV-107267?focusedCommentId=1241008

</details>

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code
- [X] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments