### PR TITLE
[AV-127117] Make CopyToRegions a Set

### DIFF
--- a/acceptance_tests/snapshot_backup_schedule_acceptance_test.go
+++ b/acceptance_tests/snapshot_backup_schedule_acceptance_test.go
@@ -31,6 +31,20 @@ func TestAccSnapshotBackupScheduleResource(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccSnapshotBackupScheduleResourceConfigWithCopyToRegions(resourceName, 12, 240, startTime, "null"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsSnapshotBackupScheduleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(resourceReference, "interval", "12"),
+					resource.TestCheckResourceAttr(resourceReference, "retention", "240"),
+					resource.TestCheckResourceAttr(resourceReference, "start_time", startTime),
+					resource.TestCheckNoResourceAttr(resourceReference, "copy_to_regions"),
+				),
+			},
+
+			{
 				Config: testAccSnapshotBackupScheduleResourceConfigWithCopyToRegions(resourceName, 12, 240, startTime, copyToRegions),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsSnapshotBackupScheduleResource(t, resourceReference),

--- a/internal/datasources/snapshot_backup_schedule.go
+++ b/internal/datasources/snapshot_backup_schedule.go
@@ -86,6 +86,7 @@ func (d *SnapshotBackupSchedule) Read(ctx context.Context, req datasource.ReadRe
 
 	copyToRegions, diags := types.SetValueFrom(ctx, types.StringType, snapshotBackupSchedule.CopyToRegions)
 	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 

--- a/internal/datasources/snapshot_backup_schedule.go
+++ b/internal/datasources/snapshot_backup_schedule.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
@@ -83,7 +84,12 @@ func (d *SnapshotBackupSchedule) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	state = providerschema.NewSnapshotBackupSchedule(snapshotBackupSchedule, organizationId, projectId, clusterId)
+	copyToRegions, diags := types.SetValueFrom(ctx, types.StringType, snapshotBackupSchedule.CopyToRegions)
+	if diags.HasError() {
+		return
+	}
+
+	state = providerschema.NewSnapshotBackupSchedule(snapshotBackupSchedule, organizationId, projectId, clusterId, copyToRegions)
 
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/datasources/snapshot_backup_schedule.go
+++ b/internal/datasources/snapshot_backup_schedule.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
@@ -84,15 +83,16 @@ func (d *SnapshotBackupSchedule) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	copyToRegions, diags := types.SetValueFrom(ctx, types.StringType, snapshotBackupSchedule.CopyToRegions)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
+	refreshedState, err := providerschema.NewSnapshotBackupSchedule(ctx, snapshotBackupSchedule, organizationId, projectId, clusterId)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Refreshing State",
+			"Could not refresh the state of Snapshot Backup Schedule data source for cluster with ID "+state.ClusterID.String()+": "+err.Error(),
+		)
 		return
 	}
 
-	state = providerschema.NewSnapshotBackupSchedule(snapshotBackupSchedule, organizationId, projectId, clusterId, copyToRegions)
-
-	diags = resp.State.Set(ctx, state)
+	diags = resp.State.Set(ctx, refreshedState)
 	resp.Diagnostics.Append(diags...)
 }
 

--- a/internal/resources/snapshot_backup_schedule.go
+++ b/internal/resources/snapshot_backup_schedule.go
@@ -70,16 +70,16 @@ func (s *SnapshotBackupSchedule) Create(ctx context.Context, req resource.Create
 		clusterId      = plan.ClusterID.ValueString()
 	)
 
-	var copyToRegions []string
-	if !plan.CopyToRegions.IsUnknown() {
-		diags = plan.CopyToRegions.ElementsAs(ctx, &copyToRegions, false)
-		if diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
+	copyToRegions, err := s.convertCopyToRegions(ctx, plan.CopyToRegions)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Extracting CopyToRegions Elements",
+			err.Error(),
+		)
+		return
 	}
 
-	err := s.upsertSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan, copyToRegions)
+	err = s.upsertSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan, copyToRegions)
 	if err != nil {
 		tflog.Debug(ctx, "Error upserting snapshot backup schedule", map[string]interface{}{
 			"organizationId": organizationId,
@@ -112,7 +112,7 @@ func (s *SnapshotBackupSchedule) Create(ctx context.Context, req resource.Create
 			refreshedState.CopyToRegions = types.SetNull(types.StringType)
 		}
 	} else {
-		refreshedState, err = s.morphToTerraformCloudSnapshotBackupSchedule(ctx, snapshotBackupSchedule, organizationId, projectId, clusterId)
+		refreshedState, err = providerschema.NewSnapshotBackupSchedule(ctx, *snapshotBackupSchedule, organizationId, projectId, clusterId)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Refreshing State",
@@ -163,7 +163,7 @@ func (s *SnapshotBackupSchedule) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	refreshedState, err := s.morphToTerraformCloudSnapshotBackupSchedule(ctx, snapshotBackupSchedule, organizationId, projectId, clusterId)
+	refreshedState, err := providerschema.NewSnapshotBackupSchedule(ctx, *snapshotBackupSchedule, organizationId, projectId, clusterId)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Refreshing State",
@@ -196,16 +196,16 @@ func (s *SnapshotBackupSchedule) Update(ctx context.Context, req resource.Update
 		clusterId      = plan.ClusterID.ValueString()
 	)
 
-	var copyToRegions []string
-	if !plan.CopyToRegions.IsUnknown() {
-		diags = plan.CopyToRegions.ElementsAs(ctx, &copyToRegions, false)
-		if diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
+	copyToRegions, err := s.convertCopyToRegions(ctx, plan.CopyToRegions)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Extracting CopyToRegions Elements",
+			err.Error(),
+		)
+		return
 	}
 
-	err := s.upsertSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan, copyToRegions)
+	err = s.upsertSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan, copyToRegions)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Upserting Snapshot Backup Schedule in Capella",
@@ -229,7 +229,7 @@ func (s *SnapshotBackupSchedule) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	refreshedState, err := s.morphToTerraformCloudSnapshotBackupSchedule(ctx, snapshotBackupSchedule, organizationId, projectId, clusterId)
+	refreshedState, err := providerschema.NewSnapshotBackupSchedule(ctx, *snapshotBackupSchedule, organizationId, projectId, clusterId)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Refreshing State",
@@ -398,15 +398,15 @@ func (s *SnapshotBackupSchedule) getStartTime(ctx context.Context, currentStartT
 	return newStartTime.Format(time.RFC3339), nil
 }
 
-// morphToTerraformCloudSnapshotBackupSchedule creates a snapshot backup schedule from a snapshot backup schedule response.
-func (s *SnapshotBackupSchedule) morphToTerraformCloudSnapshotBackupSchedule(ctx context.Context, scheduleResp *snapshot_backup_schedule.SnapshotBackupSchedule, organizationId, projectId, clusterId string) (*providerschema.SnapshotBackupSchedule, error) {
-	copyToRegions, diags := types.SetValueFrom(ctx, types.StringType, scheduleResp.CopyToRegions)
-	if diags.HasError() {
-		return nil, fmt.Errorf("copyToRegions set error")
+func (s *SnapshotBackupSchedule) convertCopyToRegions(ctx context.Context, copyToRegionsSet types.Set) ([]string, error) {
+	var copyToRegions []string
+	if !copyToRegionsSet.IsUnknown() {
+		diags := copyToRegionsSet.ElementsAs(ctx, &copyToRegions, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("error while extracting copyToRegions elements")
+		}
 	}
-
-	snapshotBackupSchedule := providerschema.NewSnapshotBackupSchedule(*scheduleResp, organizationId, projectId, clusterId, copyToRegions)
-	return &snapshotBackupSchedule, nil
+	return copyToRegions, nil
 }
 
 // Configure adds the provider configured api to the snapshot backup schedule resource.

--- a/internal/resources/snapshot_backup_schedule.go
+++ b/internal/resources/snapshot_backup_schedule.go
@@ -107,8 +107,12 @@ func (s *SnapshotBackupSchedule) Create(ctx context.Context, req resource.Create
 			"Error Getting Snapshot Backup Schedule in Capella",
 			"Could not get Capella Snapshot Backup Schedule for cluster with ID "+plan.ClusterID.String()+": "+err.Error(),
 		)
-		refreshedState = &providerschema.SnapshotBackupSchedule{}
-		refreshedState.CopyToRegions = types.SetNull(types.StringType)
+		refreshedState = &providerschema.SnapshotBackupSchedule{
+			OrganizationID: types.StringValue(organizationId),
+			ProjectID:      types.StringValue(projectId),
+			ClusterID:      types.StringValue(clusterId),
+			CopyToRegions:  types.SetNull(types.StringType),
+		}
 	} else {
 		refreshedState, err = s.morphToTerraformCloudSnapshotBackupSchedule(ctx, snapshotBackupSchedule, organizationId, projectId, clusterId)
 		if err != nil {

--- a/internal/resources/snapshot_backup_schedule.go
+++ b/internal/resources/snapshot_backup_schedule.go
@@ -195,10 +195,12 @@ func (s *SnapshotBackupSchedule) Update(ctx context.Context, req resource.Update
 	)
 
 	var copyToRegions []string
-	diags = plan.CopyToRegions.ElementsAs(ctx, &copyToRegions, false)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
+	if !plan.CopyToRegions.IsUnknown() {
+		diags = plan.CopyToRegions.ElementsAs(ctx, &copyToRegions, false)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
 	}
 
 	err := s.upsertSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan, copyToRegions)

--- a/internal/resources/snapshot_backup_schedule.go
+++ b/internal/resources/snapshot_backup_schedule.go
@@ -107,11 +107,9 @@ func (s *SnapshotBackupSchedule) Create(ctx context.Context, req resource.Create
 			"Error Getting Snapshot Backup Schedule in Capella",
 			"Could not get Capella Snapshot Backup Schedule for cluster with ID "+plan.ClusterID.String()+": "+err.Error(),
 		)
-		refreshedState = &providerschema.SnapshotBackupSchedule{
-			OrganizationID: types.StringValue(organizationId),
-			ProjectID:      types.StringValue(projectId),
-			ClusterID:      types.StringValue(clusterId),
-			CopyToRegions:  types.SetNull(types.StringType),
+		refreshedState = &plan
+		if plan.CopyToRegions.IsUnknown() {
+			refreshedState.CopyToRegions = types.SetNull(types.StringType)
 		}
 	} else {
 		refreshedState, err = s.morphToTerraformCloudSnapshotBackupSchedule(ctx, snapshotBackupSchedule, organizationId, projectId, clusterId)

--- a/internal/resources/snapshot_backup_schedule.go
+++ b/internal/resources/snapshot_backup_schedule.go
@@ -70,7 +70,16 @@ func (s *SnapshotBackupSchedule) Create(ctx context.Context, req resource.Create
 		clusterId      = plan.ClusterID.ValueString()
 	)
 
-	err := s.upsertSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan)
+	var copyToRegions []string
+	if !plan.CopyToRegions.IsUnknown() {
+		diags = plan.CopyToRegions.ElementsAs(ctx, &copyToRegions, false)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+	}
+
+	err := s.upsertSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan, copyToRegions)
 	if err != nil {
 		tflog.Debug(ctx, "Error upserting snapshot backup schedule", map[string]interface{}{
 			"organizationId": organizationId,
@@ -99,10 +108,16 @@ func (s *SnapshotBackupSchedule) Create(ctx context.Context, req resource.Create
 			"Could not get Capella Snapshot Backup Schedule for cluster with ID "+plan.ClusterID.String()+": "+err.Error(),
 		)
 		refreshedState = &providerschema.SnapshotBackupSchedule{}
-		refreshedState.CopyToRegions = []types.String{}
+		refreshedState.CopyToRegions = types.SetNull(types.StringType)
 	} else {
-		newSnapshotBackupSchedule := providerschema.NewSnapshotBackupSchedule(*snapshotBackupSchedule, organizationId, projectId, clusterId)
-		refreshedState = &newSnapshotBackupSchedule
+		refreshedState, err = s.morphToTerraformCloudSnapshotBackupSchedule(ctx, snapshotBackupSchedule, organizationId, projectId, clusterId)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Refreshing State",
+				"Could not refresh the state of Snapshot Backup Schedule resource for cluster with ID "+plan.ClusterID.String()+": "+err.Error(),
+			)
+			return
+		}
 	}
 
 	// Sets state to fully populated data.
@@ -146,7 +161,15 @@ func (s *SnapshotBackupSchedule) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	refreshedState := providerschema.NewSnapshotBackupSchedule(*snapshotBackupSchedule, organizationId, projectId, clusterId)
+	refreshedState, err := s.morphToTerraformCloudSnapshotBackupSchedule(ctx, snapshotBackupSchedule, organizationId, projectId, clusterId)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Refreshing State",
+			"Could not refresh the state of Snapshot Backup Schedule resource for cluster with ID "+state.ClusterID.String()+": "+err.Error(),
+		)
+		return
+	}
+
 	diags = resp.State.Set(ctx, refreshedState)
 	resp.Diagnostics.Append(diags...)
 }
@@ -171,7 +194,14 @@ func (s *SnapshotBackupSchedule) Update(ctx context.Context, req resource.Update
 		clusterId      = plan.ClusterID.ValueString()
 	)
 
-	err := s.upsertSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan)
+	var copyToRegions []string
+	diags = plan.CopyToRegions.ElementsAs(ctx, &copyToRegions, false)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	err := s.upsertSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan, copyToRegions)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Upserting Snapshot Backup Schedule in Capella",
@@ -179,6 +209,7 @@ func (s *SnapshotBackupSchedule) Update(ctx context.Context, req resource.Update
 		)
 		return
 	}
+
 	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan.StartTime.ValueString())
 	if err != nil {
 		tflog.Debug(ctx, "Error getting snapshot backup schedule after upsert", map[string]interface{}{
@@ -191,9 +222,17 @@ func (s *SnapshotBackupSchedule) Update(ctx context.Context, req resource.Update
 			"Error Getting Snapshot Backup Schedule in Capella",
 			"Could not get Capella Snapshot Backup Schedule for cluster with ID "+plan.ClusterID.String()+": "+err.Error(),
 		)
+		return
 	}
 
-	refreshedState := providerschema.NewSnapshotBackupSchedule(*snapshotBackupSchedule, organizationId, projectId, clusterId)
+	refreshedState, err := s.morphToTerraformCloudSnapshotBackupSchedule(ctx, snapshotBackupSchedule, organizationId, projectId, clusterId)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Refreshing State",
+			"Could not refresh the state of Snapshot Backup Schedule resource for cluster with ID "+plan.ClusterID.String()+": "+err.Error(),
+		)
+		return
+	}
 
 	// Sets state to fully populated data.
 	diags = resp.State.Set(ctx, refreshedState)
@@ -255,13 +294,13 @@ func (s *SnapshotBackupSchedule) Delete(ctx context.Context, req resource.Delete
 }
 
 // upsertSnapshotBackupSchedule creates or updates the snapshot backup schedule.
-func (s *SnapshotBackupSchedule) upsertSnapshotBackupSchedule(ctx context.Context, organizationId, projectId, clusterId string, plan providerschema.SnapshotBackupSchedule) error {
+func (s *SnapshotBackupSchedule) upsertSnapshotBackupSchedule(ctx context.Context, organizationId, projectId, clusterId string, plan providerschema.SnapshotBackupSchedule, copyToRegions []string) error {
 
 	createSnapshotBackupScheduleRequest := snapshot_backup_schedule.SnapshotBackupSchedule{
 		Interval:      plan.Interval.ValueInt64(),
 		Retention:     plan.Retention.ValueInt64(),
 		StartTime:     plan.StartTime.ValueString(),
-		CopyToRegions: providerschema.BaseStringsToStrings(plan.CopyToRegions),
+		CopyToRegions: copyToRegions,
 	}
 
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/cloudsnapshotbackupschedule", s.HostURL, organizationId, projectId, clusterId)
@@ -288,7 +327,7 @@ func (s *SnapshotBackupSchedule) upsertSnapshotBackupSchedule(ctx context.Contex
 }
 
 // getSnapshotBackupSchedule retrieves the snapshot backup schedule for a cluster.
-func (s *SnapshotBackupSchedule) getSnapshotBackupSchedule(ctx context.Context, organizationId, projectId, clusterId string, stateTimeString string) (*snapshot_backup_schedule.SnapshotBackupSchedule, error) {
+func (s *SnapshotBackupSchedule) getSnapshotBackupSchedule(ctx context.Context, organizationId, projectId, clusterId string, startTimeString string) (*snapshot_backup_schedule.SnapshotBackupSchedule, error) {
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/cloudsnapshotbackupschedule", s.HostURL, organizationId, projectId, clusterId)
 	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
 	backupScheduleResp, err := s.ClientV1.ExecuteWithRetry(
@@ -319,7 +358,7 @@ func (s *SnapshotBackupSchedule) getSnapshotBackupSchedule(ctx context.Context, 
 		return nil, err
 	}
 
-	snapshotBackupSchedule.StartTime, err = s.getStartTime(ctx, stateTimeString, &snapshotBackupSchedule)
+	snapshotBackupSchedule.StartTime, err = s.getStartTime(ctx, startTimeString, &snapshotBackupSchedule)
 	if err != nil {
 		return nil, err
 	}
@@ -353,6 +392,17 @@ func (s *SnapshotBackupSchedule) getStartTime(ctx context.Context, currentStartT
 		return currentStartTimeString, nil
 	}
 	return newStartTime.Format(time.RFC3339), nil
+}
+
+// morphToTerraformCloudSnapshotBackupSchedule creates a snapshot backup schedule from a snapshot backup schedule response.
+func (s *SnapshotBackupSchedule) morphToTerraformCloudSnapshotBackupSchedule(ctx context.Context, scheduleResp *snapshot_backup_schedule.SnapshotBackupSchedule, organizationId, projectId, clusterId string) (*providerschema.SnapshotBackupSchedule, error) {
+	copyToRegions, diags := types.SetValueFrom(ctx, types.StringType, scheduleResp.CopyToRegions)
+	if diags.HasError() {
+		return nil, fmt.Errorf("copyToRegions set error")
+	}
+
+	snapshotBackupSchedule := providerschema.NewSnapshotBackupSchedule(*scheduleResp, organizationId, projectId, clusterId, copyToRegions)
+	return &snapshotBackupSchedule, nil
 }
 
 // Configure adds the provider configured api to the snapshot backup schedule resource.

--- a/internal/resources/snapshot_backup_schedule_schema.go
+++ b/internal/resources/snapshot_backup_schedule_schema.go
@@ -20,7 +20,7 @@ func SnapshotBackupScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "interval", snapshotBackupScheduleBuilder, int64Attribute(required))
 	capellaschema.AddAttr(attrs, "retention", snapshotBackupScheduleBuilder, int64Attribute(required))
 	capellaschema.AddAttr(attrs, "start_time", snapshotBackupScheduleBuilder, stringDefaultAttribute(time.Now().Truncate(time.Hour).Format(time.RFC3339), optional, computed))
-	capellaschema.AddAttr(attrs, "copy_to_regions", snapshotBackupScheduleBuilder, stringSetAttribute(optional, computed))
+	capellaschema.AddAttr(attrs, "copy_to_regions", snapshotBackupScheduleBuilder, stringSetAttribute(optional))
 
 	return schema.Schema{
 		MarkdownDescription: "Manages snapshot backup schedule resource",

--- a/internal/resources/snapshot_backup_schedule_schema.go
+++ b/internal/resources/snapshot_backup_schedule_schema.go
@@ -20,7 +20,7 @@ func SnapshotBackupScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "interval", snapshotBackupScheduleBuilder, int64Attribute(required))
 	capellaschema.AddAttr(attrs, "retention", snapshotBackupScheduleBuilder, int64Attribute(required))
 	capellaschema.AddAttr(attrs, "start_time", snapshotBackupScheduleBuilder, stringDefaultAttribute(time.Now().Truncate(time.Hour).Format(time.RFC3339), optional, computed))
-	capellaschema.AddAttr(attrs, "copy_to_regions", snapshotBackupScheduleBuilder, stringSetAttribute(optional, computed, useStateForUnknown))
+	capellaschema.AddAttr(attrs, "copy_to_regions", snapshotBackupScheduleBuilder, stringSetAttribute(optional, computed))
 
 	return schema.Schema{
 		MarkdownDescription: "Manages snapshot backup schedule resource",

--- a/internal/schema/snapshot_backup_schedule.go
+++ b/internal/schema/snapshot_backup_schedule.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -33,16 +34,22 @@ func (s SnapshotBackupSchedule) AttributeTypes() map[string]attr.Type {
 	}
 }
 
-func NewSnapshotBackupSchedule(snapshotBackupSchedule snapshot_backup_schedule.SnapshotBackupSchedule, organizationID, projectID, clusterID string, copyToRegions basetypes.SetValue) SnapshotBackupSchedule {
-	return SnapshotBackupSchedule{
+func NewSnapshotBackupSchedule(ctx context.Context, scheduleResp snapshot_backup_schedule.SnapshotBackupSchedule, organizationID, projectID, clusterID string) (*SnapshotBackupSchedule, error) {
+	copyToRegions, diags := types.SetValueFrom(ctx, types.StringType, scheduleResp.CopyToRegions)
+	if diags.HasError() {
+		return nil, fmt.Errorf("copyToRegions set error")
+	}
+
+	snapshotBackupSchedule := SnapshotBackupSchedule{
 		OrganizationID: types.StringValue(organizationID),
 		ProjectID:      types.StringValue(projectID),
 		ClusterID:      types.StringValue(clusterID),
-		Interval:       types.Int64Value(snapshotBackupSchedule.Interval),
-		Retention:      types.Int64Value(snapshotBackupSchedule.Retention),
-		StartTime:      types.StringValue(snapshotBackupSchedule.StartTime),
+		Interval:       types.Int64Value(scheduleResp.Interval),
+		Retention:      types.Int64Value(scheduleResp.Retention),
+		StartTime:      types.StringValue(scheduleResp.StartTime),
 		CopyToRegions:  copyToRegions,
 	}
+	return &snapshotBackupSchedule, nil
 }
 
 // Validate is used to verify that IDs have been properly imported.

--- a/internal/schema/snapshot_backup_schedule.go
+++ b/internal/schema/snapshot_backup_schedule.go
@@ -12,13 +12,13 @@ import (
 )
 
 type SnapshotBackupSchedule struct {
-	OrganizationID types.String   `tfsdk:"organization_id"`
-	ProjectID      types.String   `tfsdk:"project_id"`
-	ClusterID      types.String   `tfsdk:"cluster_id"`
-	Interval       types.Int64    `tfsdk:"interval"`
-	Retention      types.Int64    `tfsdk:"retention"`
-	StartTime      types.String   `tfsdk:"start_time"`
-	CopyToRegions  []types.String `tfsdk:"copy_to_regions"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	ProjectID      types.String `tfsdk:"project_id"`
+	ClusterID      types.String `tfsdk:"cluster_id"`
+	Interval       types.Int64  `tfsdk:"interval"`
+	Retention      types.Int64  `tfsdk:"retention"`
+	StartTime      types.String `tfsdk:"start_time"`
+	CopyToRegions  types.Set    `tfsdk:"copy_to_regions"`
 }
 
 func (s SnapshotBackupSchedule) AttributeTypes() map[string]attr.Type {
@@ -33,7 +33,7 @@ func (s SnapshotBackupSchedule) AttributeTypes() map[string]attr.Type {
 	}
 }
 
-func NewSnapshotBackupSchedule(snapshotBackupSchedule snapshot_backup_schedule.SnapshotBackupSchedule, organizationID, projectID, clusterID string) SnapshotBackupSchedule {
+func NewSnapshotBackupSchedule(snapshotBackupSchedule snapshot_backup_schedule.SnapshotBackupSchedule, organizationID, projectID, clusterID string, copyToRegions basetypes.SetValue) SnapshotBackupSchedule {
 	return SnapshotBackupSchedule{
 		OrganizationID: types.StringValue(organizationID),
 		ProjectID:      types.StringValue(projectID),
@@ -41,7 +41,7 @@ func NewSnapshotBackupSchedule(snapshotBackupSchedule snapshot_backup_schedule.S
 		Interval:       types.Int64Value(snapshotBackupSchedule.Interval),
 		Retention:      types.Int64Value(snapshotBackupSchedule.Retention),
 		StartTime:      types.StringValue(snapshotBackupSchedule.StartTime),
-		CopyToRegions:  StringsToBaseStrings(snapshotBackupSchedule.CopyToRegions),
+		CopyToRegions:  copyToRegions,
 	}
 }
 


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-127117

## Description

Change `CopyToRegions` from `[]string` to `types.Set`, so there won't be an error if `CopyToRegions` is unknown. Make `CopyToRegions` null in the `createSnapshotBackupScheduleRequest`, if it is unknown. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

**Snapshot Backup Schedule Resource for a GCP Cluster**

*Create* 

Running `terraform plan` with 

```
cloud_snapshot_backup_schedule = {
    interval = 4
    retention = 168
}
```
creates the plan 

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be created
  + resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = (known after apply)
      + interval        = 4
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-04-09T16:00:00+01:00"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + new_cloud_snapshot_backup_schedule = {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = (known after apply)
      + interval        = 4
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-04-09T16:00:00+01:00"
    }
```

Running `terraform apply` successfully creates the Snapshot Backup Schedule resource.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be created
  + resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = (known after apply)
      + interval        = 4
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-04-09T16:00:00+01:00"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + new_cloud_snapshot_backup_schedule = {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = (known after apply)
      + interval        = 4
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-04-09T16:00:00+01:00"
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Creating...
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Creation complete after 0s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

new_cloud_snapshot_backup_schedule = {
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "copy_to_regions" = toset(null) /* of string */
  "interval" = 4
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "retention" = 168
  "start_time" = "2026-04-09T16:00:00+01:00"
}
```

<img width="1677" height="523" alt="Screenshot 2026-04-09 at 16 28 35" src="https://github.com/user-attachments/assets/a08d833b-204a-4768-b71a-c2eec3031d8c" />

*Update*

Running `terraform apply` with 

```
cloud_snapshot_backup_schedule = {
    interval = 4
    retention = 168
   copy_to_regions = ["test"]
}
```

returns an error message explaining that cross-region copies are not supported for GCP clusters.

```
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be updated in-place
  ~ resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      + copy_to_regions = [
          + "test",
        ]
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ new_cloud_snapshot_backup_schedule = {
      ~ copy_to_regions = null -> [
          + "test",
        ]
        # (6 unchanged attributes hidden)
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Modifying...
╷
│ Error: Error Upserting Snapshot Backup Schedule in Capella
│ 
│   with couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule,
│   on create_snapshot_backup_schedule.tf line 5, in resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule":
│    5: resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
│ 
│ Could not upsert Capella Snapshot Backup Schedule for cluster with ID ffffffff-aaaa-1414-eeee-000000000000: {"code":501,"hint":"The server does
│ not support the functionality required to fulfill the request. Please contact support for more
│ information.","httpStatusCode":501,"message":"Cross-region cloud snapshot backup and restore operations are not supported for GCP clusters at
│ this time. Please contact support for more information."}
╵
```

Running `terraform plan` with

```
cloud_snapshot_backup_schedule = {
    interval = 12
    retention = 168
}
```

creates the following plan

```
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be updated in-place
  ~ resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      + copy_to_regions = (known after apply)
      ~ interval        = 4 -> 12
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ new_cloud_snapshot_backup_schedule = {
      + copy_to_regions = (known after apply)
      ~ interval        = 4 -> 12
        # (5 unchanged attributes hidden)
    }
```

Running `terraform apply` successfully updates the Snapshot Backup Schedule resource.

```
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be updated in-place
  ~ resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      + copy_to_regions = (known after apply)
      ~ interval        = 4 -> 12
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ new_cloud_snapshot_backup_schedule = {
      + copy_to_regions = (known after apply)
      ~ interval        = 4 -> 12
        # (5 unchanged attributes hidden)
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Modifying...
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Modifications complete after 1s

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

new_cloud_snapshot_backup_schedule = {
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "copy_to_regions" = toset(null) /* of string */
  "interval" = 12
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "retention" = 168
  "start_time" = "2026-04-09T16:00:00+01:00"
}
```
<img width="1679" height="522" alt="Screenshot 2026-04-09 at 16 43 31" src="https://github.com/user-attachments/assets/209f5637-e685-4f16-b077-c8aeb2db755d" />

**Snapshot Backup Schedule Data Source for a GCP Cluster**

Running `terraform plan` creates the following plan

```
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Reading...
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Read complete after 0s

Changes to Outputs:
  + existing_cloud_snapshot_backup_schedule = {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = null
      + interval        = 12
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-04-09T16:00:00+01:00"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```

Running `terraform apply` successfully applies the plan.

```
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Reading...
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Read complete after 0s

Changes to Outputs:
  + existing_cloud_snapshot_backup_schedule = {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = null
      + interval        = 12
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-04-09T16:00:00+01:00"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes


Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

existing_cloud_snapshot_backup_schedule = {
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "copy_to_regions" = toset(null) /* of string */
  "interval" = 12
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "retention" = 168
  "start_time" = "2026-04-09T16:00:00+01:00"
}
```

**Snapshot Backup Schedule Resource for an AWS Cluster**

*Create*

Running `terraform plan` with 

```
cloud_snapshot_backup_schedule = {
    interval = 4
    retention = 168
}
```

creates the following plan

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be created
  + resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = (known after apply)
      + interval        = 4
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-04-09T17:00:00+01:00"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + new_cloud_snapshot_backup_schedule = {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = (known after apply)
      + interval        = 4
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-04-09T17:00:00+01:00"
    }
```

Running `terraform apply`  successfully creates the Snapshot Backup Schedule resource.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be created
  + resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = (known after apply)
      + interval        = 4
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-04-09T17:00:00+01:00"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + new_cloud_snapshot_backup_schedule = {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = (known after apply)
      + interval        = 4
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-04-09T17:00:00+01:00"
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Creating...
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Creation complete after 1s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

new_cloud_snapshot_backup_schedule = {
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "copy_to_regions" = toset(null) /* of string */
  "interval" = 4
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "retention" = 168
  "start_time" = "2026-04-09T17:00:00+01:00"
}
```

<img width="1686" height="520" alt="Screenshot 2026-04-09 at 17 27 00" src="https://github.com/user-attachments/assets/aaa620f8-20e7-4511-81d0-b744bb97cd4a" />

*Update*

Running `terraform plan` with 

```
cloud_snapshot_backup_schedule = {
    interval = 12
    retention = 168
    copy_to_regions = ["eu-west-1"]
}
```

creates the following plan 

```
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be updated in-place
  ~ resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      + copy_to_regions = [
          + "eu-west-1",
        ]
      ~ interval        = 4 -> 12
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ new_cloud_snapshot_backup_schedule = {
      ~ copy_to_regions = null -> [
          + "eu-west-1",
        ]
      ~ interval        = 4 -> 12
        # (5 unchanged attributes hidden)
    }
```

Running `terraform apply` successfully updates the Snapshot Backup Schedule.

```
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be updated in-place
  ~ resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      + copy_to_regions = [
          + "eu-west-1",
        ]
      ~ interval        = 4 -> 12
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ new_cloud_snapshot_backup_schedule = {
      ~ copy_to_regions = null -> [
          + "eu-west-1",
        ]
      ~ interval        = 4 -> 12
        # (5 unchanged attributes hidden)
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Modifying...
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Modifications complete after 0s

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

new_cloud_snapshot_backup_schedule = {
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "copy_to_regions" = toset([
    "eu-west-1",
  ])
  "interval" = 12
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "retention" = 168
  "start_time" = "2026-04-09T17:00:00+01:00"
}
```

<img width="1680" height="517" alt="Screenshot 2026-04-09 at 17 31 53" src="https://github.com/user-attachments/assets/d674c4fd-ba46-4ed7-85dd-612dfed52abc" />

**Snapshot Backup Schedule Data Source for an AWS Cluster**

Running `terraform plan` creates the following plan

```
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Reading...
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Read complete after 1s

Changes to Outputs:
  + existing_cloud_snapshot_backup_schedule = {
      + cluster_id      = "71f78545-3d7b-46f1-8a3a-9e240211b574"
      + copy_to_regions = [
          + "eu-west-1",
        ]
      + interval        = 12
      + organization_id = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
      + project_id      = "68de26a7-e86b-47b5-a1bf-e66daab92d65"
      + retention       = 168
      + start_time      = "2026-04-09T17:00:00+01:00"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```

Running `terraform apply` successfully applies the plan

```
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Reading...
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Read complete after 0s

Changes to Outputs:
  + existing_cloud_snapshot_backup_schedule = {
      + cluster_id      = "71f78545-3d7b-46f1-8a3a-9e240211b574"
      + copy_to_regions = [
          + "eu-west-1",
        ]
      + interval        = 12
      + organization_id = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
      + project_id      = "68de26a7-e86b-47b5-a1bf-e66daab92d65"
      + retention       = 168
      + start_time      = "2026-04-09T17:00:00+01:00"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes


Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

existing_cloud_snapshot_backup_schedule = {
  "cluster_id" = "71f78545-3d7b-46f1-8a3a-9e240211b574"
  "copy_to_regions" = toset([
    "eu-west-1",
  ])
  "interval" = 12
  "organization_id" = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
  "project_id" = "68de26a7-e86b-47b5-a1bf-e66daab92d65"
  "retention" = 168
  "start_time" = "2026-04-09T17:00:00+01:00"
}
```


</details>

## Further comments