### PR TITLE
[AV-125169] Fix import crash

### DIFF
--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -101,6 +101,9 @@ func splitImportString(importString string, keyParams []Attr) (map[Attr]string, 
 	IDs := make(map[Attr]string)
 	for _, pair := range pairs {
 		keyValue := strings.SplitN(pair, equalsDelimiter, 2)
+		if len(keyValue) < 2 {
+			return nil, fmt.Errorf("error parsing terraform import: %s", errors.ErrInvalidImport)
+		}
 		IDs[importIds[keyValue[0]]] = keyValue[1]
 	}
 

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -90,7 +90,7 @@ func splitImportString(importString string, keyParams []Attr) (map[Attr]string, 
 
 	pairs := strings.Split(importString, idDelimiter)
 	if len(pairs) != len(keyParams) {
-		return nil, fmt.Errorf("error parsing terraform import: %s", errors.ErrInvalidImport)
+		return nil, fmt.Errorf("error parsing terraform import: %w", errors.ErrInvalidImport)
 	}
 
 	// Use the equals delimiter to further split each pair and
@@ -102,7 +102,7 @@ func splitImportString(importString string, keyParams []Attr) (map[Attr]string, 
 	for _, pair := range pairs {
 		keyValue := strings.SplitN(pair, equalsDelimiter, 2)
 		if len(keyValue) < 2 {
-			return nil, fmt.Errorf("error parsing terraform import: %s", errors.ErrInvalidImport)
+			return nil, fmt.Errorf("error parsing terraform import: %w", errors.ErrInvalidImport)
 		}
 		IDs[importIds[keyValue[0]]] = keyValue[1]
 	}

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -104,7 +104,11 @@ func splitImportString(importString string, keyParams []Attr) (map[Attr]string, 
 		if len(keyValue) < 2 {
 			return nil, fmt.Errorf("error parsing terraform import: %w", errors.ErrInvalidImport)
 		}
-		IDs[importIds[keyValue[0]]] = keyValue[1]
+		attr, ok := importIds[keyValue[0]]
+		if !ok {
+			return nil, fmt.Errorf("error parsing terraform import: %w", errors.ErrInvalidImport)
+		}
+		IDs[attr] = keyValue[1]
 	}
 
 	return IDs, nil

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_ValidateSchemaState(t *testing.T) {
@@ -110,9 +110,9 @@ func TestSplitImportStringError(t *testing.T) {
 		t.Run(test.importString, func(t *testing.T) {
 			_, err := splitImportString(test.importString, test.keys)
 			if test.shouldError {
-				assert.ErrorContains(t, err, "error parsing terraform import")
+				assert.ErrorIs(t, err, errors.ErrInvalidImport)
 			} else {
-				assert.NilError(t, err)
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -92,3 +92,28 @@ func Test_ValidateSchemaState(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitImportStringError(t *testing.T) {
+	type test struct {
+		importString string
+		keys         []Attr
+		shouldError  bool
+	}
+
+	tests := []test{
+		{"id=123,org=456", []Attr{"id", "org"}, false},
+		{"id=123,org=456", []Attr{"id", "org", "project"}, true},
+		{"id,org=456", []Attr{"id", "org"}, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.importString, func(t *testing.T) {
+			_, err := splitImportString(test.importString, test.keys)
+			if test.shouldError {
+				assert.ErrorContains(t, err, "error parsing terraform import")
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -101,9 +101,9 @@ func TestSplitImportStringError(t *testing.T) {
 	}
 
 	tests := []test{
-		{"id=123,org=456", []Attr{"id", "org"}, false},
-		{"id=123,org=456", []Attr{"id", "org", "project"}, true},
-		{"id,org=456", []Attr{"id", "org"}, true},
+		{"id=123,organization_id=456", []Attr{Id, OrganizationId}, false},
+		{"id=123,organization_id=456", []Attr{Id, OrganizationId, ProjectId}, true},
+		{"id,organization_id=456", []Attr{Id, OrganizationId}, true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-125169

## Description

fix for https://github.com/couchbasecloud/terraform-provider-couchbase-capella/issues/419

this cherry picked fix from customer PR

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [X] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
 

```
go test ./internal/schema/ -run 'Test_ValidateSchemaState|TestSplitImportStringError' -v
=== RUN   Test_ValidateSchemaState
=== RUN   Test_ValidateSchemaState/[POSITIVE]_-_Multiple_IDs_successfully_validated_via_terraform_apply
=== RUN   Test_ValidateSchemaState/[POSITIVE]_-_Multiple_IDs_successfully_validated_via_terraform_import
=== RUN   Test_ValidateSchemaState/[POSITIVE]_-_IDs_are_passed_in_a_different_order_via_terraform_import
=== RUN   Test_ValidateSchemaState/[NEGATIVE]_-_IDs_are_passed_incorrectly_via_terraform_import
=== RUN   Test_ValidateSchemaState/[NEGATIVE]_-_IDs_are_passed_with_incorrect_names_via_terraform_import
--- PASS: Test_ValidateSchemaState (0.00s)
    --- PASS: Test_ValidateSchemaState/[POSITIVE]_-_Multiple_IDs_successfully_validated_via_terraform_apply (0.00s)
    --- PASS: Test_ValidateSchemaState/[POSITIVE]_-_Multiple_IDs_successfully_validated_via_terraform_import (0.00s)
    --- PASS: Test_ValidateSchemaState/[POSITIVE]_-_IDs_are_passed_in_a_different_order_via_terraform_import (0.00s)
    --- PASS: Test_ValidateSchemaState/[NEGATIVE]_-_IDs_are_passed_incorrectly_via_terraform_import (0.00s)
    --- PASS: Test_ValidateSchemaState/[NEGATIVE]_-_IDs_are_passed_with_incorrect_names_via_terraform_import (0.00s)
=== RUN   TestSplitImportStringError
=== RUN   TestSplitImportStringError/id=123,organization_id=456
=== RUN   TestSplitImportStringError/id=123,organization_id=456#01
=== RUN   TestSplitImportStringError/id,organization_id=456
--- PASS: TestSplitImportStringError (0.00s)
    --- PASS: TestSplitImportStringError/id=123,organization_id=456 (0.00s)
    --- PASS: TestSplitImportStringError/id=123,organization_id=456#01 (0.00s)
    --- PASS: TestSplitImportStringError/id,organization_id=456 (0.00s)
PASS
ok      github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema  (cached)
```

</details>

## Further comments