### PR TITLE
[AV-111480] Fix OIDC value conversion error

### DIFF
--- a/internal/resources/app_endpoint.go
+++ b/internal/resources/app_endpoint.go
@@ -760,11 +760,24 @@ func morphToAppEndpointRequest(
 	}
 
 	if !plan.Oidc.IsNull() {
-		oidc := []app_endpoints.AppEndpointOidc{}
-		if diags := plan.Oidc.ElementsAs(ctx, &oidc, false); diags.HasError() {
+		var tfOidcList []providerschema.AppEndpointOidc
+		if diags := plan.Oidc.ElementsAs(ctx, &tfOidcList, false); diags.HasError() {
 			return nil, diags
 		}
-		appEndpointRequest.Oidc = oidc
+
+		apiOidcList := make([]app_endpoints.AppEndpointOidc, len(tfOidcList))
+		for i, tfOidc := range tfOidcList {
+			apiOidcList[i] = app_endpoints.AppEndpointOidc{
+				Issuer:        tfOidc.Issuer.ValueString(),
+				Register:      tfOidc.Register.ValueBool(),
+				ClientId:      tfOidc.ClientId.ValueString(),
+				UserPrefix:    tfOidc.UserPrefix.ValueString(),
+				DiscoveryUrl:  tfOidc.DiscoveryUrl.ValueString(),
+				UsernameClaim: tfOidc.UsernameClaim.ValueString(),
+				RolesClaim:    tfOidc.RolesClaim.ValueString(),
+			}
+		}
+		appEndpointRequest.Oidc = apiOidcList
 	}
 
 	return appEndpointRequest, nil

--- a/internal/resources/app_endpoint.go
+++ b/internal/resources/app_endpoint.go
@@ -110,12 +110,6 @@ func (a *AppEndpoint) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
-	diags = resp.State.Set(ctx, plan)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	refreshedState, err := a.refreshAppEndpoint(
 		ctx,
 		organizationId,


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-111480

## Description

fixes value conversion error when oidc is configured for app endpoint

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  
**NOTE:  for this test, even though there is connection refused error, that still shows the fix works.  value conversion error occurs before request is sent**

```
terraform apply -auto-approve
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/$USER/GolandProjects/terraform-provider-couchbase-capella/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_app_endpoint.endpoint2 will be created
  + resource "couchbase-capella_app_endpoint" "endpoint2" {
      + admin_url          = (known after apply)
      + app_service_id     = <app_service_id>
      + bucket             = "b1"
      + cluster_id         = <cluster_id>
      + cors               = {
          + disabled     = false
          + headers      = []
          + login_origin = []
          + max_age      = 0
          + origin       = []
        }
      + delta_sync_enabled = false
      + metrics_url        = (known after apply)
      + name               = "test-endpoint-2"
      + oidc               = [
          + {
              + client_id      = "example-client-id"
              + discovery_url  = "https://example-issuer.com/.well-known/openid-configuration"
              + is_default     = (known after apply)
              + issuer         = "https://example-issuer.com"
              + provider_id    = (known after apply)
              + register       = false
              + roles_claim    = "roles"
              + user_prefix    = "user_"
              + username_claim = "sub"
            },
        ]
      + organization_id    = <org_id>
      + project_id         = <project_id>
      + public_url         = (known after apply)
      + require_resync     = (known after apply)
      + scopes             = {
          + "s1" = {
              + collections = {
                  + "c2" = {
                      + access_control_function = (known after apply)
                      + import_filter           = (known after apply)
                    },
                }
            },
        }
      + state              = (known after apply)
      + user_xattr_key     = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
couchbase-capella_app_endpoint.endpoint2: Creating...
╷
│ Error: Error executing request
│ 
│   with couchbase-capella_app_endpoint.endpoint2,
│   on config.tf line 48, in resource "couchbase-capella_app_endpoint" "endpoint2":
│   48: resource "couchbase-capella_app_endpoint" "endpoint2" {
│ 
│ There is an error during App Endpoint creation. unexpected error: failed to execute request: Post
│ "http://localhost:8084/v4/organizations/{orgId}/projects/{projectId}/clusters/{clusterId}/appservices/{app_service_id}/appEndpoints":
│ dial tcp [::1]:8084: connect: connection refused
```

</details>

## Required Checklist:

- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if required)
- [X] I have run make fmt and formatted my code
- [X] I have made sure that no schema field is marked with both requiresReplace and computed
## Further comments