### PR TITLE
Add Couchbase Server 8.0 version to cluster examples. Fix Azure disk configuration for Ultra.

### DIFF
--- a/examples/cluster/azure/create_cluster.tf
+++ b/examples/cluster/azure/create_cluster.tf
@@ -24,7 +24,9 @@ resource "couchbase-capella_cluster" "new_cluster" {
           ram = var.compute.ram
         }
         disk = {
+          storage       = var.disk.size
           type          = var.disk.type
+          iops          = var.disk.iops
           autoexpansion = var.disk.autoexpansion
         }
       }
@@ -38,6 +40,9 @@ resource "couchbase-capella_cluster" "new_cluster" {
   support = {
     plan     = var.support.plan
     timezone = var.support.timezone
+  }
+  couchbase_server = {
+    version = var.couchbase_server.version
   }
 }
 

--- a/examples/cluster/azure/terraform.premium.tfvars
+++ b/examples/cluster/azure/terraform.premium.tfvars
@@ -7,6 +7,10 @@ cloud_provider = {
   region = "eastus"
 }
 
+couchbase_server = {
+  version = "8.0"
+}
+
 cluster = {
   name               = "New Terraform Azure Cluster 6"
   cidr               = "10.0.6.0/23"

--- a/examples/cluster/azure/terraform.ultra.tfvars
+++ b/examples/cluster/azure/terraform.ultra.tfvars
@@ -6,6 +6,11 @@ cloud_provider = {
   name   = "azure",
   region = "eastus"
 }
+
+couchbase_server = {
+  version = "8.0"
+}
+
 cluster = {
   name               = "TF Azure Ultra"
   cidr               = "10.10.0.0/23"
@@ -21,7 +26,7 @@ compute = {
 
 disk = {
   type          = "Ultra"
-  size          = 128
+  size          = 64
   iops          = 5000
   autoexpansion = true
 }

--- a/examples/cluster/azure/variables.tf
+++ b/examples/cluster/azure/variables.tf
@@ -20,6 +20,14 @@ variable "cloud_provider" {
   })
 }
 
+variable "couchbase_server" {
+  description = "Couchbase Server version configuration"
+
+  type = object({
+    version = string
+  })
+}
+
 variable "cluster" {
   description = "Cluster configuration details useful for creation"
 

--- a/examples/cluster/create_cluster.tf
+++ b/examples/cluster/create_cluster.tf
@@ -42,5 +42,8 @@ resource "couchbase-capella_cluster" "new_cluster" {
     plan     = var.support.plan
     timezone = var.support.timezone
   }
+  couchbase_server = {
+    version = var.couchbase_server.version
+  }
 }
 

--- a/examples/cluster/gcp/create_cluster.tf
+++ b/examples/cluster/gcp/create_cluster.tf
@@ -40,5 +40,7 @@ resource "couchbase-capella_cluster" "new_cluster" {
     plan     = var.support.plan
     timezone = var.support.timezone
   }
+  couchbase_server = {
+    version = var.couchbase_server.version
+  }
 }
-

--- a/examples/cluster/gcp/terraform.template.tfvars
+++ b/examples/cluster/gcp/terraform.template.tfvars
@@ -6,6 +6,10 @@ cloud_provider = {
   region = "us-east1"
 }
 
+couchbase_server = {
+  version = "8.0"
+}
+
 cluster = {
   name               = "New Terraform Cluster"
   cidr               = "192.168.0.0/20"

--- a/examples/cluster/gcp/variables.tf
+++ b/examples/cluster/gcp/variables.tf
@@ -20,6 +20,14 @@ variable "cloud_provider" {
   })
 }
 
+variable "couchbase_server" {
+  description = "Couchbase Server version configuration"
+
+  type = object({
+    version = string
+  })
+}
+
 variable "cluster" {
   description = "Cluster configuration details useful for creation"
 

--- a/examples/cluster/terraform.template.tfvars
+++ b/examples/cluster/terraform.template.tfvars
@@ -7,6 +7,10 @@ cloud_provider = {
   region = "us-east-1"
 }
 
+couchbase_server = {
+  version = "8.0"
+}
+
 cluster = {
   name               = "New Terraform Cluster"
   cidr               = "192.168.0.0/20"
@@ -35,6 +39,10 @@ support = {
 # cloud_provider = {
 #   name   = "aws",
 #   region = "us-east-1"
+# }
+#
+# couchbase_server = {
+#  version = "8.0"
 # }
 #
 # cluster = {

--- a/examples/cluster/variables.tf
+++ b/examples/cluster/variables.tf
@@ -20,6 +20,14 @@ variable "cloud_provider" {
   })
 }
 
+variable "couchbase_server" {
+  description = "Couchbase Server version configuration"
+
+  type = object({
+    version = string
+  })
+}
+
 variable "cluster" {
   description = "Cluster configuration details useful for creation"
 


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Description

Cluster creation examples for AWS, GCP and Azure default to older Server versions 7.6 when following the current steps.

Specified 8.0 as Couchbase Server version across all three providers to spin up our latest version when running terraform apply. This is needed to default to our latest version with the most up to date enhancements and bug fixes.

The Azure disk configuration for Ultra has been updated to an appropriate disk storage size for the example. This removes two issues, one of not specifying storage and iops for disk at cluster creation and the other for a current warning at 128GB.

## Type of Change

- Bug fix (non-breaking change which fixes an issue).
- New feature (non-breaking change which adds functionality).

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- Manually tested.

#### Cluster Creation Version 8.0
<img width="790" height="405" alt="Screenshot 2026-04-08 at 4 48 53 PM" src="https://github.com/user-attachments/assets/fd9b7f64-96c5-4a31-9b29-1fc4b22e9dec" />
<img width="1220" height="97" alt="Screenshot 2026-04-08 at 4 49 17 PM" src="https://github.com/user-attachments/assets/6774f520-f4ed-4697-88c0-4adf921ae454" />

#### Azure Disk Configuration for Ultra
<img width="730" height="371" alt="Screenshot 2026-04-08 at 4 49 45 PM" src="https://github.com/user-attachments/assets/fb665e1a-ca5c-480c-9437-f29be6190914" />

<img width="730" height="253" alt="Screenshot 2026-04-08 at 4 50 49 PM" src="https://github.com/user-attachments/assets/96a94600-cf9f-42c5-bf41-806bc0045794" />