### PR TITLE
[AV-108158] Remove cluster ID arg from import command in examples readme

### DIFF
--- a/examples/cluster/README.md
+++ b/examples/cluster/README.md
@@ -650,7 +650,7 @@ Please note, this command will only remove the resource from the Terraform State
 
 ### Now, let's import the resource in Terraform
 
-Command: `terraform import couchbase-capella_cluster.new_cluster id=<cluster_id>,cluster_id=<cluster_id>,project_id=<project_id>,organization_id=<organization_id>`
+Command: `terraform import couchbase-capella_cluster.new_cluster id=<cluster_id>,project_id=<project_id>,organization_id=<organization_id>`
 
 In this case, the complete command is:
 `terraform import couchbase-capella_cluster.new_cluster id=ffffffff-aaaa-1414-eeee-00000000000,project_id=ffffffff-aaaa-1414-eeee-00000000000,organization_id=ffffffff-aaaa-1414-eeee-00000000000`


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-108158

## Description

examples readme for cluster states import command is 

`terraform import couchbase-capella_cluster.new_cluster id=<cluster_id>,project_id=<project_id>,organization_id=<organization_id>`

while testing, i was getting 

```

│ Error: Error Reading Capella Cluster
│
│ Could Not Read Capella Cluster "id=brasseallenemerson,cluster_id=ffffffff-aaaa-1414-eeee-00000000000,project_id=ffffffff-aaaa-1414-eeee-00000000000organization_id=ffffffff-aaaa-1414-eeee-00000000000": failed to validate resource state: terraform import parameters did not match those expected for the resource, please check provider documentation for syntax: error parsing terraform import: terraform import parameters did not match those expected for the resource, please check provider documentation for syntax
╵
```

while passing the cluster_id arg, after removing this arg it works fine. This also aligns with the example command in the same readme

removed the cluster_id arg from the example command
<!-- What does this change do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [x] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

testing without cluster_id arg
```
 $ terraform import  couchbase-capella_cluster.new_cluster id=ffffffff-aaaa-1414-eeee-00000000000,project_id=ffffffff-aaaa-1414-eeee-00000000000,organization_id=ffffffff-aaaa-1414-eeee-00000000000                                                                                                                                                                                                                                                                                                                                      1 ↵
couchbase-capella_cluster.new_cluster: Importing from ID "id=ffffffff-aaaa-1414-eeee-00000000000project_id=ffffffff-aaaa-1414-eeee-00000000000,organization_id=ffffffff-aaaa-1414-eeee-00000000000"...
couchbase-capella_cluster.new_cluster: Import prepared!
  Prepared couchbase-capella_cluster for import
couchbase-capella_cluster.new_cluster: Refreshing state... [id=id=ffffffff-aaaa-1414-eeee-00000000000,project_id=ffffffff-aaaa-1414-eeee-00000000000,organization_id=ffffffff-aaaa-1414-eeee-00000000000]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

╷
│ Warning: Value for undeclared variable
│ 
│ The root module does not declare a variable named "delta_sync_enabled" but a value was found in file "terraform.tfvars". If you meant to use this value, add a "variable" block to the configuration.
│ 
│ To silence these warnings, use TF_VAR_... environment variables to provide certain "global" settings to all configurations in your organization. To reduce the verbosity of these warnings, use the -compact-warnings option.
╵
```

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Required Checklist:

- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if required)
- [ ] I have run make fmt and formatted my code
- [ ] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments