### PR TITLE
[AV-107327] Dynamically set if_match

### DIFF
--- a/acceptance_tests/cluster_acceptance_test.go
+++ b/acceptance_tests/cluster_acceptance_test.go
@@ -28,6 +28,11 @@ func TestAccClusterResourceWithOnlyReqFieldAWS(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"http": {
+				Source: "hashicorp/http",
+			},
+		},
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -65,32 +70,24 @@ func TestAccClusterResourceWithOnlyReqFieldAWS(t *testing.T) {
 			// Update number of nodes, compute type, disk size and type, cluster name, support plan, time zone and description from empty string,
 			// and Read testing
 			{
-				Config: testAccClusterResourceConfigUpdateWhenClusterCreatedWithReqFieldOnlyAndIfMatch(resourceName, cidr),
+				Config:             testAccClusterResourceConfigUpdateWhenClusterCreatedWithReqFieldOnlyAndIfMatch(resourceName, cidr),
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsClusterResource(resourceReference),
-					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
-					resource.TestCheckResourceAttr(resourceReference, "description", "Cluster Updated"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.type", "aws"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider.cidr", cidr),
 					resource.TestCheckResourceAttr(resourceReference, "configuration_type", "multiNode"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.cpu", "8"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.compute.ram", "32"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.storage", "51"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.type", "gp3"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.node.disk.iops", "3001"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.num_of_nodes", "2"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.services.#", "2"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.services.0", "index"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.1.services.1", "query"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.compute.ram", "16"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "51"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.type", "gp3"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.iops", "3001"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.storage", "50"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.type", "io2"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.node.disk.iops", "3000"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.num_of_nodes", "3"),
-					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.#", "3"),
 					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.0", "data"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.1", "index"),
+					resource.TestCheckResourceAttr(resourceReference, "service_groups.0.services.2", "query"),
 					resource.TestCheckResourceAttr(resourceReference, "availability.type", "multi"),
 					resource.TestCheckResourceAttr(resourceReference, "support.plan", "enterprise"),
 					resource.TestCheckResourceAttr(resourceReference, "support.timezone", "IST"),
@@ -729,11 +726,32 @@ func testAccClusterResourceConfigUpdateWhenClusterCreatedWithReqFieldOnlyAndIfMa
 	return fmt.Sprintf(`
 %[1]s
 
+data "couchbase-capella_clusters" "existing_clusters" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+}
+
+locals {
+  cluster_id = [
+    for cluster in data.couchbase-capella_clusters.existing_clusters.data :
+    cluster.id if cluster.name == "%[4]s"
+  ][0]
+  
+  cluster_etag = regex("[0-9]+", data.http.cluster_info[0].response_headers["Etag"])
+}
+
+data "http" "cluster_info" {
+  url   = "${var.host}/v4/organizations/%[2]s/projects/%[3]s/clusters/${local.cluster_id}"
+
+  request_headers = {
+    Authorization = "Bearer ${var.auth_token}"
+  }
+}
+
 resource "couchbase-capella_cluster" "%[4]s" {
   organization_id = "%[2]s"
   project_id      = "%[3]s"
-  name            = "%[4]s"
-  description     = "Cluster Updated"
+  name            =  "%[4]s"
   cloud_provider = {
     type   = "aws"
     region = "us-east-1"
@@ -743,32 +761,17 @@ resource "couchbase-capella_cluster" "%[4]s" {
     {
       node = {
         compute = {
-          cpu = 8
-          ram = 32
-        }
-        disk = {
-          storage = 51
-          type    = "gp3"
-          iops    = 3001
-        }
-      }
-      num_of_nodes = 2
-      services     = ["index", "query"]
-    },
-    {
-      node = {
-        compute = {
           cpu = 4
           ram = 16
         }
         disk = {
-          storage = 51
-          type    = "gp3"
-          iops    = 3001
+          storage = 50
+          type    = "io2"
+          iops    = 3000
         }
       }
       num_of_nodes = 3
-      services     = ["data"]
+      services     = ["data", "index", "query"]
     }
   ]
   availability = {
@@ -778,7 +781,8 @@ resource "couchbase-capella_cluster" "%[4]s" {
     plan     = "enterprise"
     timezone = "IST"
   }
-  if_match = 5
+
+  if_match = local.cluster_etag
 }
 `, globalProviderBlock, globalOrgId, globalProjectId, resourceName, cidr)
 }


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-107327

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
<!-- What does this change do? Why is it needed? -->

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

```
TF_ACC=1 go test -timeout=120m -v ./acceptance_tests/ -run TestAccClusterResourceWithOnlyReqFiel
dAWS
2025/08/05 21:54:45 project created
=== RUN   TestAccClusterResourceWithOnlyReqFieldAWS
=== PAUSE TestAccClusterResourceWithOnlyReqFieldAWS
=== CONT  TestAccClusterResourceWithOnlyReqFieldAWS
--- PASS: TestAccClusterResourceWithOnlyReqFieldAWS (407.91s)
PASS
ok      github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests 408.728s
```

</details>

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code
- [X] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments