### PR TITLE
Fix copy_to_regions optional field causing Value Conversion Error

### DIFF
--- a/acceptance_tests/snapshot_backup_schedule_acceptance_test.go
+++ b/acceptance_tests/snapshot_backup_schedule_acceptance_test.go
@@ -132,6 +132,46 @@ func TestAccSnapshotBackupScheduleResourceInvalidCopyToRegions(t *testing.T) {
 	})
 }
 
+func TestAccSnapshotBackupScheduleResourceWithoutCopyToRegions(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cloud_snapshot_backup_schedule_")
+	resourceReference := "couchbase-capella_cloud_snapshot_backup_schedule." + resourceName
+
+	startTime := time.Now().Add(24 * time.Hour).Truncate(time.Hour).Format(time.RFC3339)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotBackupScheduleResourceConfigWithoutCopyToRegions(resourceName, 12, 240, startTime),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsSnapshotBackupScheduleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(resourceReference, "interval", "12"),
+					resource.TestCheckResourceAttr(resourceReference, "retention", "240"),
+					resource.TestCheckResourceAttr(resourceReference, "start_time", startTime),
+				),
+			},
+		},
+	})
+}
+
+func testAccSnapshotBackupScheduleResourceConfigWithoutCopyToRegions(resourceName string, interval, retention int, startTime string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+	resource "couchbase-capella_cloud_snapshot_backup_schedule" "%[2]s" {
+		organization_id = "%[3]s"
+		project_id = "%[4]s"
+		cluster_id = "%[5]s"
+		interval = %[6]d
+		retention = %[7]d
+		start_time = "%[8]s"
+	}
+	`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, interval, retention, startTime)
+}
+
 func testAccSnapshotBackupScheduleResourceConfigWithCopyToRegions(resourceName string, interval, retention int, startTime, copyToRegions string) string {
 	return fmt.Sprintf(`
 	%[1]s

--- a/internal/resources/snapshot_backup_schedule.go
+++ b/internal/resources/snapshot_backup_schedule.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -99,7 +100,7 @@ func (s *SnapshotBackupSchedule) Create(ctx context.Context, req resource.Create
 			"Could not get Capella Snapshot Backup Schedule for cluster with ID "+plan.ClusterID.String()+": "+err.Error(),
 		)
 		refreshedState = &providerschema.SnapshotBackupSchedule{}
-		refreshedState.CopyToRegions = []types.String{}
+		refreshedState.CopyToRegions = types.SetValueMust(types.StringType, []attr.Value{})
 	} else {
 		newSnapshotBackupSchedule := providerschema.NewSnapshotBackupSchedule(*snapshotBackupSchedule, organizationId, projectId, clusterId)
 		refreshedState = &newSnapshotBackupSchedule
@@ -256,12 +257,18 @@ func (s *SnapshotBackupSchedule) Delete(ctx context.Context, req resource.Delete
 
 // upsertSnapshotBackupSchedule creates or updates the snapshot backup schedule.
 func (s *SnapshotBackupSchedule) upsertSnapshotBackupSchedule(ctx context.Context, organizationId, projectId, clusterId string, plan providerschema.SnapshotBackupSchedule) error {
+	var copyToRegions []string
+	if !plan.CopyToRegions.IsNull() && !plan.CopyToRegions.IsUnknown() {
+		elems := make([]types.String, 0, len(plan.CopyToRegions.Elements()))
+		plan.CopyToRegions.ElementsAs(ctx, &elems, false)
+		copyToRegions = providerschema.BaseStringsToStrings(elems)
+	}
 
 	createSnapshotBackupScheduleRequest := snapshot_backup_schedule.SnapshotBackupSchedule{
 		Interval:      plan.Interval.ValueInt64(),
 		Retention:     plan.Retention.ValueInt64(),
 		StartTime:     plan.StartTime.ValueString(),
-		CopyToRegions: providerschema.BaseStringsToStrings(plan.CopyToRegions),
+		CopyToRegions: copyToRegions,
 	}
 
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/cloudsnapshotbackupschedule", s.HostURL, organizationId, projectId, clusterId)

--- a/internal/schema/snapshot_backup_schedule.go
+++ b/internal/schema/snapshot_backup_schedule.go
@@ -11,14 +11,27 @@ import (
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
 )
 
+// StringsToSetValue converts a slice of strings to a types.Set of string elements.
+func StringsToSetValue(strs []string) (basetypes.SetValue, error) {
+	elems := make([]attr.Value, len(strs))
+	for i, s := range strs {
+		elems[i] = types.StringValue(s)
+	}
+	set, diags := types.SetValue(types.StringType, elems)
+	if diags.HasError() {
+		return types.SetUnknown(types.StringType), fmt.Errorf("error converting strings to set")
+	}
+	return set, nil
+}
+
 type SnapshotBackupSchedule struct {
-	OrganizationID types.String   `tfsdk:"organization_id"`
-	ProjectID      types.String   `tfsdk:"project_id"`
-	ClusterID      types.String   `tfsdk:"cluster_id"`
-	Interval       types.Int64    `tfsdk:"interval"`
-	Retention      types.Int64    `tfsdk:"retention"`
-	StartTime      types.String   `tfsdk:"start_time"`
-	CopyToRegions  []types.String `tfsdk:"copy_to_regions"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	ProjectID      types.String `tfsdk:"project_id"`
+	ClusterID      types.String `tfsdk:"cluster_id"`
+	Interval       types.Int64  `tfsdk:"interval"`
+	Retention      types.Int64  `tfsdk:"retention"`
+	StartTime      types.String `tfsdk:"start_time"`
+	CopyToRegions  types.Set    `tfsdk:"copy_to_regions"`
 }
 
 func (s SnapshotBackupSchedule) AttributeTypes() map[string]attr.Type {
@@ -34,6 +47,7 @@ func (s SnapshotBackupSchedule) AttributeTypes() map[string]attr.Type {
 }
 
 func NewSnapshotBackupSchedule(snapshotBackupSchedule snapshot_backup_schedule.SnapshotBackupSchedule, organizationID, projectID, clusterID string) SnapshotBackupSchedule {
+	copyToRegions, _ := StringsToSetValue(snapshotBackupSchedule.CopyToRegions)
 	return SnapshotBackupSchedule{
 		OrganizationID: types.StringValue(organizationID),
 		ProjectID:      types.StringValue(projectID),
@@ -41,7 +55,7 @@ func NewSnapshotBackupSchedule(snapshotBackupSchedule snapshot_backup_schedule.S
 		Interval:       types.Int64Value(snapshotBackupSchedule.Interval),
 		Retention:      types.Int64Value(snapshotBackupSchedule.Retention),
 		StartTime:      types.StringValue(snapshotBackupSchedule.StartTime),
-		CopyToRegions:  StringsToBaseStrings(snapshotBackupSchedule.CopyToRegions),
+		CopyToRegions:  copyToRegions,
 	}
 }
 


### PR DESCRIPTION
## Summary

- `copy_to_regions` was typed as `[]types.String` in the schema struct but declared as a `SetAttribute` in the resource schema. When the field is omitted from config, the Terraform framework sets it to an unknown value that a plain Go slice cannot represent — only `types.Set` can.
- Changed `CopyToRegions` field from `[]types.String` to `types.Set` and updated all conversion logic accordingly.
- Added an acceptance test covering creation without `copy_to_regions` set.

## Reproduction

```hcl
resource "couchbase-capella_cloud_snapshot_backup_schedule" "example" {
  interval        = 4
  retention       = 168
  start_time      = "2024-01-01T00:00:00+00:00"
  cluster_id      = couchbase-capella_cluster.example.id
  project_id      = couchbase-capella_cluster.example.project_id
  organization_id = local.capella_org_id
}
```

Previously produced:
```
│ Error: Value Conversion Error
│ Path: copy_to_regions
│ Target Type: []basetypes.StringValue
│ Suggested Type: basetypes.SetValue
```

## Test plan

- [ ] `TestAccSnapshotBackupScheduleResourceWithoutCopyToRegions` — new test, creates resource without `copy_to_regions`
- [ ] `TestAccSnapshotBackupScheduleResource` — existing happy-path test still passes
- [ ] `TestAccSnapshotBackupScheduleResourceInvalidCopyToRegions` — existing negative test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)