### PR TITLE
[AV-127227] Remove App Endpoint from state if not found

### DIFF
--- a/acceptance_tests/app_endpoint.go
+++ b/acceptance_tests/app_endpoint.go
@@ -82,6 +82,25 @@ func createAppEndpoint(ctx context.Context, client *api.Client) error {
 	return nil
 }
 
+func deleteAppEndpointByName(ctx context.Context, client *api.Client, name string) error {
+	url := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/appservices/%s/appEndpoints/%s",
+		globalHost,
+		globalOrgId,
+		globalProjectId,
+		globalClusterId,
+		globalAppServiceId,
+		name,
+	)
+	cfg := api.EndpointCfg{
+		Url:           url,
+		Method:        http.MethodDelete,
+		SuccessStatus: http.StatusAccepted,
+	}
+	_, err := client.ExecuteWithRetry(ctx, cfg, nil, globalToken, nil)
+	return err
+}
+
 func appEndpointWait(ctx context.Context, client *api.Client) error {
 	const maxWaitTime = 10 * time.Minute
 	const checkInterval = 1 * time.Minute

--- a/acceptance_tests/app_endpoint_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_acceptance_test.go
@@ -1,12 +1,16 @@
 package acceptance_tests
 
 import (
+	"context"
 	"fmt"
 	re "regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/require"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 )
 
 func TestAccAppEndpoint(t *testing.T) {
@@ -42,6 +46,31 @@ func TestAccAppEndpoint(t *testing.T) {
 				ResourceName:      resourceReference,
 				ImportStateIdFunc: generateAppEndpointImportId(resourceReference),
 				ImportState:       true,
+			},
+			// Simulate external deletion of the app endpoint to verify that the provider will remove it from state and recreate the resource on apply
+			{
+				PreConfig: func() {
+					ctx := context.Background()
+					client := api.NewClient(timeout)
+					if err := deleteAppEndpointByName(ctx, client, epName); err != nil {
+						require.NoError(t, err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccAppEndpointResourceConfig(resourceName, epName, bucket, "new_xattr", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(resourceReference, "app_service_id", globalAppServiceId),
+					resource.TestCheckResourceAttr(resourceReference, "bucket", bucket),
+					resource.TestCheckResourceAttr(resourceReference, "name", epName),
+					resource.TestCheckResourceAttr(resourceReference, "delta_sync_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceReference, "user_xattr_key", "new_xattr"),
+				),
 			},
 		},
 	})

--- a/internal/api/error.go
+++ b/internal/api/error.go
@@ -65,3 +65,18 @@ func CheckResourceNotFoundError(err error) (bool, string) {
 		return false, err.Error()
 	}
 }
+
+// CheckResourceForbiddenError is used to check if an error is of
+// type api.Error and whether the error is a 403 Forbidden response.
+func CheckResourceForbiddenError(err error) (bool, string) {
+	var apiError *Error
+	switch {
+	case errors.As(err, &apiError):
+		if apiError.HttpStatusCode != http.StatusForbidden {
+			return false, apiError.CompleteError()
+		}
+		return true, apiError.CompleteError()
+	default:
+		return false, err.Error()
+	}
+}

--- a/internal/api/error_test.go
+++ b/internal/api/error_test.go
@@ -111,3 +111,68 @@ func Test_CheckResourceNotFound(t *testing.T) {
 		})
 	}
 }
+
+func Test_CheckResourceForbiddenError(t *testing.T) {
+	var (
+		errMessage = "Access Denied."
+		err403     = Error{
+			HttpStatusCode: http.StatusForbidden,
+			Message:        errMessage,
+		}
+		err500 = Error{
+			HttpStatusCode: http.StatusInternalServerError,
+			Message:        errMessage,
+		}
+		err404 = Error{
+			HttpStatusCode: http.StatusNotFound,
+			Message:        errMessage,
+		}
+	)
+
+	tests := []struct {
+		name      string
+		err       error
+		expOutput string
+		expBool   bool
+	}{
+		{
+			name:      "403 Forbidden error",
+			err:       &err403,
+			expOutput: err403.CompleteError(),
+			expBool:   true,
+		},
+		{
+			name:      "500 error is not forbidden",
+			err:       &err500,
+			expOutput: err500.CompleteError(),
+			expBool:   false,
+		},
+		{
+			name:      "404 error is not forbidden",
+			err:       &err404,
+			expOutput: err404.CompleteError(),
+			expBool:   false,
+		},
+		{
+			name:      "Wrapped 403 error",
+			err:       fmt.Errorf("received error: %w", &err403),
+			expOutput: err403.CompleteError(),
+			expBool:   true,
+		},
+		{
+			name:      "Non-API error is not forbidden",
+			err:       assert.AnError,
+			expOutput: assert.AnError.Error(),
+			expBool:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isForbidden, errString := CheckResourceForbiddenError(test.err)
+
+			assert.Equal(t, test.expOutput, errString)
+			assert.Equal(t, test.expBool, isForbidden)
+		})
+	}
+}

--- a/internal/resources/app_endpoint.go
+++ b/internal/resources/app_endpoint.go
@@ -184,7 +184,7 @@ func setAppEndpointComputedAttributesToNull(ctx context.Context, plan *providers
 
 				collectionsMapValue, d := types.MapValueFrom(ctx, types.ObjectType{
 					AttrTypes: providerschema.
-					AppEndpointCollection{}.
+						AppEndpointCollection{}.
 						AttributeTypes(),
 				}, collectionsMap)
 				diags.Append(d...)
@@ -201,7 +201,7 @@ func setAppEndpointComputedAttributesToNull(ctx context.Context, plan *providers
 				"collections": types.MapType{
 					ElemType: types.ObjectType{
 						AttrTypes: providerschema.
-						AppEndpointCollection{}.
+							AppEndpointCollection{}.
 							AttributeTypes(),
 					},
 				},
@@ -286,20 +286,105 @@ func (a *AppEndpoint) Read(ctx context.Context, req resource.ReadRequest, resp *
 		endpointName,
 	)
 	if err != nil {
-		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
-		if resourceNotFound {
-			tflog.Info(ctx, "resource doesn't exist in remote server removing resource from state file")
-			resp.State.RemoveResource(ctx)
+		forbidden, errString := api.CheckResourceForbiddenError(err)
+		if !forbidden {
+			resp.Diagnostics.AddError(
+				"Error refreshing App Endpoint",
+				fmt.Sprintf("Could not refresh App Endpoint %s: %s", endpointName, errString),
+			)
 			return
 		}
+		a.handleForbiddenRead(ctx, organizationId, projectId, clusterId, appServiceId, endpointName, errString, resp)
+		return
+	}
+
+	diags = resp.State.Set(ctx, newstate)
+	resp.Diagnostics.Append(diags...)
+}
+
+// handleForbiddenRead disambiguates a 403 on GET by listing App Endpoints and deciding
+// whether the resource is genuinely gone, the user has a permissions problem, or the
+// 403 was transient. It updates the diagnostics or state accordingly.
+func (a *AppEndpoint) handleForbiddenRead(
+	ctx context.Context,
+	orgId, projId, clusterId, appSvcId, endpointName, getErrString string,
+	resp *resource.ReadResponse,
+) {
+	list, listErr := a.listAppEndpoints(ctx, orgId, projId, clusterId, appSvcId)
+	if listErr != nil {
+		listForbidden, listErrString := api.CheckResourceForbiddenError(listErr)
+		if listForbidden {
+			// Keep list operation opaque to user as we know it's a definite 403
+			resp.Diagnostics.AddError(
+				"Permission denied reading App Endpoint",
+				fmt.Sprintf(
+					"Received 403 Forbidden on Get App Endpoint %s. "+
+						"This indicates there may be a potential permissions (RBAC) issue. The Terraform state has "+
+						"not been modified. Check API permissions and try again. Error: %s",
+					endpointName,
+					getErrString,
+				),
+			)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error refreshing App Endpoint",
-			fmt.Sprintf("Could not refresh App Endpoint %s: %s", endpointName, errString),
+			fmt.Sprintf(
+				"Received a 403 when getting App Endpoint %s, and failed to List App Endpoints: %s",
+				endpointName,
+				listErrString,
+			),
 		)
 		return
 	}
-	diags = resp.State.Set(ctx, newstate)
-	resp.Diagnostics.Append(diags...)
+
+	if appEndpointInList(list, endpointName) {
+		resp.Diagnostics.AddError(
+			"Transient permission error reading App Endpoint",
+			fmt.Sprintf(
+				"Received a 403 when getting App Endpoint %s, but listing App Endpoints confirms the endpoint still "+
+					"exists. The Terraform state has not been modified. Please retry the current operation. "+
+					"Original error: %s",
+				endpointName,
+				getErrString,
+			),
+		)
+		return
+	}
+
+	tflog.Info(ctx, "App Endpoint no longer exists, removing from state")
+	resp.State.RemoveResource(ctx)
+}
+
+// listAppEndpoints fetches all App Endpoints for an App Service.
+func (a *AppEndpoint) listAppEndpoints(
+	ctx context.Context, orgId, projId, clusterId, appSvcId string,
+) ([]app_endpoints.GetAppEndpointResponse, error) {
+	url := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/appservices/%s/appEndpoints",
+		a.HostURL,
+		orgId,
+		projId,
+		clusterId,
+		appSvcId,
+	)
+	cfg := api.EndpointCfg{
+		Url:           url,
+		Method:        http.MethodGet,
+		SuccessStatus: http.StatusOK,
+	}
+	return api.GetPaginated[[]app_endpoints.GetAppEndpointResponse](ctx, a.ClientV1, a.Token, cfg, api.SortByName)
+}
+
+// appEndpointInList reports whether an endpoint with the given name appears in the List App Endpoint response.
+func appEndpointInList(list []app_endpoints.GetAppEndpointResponse, name string) bool {
+	for _, endpoint := range list {
+		if endpoint.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // Update updates an existing App Endpoint.
@@ -407,14 +492,9 @@ func (a *AppEndpoint) Delete(ctx context.Context, req resource.DeleteRequest, re
 		nil,
 	)
 	if err != nil {
-		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
-		if resourceNotFound {
-			tflog.Info(ctx, "resource doesn't exist in remote server removing resource from state file")
-			return
-		}
 		resp.Diagnostics.AddError(
 			"Error deleting App Endpoint",
-			fmt.Sprintf("Could not delete App Endpoint %s: %s", endpointName, errString),
+			fmt.Sprintf("Could not delete App Endpoint %s: %s", endpointName, err.Error()),
 		)
 		return
 	}
@@ -554,7 +634,7 @@ func (a *AppEndpoint) refreshAppEndpoint(
 				ctx,
 				types.ObjectType{
 					AttrTypes: providerschema.
-					AppEndpointCollection{}.
+						AppEndpointCollection{}.
 						AttributeTypes(),
 				},
 				collectionsMapElements,
@@ -588,7 +668,7 @@ func (a *AppEndpoint) refreshAppEndpoint(
 			ctx,
 			types.ObjectType{
 				AttrTypes: providerschema.
-				AppEndpointScope{}.
+					AppEndpointScope{}.
 					AttributeTypes(),
 			},
 			scopesMapElements,

--- a/internal/resources/app_endpoint_test.go
+++ b/internal/resources/app_endpoint_test.go
@@ -1,0 +1,56 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/app_endpoints"
+)
+
+func TestAppEndpointInList(t *testing.T) {
+	const (
+		e1 = "e1"
+		e2 = "e2"
+		e3 = "e3"
+	)
+
+	tests := []struct {
+		name     string
+		list     []app_endpoints.GetAppEndpointResponse
+		target   string
+		expected bool
+	}{
+		{
+			name:     "empty list",
+			list:     nil,
+			target:   e1,
+			expected: false,
+		},
+		{
+			name: "name present",
+			list: []app_endpoints.GetAppEndpointResponse{
+				{Name: e3},
+				{Name: e2},
+			},
+			target:   e2,
+			expected: true,
+		},
+		{
+			name: "name absent",
+			list: []app_endpoints.GetAppEndpointResponse{
+				{Name: e1},
+				{Name: e2},
+				{Name: e3},
+			},
+			target:   "other",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, appEndpointInList(tc.list, tc.target))
+		})
+	}
+}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-127227

## Description

When an App Endpoint is removed from underneath Terraform, we currently do not remove it from the state file as a 404 is never returned from a Get App Endpoint request to avoid leaking existence data to unauthorised users. A 403 is returned from this API if the API key is unauthorised to view the information OR if the app endpoint does not exist.

This PR works around this behaviour by doing a List App Endpoint call on 403, and if that requests succeeds and the App Endpoint is missing from the list, it then gets removed from the state file.

Essentially:
1. On a Read, if a 403 is detected from the GET, and List App Endpoint request is done.
2. If the List 403s, it is a genuine RBAC issue and an error is displayed to the user. If it does not 403, then the app endpoint is removed from the state ONLY if the App Endpoint indeed is not in the response list. If for some reason the App Endpoint does exist in the list then an error is returned, which should only happen if something changes between the GET and list (so it generally shouldn't happen).

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

# Test with valid API key
Create App Endpoint in TF

```
$ terraform state list
couchbase-capella_app_endpoint.e1
```

Delete App Endpoint on Capella

Run Terraform apply so it refreshes state

```
$ terraform apply

couchbase-capella_app_endpoint.e1: Refreshing state... [name=e1]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_app_endpoint.e1 will be created
  + resource "couchbase-capella_app_endpoint" "e1" {
      + admin_url          = (known after apply)
      + app_service_id     = "1ac76834-56a4-452d-9da6-d2db467ccf45"
      + bucket             = "travel-sample"
      + cluster_id         = "1008516d-f074-4c8c-bdc9-7905f8b41205"
      + cors               = {
          + disabled = (known after apply)
          + max_age  = (known after apply)
          + origin   = [
              + "*",
            ]
        }
      + delta_sync_enabled = (known after apply)
      + metrics_url        = (known after apply)
      + name               = "e1"
      + oidc               = [
          + {
              + client_id      = "example_client_id"
              + discovery_url  = (known after apply)
              + is_default     = (known after apply)
              + issuer         = "https://accounts.google.com"
              + provider_id    = (known after apply)
              + register       = (known after apply)
              + roles_claim    = (known after apply)
              + user_prefix    = (known after apply)
              + username_claim = (known after apply)
            },
        ]
      + organization_id    = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
      + project_id         = "78cd3fa8-2739-44d1-ad54-7573495089b0"
      + public_url         = (known after apply)
      + require_resync     = (known after apply)
      + scopes             = {
          + "inventory" = {
              + collections = {
                  + "airline" = {
                      + access_control_function = "function (doc, oldDoc, meta) {channel('c1');}"
                      + import_filter           = "function(doc) { if (doc.type != 'mobile') { return false; } return true; }"
                    },
                }
            },
        }
      + state              = (known after apply)
      + user_xattr_key     = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_app_endpoint.e1: Creating...
couchbase-capella_app_endpoint.e1: Creation complete after 2s [name=e1]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

List state

```
$ terraform state list
couchbase-capella_app_endpoint.e1
```

Run refresh and check state

```
export TF_LOG=INFO
$ terraform refresh
...
couchbase-capella_app_endpoint.e1: Refreshing state... [name=e1]
2026-04-21T18:52:58.613+0100 [INFO]  provider.terraform-provider-couchbase-capella: App Endpoint no longer exists, removing from state: @caller=/Users/isaaclambat/dev/cloud/terraform-provider-couchbase-capella/internal/resources/app_endpoint.go:356 tf_resource_type=couchbase-capella_app_endpoint tf_rpc=ReadResource @module=couchbase_capella tf_provider_addr=hashicorp.com/couchbasecloud/couchbase-capella tf_req_id=969993fc-efe0-81ee-2ef4-cc7f3e9108f3 timestamp="2026-04-21T18:52:58.613+0100"
...

~/dev/terraform/tf-repo ⌚ 18:41:42
$ terraform state list
```

# Test actual RBAC issue
Terraform apply with good API key to make endpoint
```
$ terraform apply
...
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Switch to bad API key which has perms for different project then tf apply again
```
$ terraform apply
...
couchbase-capella_app_endpoint.e1: Refreshing state... [name=e1]
2026-04-21T18:55:48.280+0100 [ERROR] provider.terraform-provider-couchbase-capella: Response contains error diagnostic: tf_proto_version=6.9 tf_provider_addr=hashicorp.com/couchbasecloud/couchbase-capella @caller=/Users/isaaclambat/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.27.0/tfprotov6/internal/diag/diagnostics.go:58 diagnostic_summary="Permission denied reading App Endpoint" tf_req_id=e7e964c5-8a03-7318-5a15-80cf37a52de9 tf_resource_type=couchbase-capella_app_endpoint tf_rpc=ReadResource @module=sdk.proto diagnostic_detail="Received 403 Forbidden on Get App Endpoint e1. This indicates there may be a potential permissions (RBAC) issue. The Terraform state has not been modified. Check API permissions and try again. Error: {\"hint\":\"Your access to the requested resource is denied. Please make sure you have the necessary permissions to access the resource.\",\"message\":\"Access Denied.\",\"code\":1002,\"httpStatusCode\":403}" diagnostic_severity=ERROR timestamp="2026-04-21T18:55:48.280+0100"
2026-04-21T18:55:48.281+0100 [ERROR] vertex "couchbase-capella_app_endpoint.e1" error: Permission denied reading App Endpoint
2026-04-21T18:55:48.281+0100 [ERROR] vertex "couchbase-capella_app_endpoint.e1 (expand)" error: Permission denied reading App Endpoint
2026-04-21T18:55:48.281+0100 [WARN]  Planning encountered errors, so plan is not applyable
╷
│ Error: Permission denied reading App Endpoint
│
│   with couchbase-capella_app_endpoint.e1,
│   on terraform.tf line 28, in resource "couchbase-capella_app_endpoint" "e1":
│   28: resource "couchbase-capella_app_endpoint" "e1" {
│
│ Received 403 Forbidden on Get App Endpoint e1. This indicates there may be a potential permissions (RBAC) issue. The Terraform state has not been modified. Check API permissions and try again.
│ Error: {"hint":"Your access to the requested resource is denied. Please make sure you have the necessary permissions to access the resource.","message":"Access
│ Denied.","code":1002,"httpStatusCode":403}

$ terraform state list
couchbase-capella_app_endpoint.e1
```

</details>

## Further comments