### PR TITLE
[AV-111371] Allow configurable vbuckets

### DIFF
--- a/internal/api/bucket/bucket.go
+++ b/internal/api/bucket/bucket.go
@@ -109,6 +109,10 @@ type CreateBucketRequest struct {
 	// The name cannot have 0 characters or empty. Minimum length of name is 1.
 	// The name cannot start with a . (period).
 	Name string `json:"name"`
+
+	// Vbuckets is the number of vbuckets in the bucket.
+	// This is only configurable on magma buckets for Couchbase 8.0 and above.
+	Vbuckets int64 `json:"vbuckets,omitempty"`
 }
 
 // CreateBucketResponse is the response received from Capella V4 Public API on requesting to create a new bucket.
@@ -170,6 +174,10 @@ type GetBucketResponse struct {
 
 	// Flush determines whether flushing is enabled on the bucket.
 	Flush bool `json:"flush"`
+
+	// Vbuckets is the number of vbuckets in the bucket.
+	// This is only configurable on magma buckets for Couchbase 8.0 and above.
+	Vbuckets int64 `json:"vbuckets"`
 }
 
 // PutBucketRequest is the request payload sent to the Capella V4 Public API in order to update an existing bucket.

--- a/internal/datasources/buckets.go
+++ b/internal/datasources/buckets.go
@@ -88,6 +88,10 @@ func (d *Buckets) Schema(_ context.Context, _ datasource.SchemaRequest, resp *da
 							Computed:            true,
 							MarkdownDescription: "The bucket storage engine type (Magma or Couchstore).",
 						},
+						"vbuckets": schema.Int64Attribute{
+							Computed:            true,
+							MarkdownDescription: "Number of vbuckets for the bucket. This is only configurable on Magma buckets for Couchbase 8.0 and above.  This requires provider version 1.5.4 or later.",
+						},
 						"memory_allocation_in_mb": schema.Int64Attribute{
 							Optional:            true,
 							Computed:            true,
@@ -192,6 +196,7 @@ func (d *Buckets) Read(ctx context.Context, req datasource.ReadRequest, resp *da
 			ProjectId:                types.StringValue(projectId),
 			ClusterId:                types.StringValue(clusterId),
 			StorageBackend:           types.StringValue(bucket.StorageBackend),
+			Vbuckets:                 types.Int64Value(bucket.Vbuckets),
 			MemoryAllocationInMB:     types.Int64Value(bucket.MemoryAllocationInMb),
 			BucketConflictResolution: types.StringValue(bucket.BucketConflictResolution),
 			DurabilityLevel:          types.StringValue(bucket.DurabilityLevel),

--- a/internal/resources/bucket.go
+++ b/internal/resources/bucket.go
@@ -103,6 +103,10 @@ func (c *Bucket) Create(ctx context.Context, req resource.CreateRequest, resp *r
 		BucketRequest.Type = plan.Type.ValueStringPointer()
 	}
 
+	if !plan.Vbuckets.IsNull() && !plan.Vbuckets.IsUnknown() {
+		BucketRequest.Vbuckets = plan.Vbuckets.ValueInt64()
+	}
+
 	if err := c.validateCreateBucket(plan); err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating bucket",
@@ -338,6 +342,7 @@ func (c *Bucket) retrieveBucket(
 		ClusterId:                types.StringValue(clusterId),
 		Type:                     types.StringValue(bucketResp.Type),
 		StorageBackend:           types.StringValue(bucketResp.StorageBackend),
+		Vbuckets:                 types.Int64Value(bucketResp.Vbuckets),
 		MemoryAllocationInMB:     types.Int64Value(bucketResp.MemoryAllocationInMb),
 		BucketConflictResolution: types.StringValue(bucketResp.BucketConflictResolution),
 		DurabilityLevel:          types.StringValue(bucketResp.DurabilityLevel),
@@ -460,7 +465,10 @@ func initializeBucketWithPlanAndId(plan providerschema.Bucket, id string) provid
 	if plan.Type.IsNull() || plan.Type.IsUnknown() {
 		plan.Type = types.StringNull()
 	}
-	// Stats is a read-only attribute, so we set it to null in the initial state
+	if plan.Vbuckets.IsNull() || plan.Vbuckets.IsUnknown() {
+		plan.Vbuckets = types.Int64Null()
+	}
+
 	plan.Stats = types.ObjectNull(providerschema.Stats{}.AttributeTypes())
 	return plan
 }

--- a/internal/resources/bucket_schema.go
+++ b/internal/resources/bucket_schema.go
@@ -1,11 +1,14 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 func BucketSchema() schema.Schema {
@@ -32,6 +35,18 @@ func BucketSchema() schema.Schema {
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Bucket size allocation in MB.",
+			},
+			"vbuckets": schema.Int64Attribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+					int64planmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
+				MarkdownDescription: "Number of vbuckets for the bucket. This is only configurable on Magma buckets for Couchbase 8.0 and above.  This requires provider version 1.5.4 or later.",
 			},
 			"bucket_conflict_resolution": schema.StringAttribute{
 				Computed: true,

--- a/internal/schema/bucket.go
+++ b/internal/schema/bucket.go
@@ -118,6 +118,10 @@ type Bucket struct {
 	// Disable Flush to avoid inadvertent data loss.
 	// Default: false
 	Flush types.Bool `tfsdk:"flush"`
+
+	// Vbuckets is the number of vBuckets for the bucket.
+	// This is only configurable on magma buckets for Couchbase 8.0 and above.
+	Vbuckets types.Int64 `tfsdk:"vbuckets"`
 }
 
 // Stats has the bucket stats that are related to memory and disk consumption.
@@ -172,6 +176,7 @@ type OneBucket struct {
 	Replicas                 types.Int64  `tfsdk:"replicas"`
 	MemoryAllocationInMB     types.Int64  `tfsdk:"memory_allocation_in_mb"`
 	Flush                    types.Bool   `tfsdk:"flush"`
+	Vbuckets                 types.Int64  `tfsdk:"vbuckets"`
 }
 
 // Validate will split the IDs by a delimiter i.e. comma , in case a terraform import CLI is invoked.


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-111371

## Description

magma buckets in 8.x have configurable vbuckets, so bucket resource should allow for this

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
 
test details in ticket

</details>

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code
- [X] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments