### PR TITLE
[AV-128452] Migrate to claude code

### DIFF
--- a/.claude/skills/tf-acceptance-test-gen/SKILL.md
+++ b/.claude/skills/tf-acceptance-test-gen/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: tf-acceptance-test-gen
+description: Generate acceptance tests for a named Terraform resource or data source in the Couchbase Capella provider.
+---
+
+# Terraform Acceptance Test Generator
+
+Acceptance tests live in `acceptance_tests/` and are named `<feature>_acceptance_test.go`.
+
+## Test structure
+
+Every resource test follows this pattern:
+
+```go
+func TestAcc<Feature>Resource(t *testing.T) {
+    resourceName := randomStringWithPrefix("tf_acc_<feature>_")
+    resourceReference := "couchbase-capella_<type_name>." + resourceName
+
+    resource.ParallelTest(t, resource.TestCase{
+        ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+        Steps: []resource.TestStep{
+            // Create and Read
+            {
+                Config: testAcc<Feature>ResourceConfig(resourceName, <values...>),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccExists<Feature>Resource(t, resourceReference),
+                    resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+                    resource.TestCheckResourceAttr(resourceReference, "<required_field>", "<expected_value>"),
+                    resource.TestCheckResourceAttrSet(resourceReference, "id"),
+                    resource.TestCheckResourceAttrSet(resourceReference, "<computed_field>"),
+                ),
+            },
+            // ImportState
+            {
+                ResourceName:      resourceReference,
+                ImportStateIdFunc: generate<Feature>ImportIdForResource(resourceReference),
+                ImportState:       true,
+            },
+            // Update (omit if resource has no updatable fields)
+            {
+                Config: testAcc<Feature>ResourceConfig(resourceName, <updated_values...>),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    resource.TestCheckResourceAttr(resourceReference, "<updated_field>", "<new_value>"),
+                ),
+            },
+        },
+            // Delete testing automatically occurs in TestCase
+    })
+}
+```
+
+- Always use `resource.ParallelTest()`.
+- Always include an ImportState step.
+- Use `TestCheckResourceAttr` for fields with known values; `TestCheckResourceAttrSet` for computed fields.
+- Never hardcode IDs — use `globalOrgId`, `globalProjectId`, `globalClusterId`, `globalBucketId`, `globalAppServiceId`.
+
+## Writing meaningful assertions
+
+The goal of each assertion is to guard a specific behaviour, not to confirm the test ran. Apply these rules:
+
+**Assert values, not just presence.** Every field you set in the config must be asserted with `TestCheckResourceAttr` using the exact value you set. `TestCheckResourceAttrSet` only proves a field is non-empty — it does not prove the provider stored the right value. Reserve `TestCheckResourceAttrSet` for fields whose values are genuinely unknowable at test time (server-generated IDs, timestamps, status fields set by the API).
+
+**After an update, assert the full state.** The update step must check every field — not just the one that changed. This catches regressions where updating field A silently resets field B to its default.
+
+**Error tests must be specific.** The `ExpectError` regex must match a substring of the real error message for that specific invalid input, not a generic pattern like `"error"` or `"invalid"`. Read the resource's `Create` implementation and `internal/errors/` to find the actual message. A test that accepts any error is not guarding the right behaviour.
+
+**Optional fields need their own test.** If a resource has optional fields that change API behaviour (not just metadata), write a dedicated test that sets those fields and asserts the resulting state. Don't rely on the happy-path test covering them incidentally.
+
+**Default values must be verified.** If a field has a default, write a test that omits it and asserts the default value appears in state. This confirms the provider applies and reads back the default correctly.
+
+## Config builder
+
+```go
+func testAcc<Feature>ResourceConfig(resourceName string, field1 <type>) string {
+    return fmt.Sprintf(`
+    %[1]s
+
+    resource "couchbase-capella_<type_name>" "%[2]s" {
+        organization_id = "%[3]s"
+        project_id      = "%[4]s"
+        cluster_id      = "%[5]s"
+        <field>         = <format_verb>
+    }
+    `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, field1)
+}
+```
+
+Always start with `%[1]s` for `globalProviderBlock`. Number format verbs sequentially.
+
+## Import ID function
+
+Read the `ImportState()` function in `internal/resources/<feature>.go` to find the exact composite key format, then implement:
+
+```go
+func generate<Feature>ImportIdForResource(resourceReference string) resource.ImportStateIdFunc {
+    return func(state *terraform.State) (string, error) {
+        var rawState map[string]string
+        for _, m := range state.Modules {
+            if len(m.Resources) > 0 {
+                if v, ok := m.Resources[resourceReference]; ok {
+                    rawState = v.Primary.Attributes
+                }
+            }
+        }
+        return fmt.Sprintf(
+            "id=%s,cluster_id=%s,project_id=%s,organization_id=%s",
+            rawState["id"], rawState["cluster_id"], rawState["project_id"], rawState["organization_id"],
+        ), nil
+    }
+}
+```
+
+## Error-case test
+
+```go
+func TestAcc<Feature>ResourceInvalid<Field>(t *testing.T) {
+    resourceName := randomStringWithPrefix("tf_acc_<feature>_")
+    resource.ParallelTest(t, resource.TestCase{
+        ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+        Steps: []resource.TestStep{
+            {
+                Config:      testAcc<Feature>ResourceConfig(resourceName, <invalid_value>),
+                ExpectError: regexp.MustCompile("<substring of expected error>"),
+            },
+        },
+    })
+}
+```
+
+## Data source tests
+
+- Test function names for datasources should use the pattern `TestAccDatasource<Feature>`. 
+  For example: `func TestAccDatasourceCluster(t *testing.T)`
+- Omit the ImportState and Update steps.
+
+## Verifying and running the tests
+
+At session start the environment check reports which variables are set. If all three required variables (`TF_VAR_host`, `TF_VAR_auth_token`, `TF_VAR_organization_id`) are present, run only the tests for the resource you just wrote:
+
+```bash
+TF_ACC=1 go test -timeout=60m -v ./acceptance_tests/ -run TestAcc<Feature>
+```
+
+When credentials are not available the tests cannot be executed. The only verification possible is that the file compiles:
+
+```bash
+go test -c ./acceptance_tests
+```
+
+If compile errors are found fix and recompile to verify no errors. 
+
+## Reference examples
+
+| Scenario | File |
+|---|---|
+| Simple resource with update | `acceptance_tests/snapshot_backup_acceptance_test.go` |
+| Resource with many optional fields | `acceptance_tests/apikey_acceptance_test.go` |
+| Complex nested resource | `acceptance_tests/cluster_acceptance_test.go` |

--- a/.claude/skills/tf-bugfix/SKILL.md
+++ b/.claude/skills/tf-bugfix/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: tf-bugfix
+description: Diagnose and fix bugs in the Terraform Capella provider with acceptance tests.
+---
+
+# Terraform Bug Fix
+
+## Instructions
+
+0. Read the Jira ticket or GitHub issue provided by the user.
+   Summarize: what is the bug, what is the expected behavior,
+   and what is the actual behavior.
+
+1. Search the codebase for the function, file, or code path
+   mentioned in the bug report. Read the relevant source files
+   to understand the current behavior.
+
+2. Identify the root cause. Explain why the current code
+   produces the bug (e.g., missing bounds check, nil pointer,
+   incorrect logic).
+
+3. Propose a robust fix that addresses the root cause.
+
+4. Add an acceptance test in `acceptance_tests/` to
+   validate the fix end-to-end:
+   - Follow existing patterns: use `resource.ParallelTest()`,
+     `globalProtoV6ProviderFactory`, and helper functions like
+     `randomStringWithPrefix`.
+   - Name the test in this format `TestAcc<Feature>_AV_XXXXX` e.g. `TestAccProject_AV_12345`.
+
+5. Do not run the acceptance test.

--- a/.claude/skills/tf-datasource-gen/SKILL.md
+++ b/.claude/skills/tf-datasource-gen/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: tf-datasource-gen
+description: generate terraform datasources based on openapi spec.
+---
+
+# Terraform Datasource Generator
+
+## Instructions
+
+0.  First inspect the repo for existing datasource code, schema files, api structs, 
+    provider registrations, and acceptance tests for the feature. For each step 1 through 
+    12 if the datasource already satisfies the user request skip the step 
+    completely, make no edits and proceed to the next step. Do not make any minor edits or fixes 
+    to existing code if the datasource already satisfies the user request. 
+    
+    For example:
+    - If api structs exist, skip creating them and use the existing structs
+    - If a datasource already exists, skip recreating it unless explicitly asked to edit it. 
+    - If an acceptance test already exists, skip creating a duplicate and extend coverage only if asked. 
+
+1.  datasource code should be in internal/datasources/
+2.  schema for datasource should be in its own file with format <feature>_schema.go
+
+    add validation for organization_id, project_id and cluster_id if present.  for example with organization_id
+
+```
+capellaschema.AddAttr(attrs, "organization_id", snapshotBackupBuilder, requiredStringWithValidator())
+
+func requiredStringWithValidator() *schema.StringAttribute {
+    return &schema.StringAttribute{
+        Required:   true,
+        Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
+    }
+}
+```
+
+3.  implement one or two datasources depending on the spec provided.
+
+    - the first is to get a specific resource.  use the get endpoint.  if there is no get endpoint then skip this implementation.
+    for example if the feature is Buckets then need bucket.go to get a specific bucket.
+
+    - the second datasource is to list all resources.  use the list endpoint. if there is no list endpoint then skip this implementation.
+    the file name should have a plural resource name.
+    for example if the feature is Buckets then need buckets.go to list all buckets.
+
+4.  create struct with feature name that embeds Data struct.  for example if the feature is Buckets then need this struct
+
+```
+type Buckets struct {
+    *providerschema.Data
+}
+```
+
+5.  need New function.  for example if feature is Buckets then need this function
+
+```
+func NewBuckets() datasource.DataSource {
+    return &Buckets{}
+}
+```
+
+6.  type should implement interfaces datasource.DataSource and datasource.DataSourceWithConfigure.
+    must use type conversion of nil to assert that the type implements the interfaces.
+
+    for example for Buckets
+
+```
+var (
+    _ datasource.DataSource              = (*Buckets)(nil)
+    _ datasource.DataSourceWithConfigure = (*Buckets)(nil)
+)
+```
+
+7.  need Metadata function.  for example with Buckets
+
+```
+func (d *Buckets) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+    resp.TypeName = req.ProviderTypeName + "_buckets"
+}
+```
+
+8.  need Configure function.  for example with Buckets
+
+```
+func (d *Buckets) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+    if req.ProviderData == nil {
+        return
+    }
+
+    data, ok := req.ProviderData.(*providerschema.Data)
+    if !ok {
+        resp.Diagnostics.AddError(
+            "Unexpected Data Source Configure Type",
+            fmt.Sprintf("Expected *providerschema.Data, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+        )
+
+        return
+    }
+
+    d.Data = data
+}
+```
+
+9.  generate necessary structs to handle API response.  put structs in internal/api/
+    use ClientV1 struct to make API calls with retry logic.  for example:
+
+```
+response, err := s.ClientV1.ExecuteWithRetry
+```
+
+10.  register the datasource in `internal/provider/provider.go` in func `(p *capellaProvider) DataSources`
+
+     for example with buckets need `datasources.NewBuckets,`
+
+11.  create acceptance tests for both datasources in acceptance_tests/ with format <feature>_test.go.
+     for example if feature is Buckets then need buckets_test.go
+
+12.  acceptance tests should run in parallel.  that is use resource.ParallelTest()
+
+

--- a/.claude/skills/tf-examples-gen/SKILL.md
+++ b/.claude/skills/tf-examples-gen/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: tf-examples-gen
+description: Generate terraform HCL examples for a feature.
+---
+
+# Terraform Examples Generator
+
+## Instructions
+
+- HCL must be in examples/.  For example if the feature is buckets create folder examples/buckets/
+
+### main.tf
+
+Create this file which should have the terraform block and provider block.
+```
+terraform {
+  required_providers {
+    couchbase-capella = {
+      source = "couchbasecloud/couchbase-capella"
+    }
+  }
+}
+
+provider "couchbase-capella" {
+  authentication_token = var.auth_token
+}
+```
+
+If main.tf exists and has terraform and provider blocks, skip this step.
+
+### variables.tf
+
+Create a file to store the variables needed for the resource and datasource.
+All examples must have the two variables organization_id and auth_token as shown
+below.
+
+```
+variable "organization_id" {
+  description = "Capella Organization ID"
+}
+
+variable "auth_token" {
+  description = "Authentication API Key"
+  sensitive   = true
+}
+```
+
+If variables.tf exists and has the necessary variables, skip this step.
+
+### terraform.template.tfvars
+
+Create a file which has placeholder values for the variables. For variables like
+organization_id use "<organization_id>".  For auth_token use "<v4-api-key-secret>"
+
+For other variables use values in ../couchbase-cloud/cmd/cp-open-api/specs/examples
+
+If terraform.template.tfvars exists and has the necessary variables, skip this step.
+
+- create_<feature>.tf
+
+Need a file named create_<feature>.tf. This file defines a resource for the specified feature.
+
+```
+
+resource "couchbase-capella_<feature>" "new_<feature>" {
+  // required and optional arguments for the resource
+}
+```
+
+The resource should have required and optional arguments derived from the
+schema in internal/resources/<feature>_schema.go
+
+If create_<feature>.tf exists and has the resource block, skip this step.
+
+### Determine if the feature has a datasource to list resources.
+
+Look for a file
+in internal/datasources/ with the plural name of the feature.
+For example if the feature is Buckets then look for buckets.go in internal/datasources/.
+
+If there is a datasource to list resources then create a list_<feature>.tf file
+it should look like this:
+
+```
+data "couchbase-capella_<feature_plural>" "list_<feature_plural>" {
+  // required and optional arguments for the datasource
+}
+```
+
+ The required and optional arguments should be derived from the schema in internal/datasources/<feature_plural>_schema.go
+
+ If there is no datasource to list resources then skip this step.
+
+
+### Look for a datasource to get a specific resource.
+
+Look for a file in internal/datasources/ with the singular name of the feature.
+For example if the feature is Buckets then look for bucket.go in internal/datasources/
+
+If there is a datasource to get a specific resource then create a get_<feature>.tf file
+it should look like this:
+
+```
+data "couchbase-capella_<feature>" "get_<feature>" {
+  // required and optional arguments for the datasource
+}
+```
+
+The required and optional arguments should be derived from the schema in internal/datasources/<feature>_schema.go
+
+If there is no datasource to get a specific resource then skip this step.
+
+### Run terraform validate to ensure the examples are valid terraform code.
+
+Fix errors until terraform validate passes.
+
+Do not run terraform init as tests will run against a dev build.

--- a/.claude/skills/tf-resource-gen/SKILL.md
+++ b/.claude/skills/tf-resource-gen/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: tf-resource-gen
+description: generate terraform resources based on openapi spec.
+---
+
+# Terraform Resource Generator
+
+## Instructions
+
+0.  First inspect the repo for existing resource code, schema files, api structs, 
+    provider registrations, and acceptance tests for the feature. For each step 1 through 
+    14 if the resource already satisfies the user request skip the step 
+    completely, make no edits and proceed to the next step. Do not make any minor edits or fixes 
+    to existing code if the resource already satisfies the user request. 
+    
+    For example:
+    - If api structs exist, skip creating them and use the existing structs
+    - If a resource already exists, skip recreating it unless explicitly asked to edit it. 
+    - If an acceptance test already exists, skip creating a duplicate and extend coverage only if asked. 
+
+1.  Resource code should be in `internal/resources/`.
+
+2.  Schema for the resource should be in its own file with format `<feature>_schema.go` in `internal/resources/`.
+
+ Add validation for organization_id, project_id and cluster_id if present. For example with organization_id:
+
+```
+ capellaschema.AddAttr(attrs, "organization_id", builder, stringAttribute([]string{required, requiresReplace},
+validator.String(stringvalidator.LengthAtLeast(1))))
+```
+
+3.  Create a struct with the feature name that embeds the Data struct. For example if the feature is SnapshotBackup:
+
+```
+ type SnapshotBackup struct {
+     *providerschema.Data
+ }
+```
+
+4.  Need a New function. For example:
+
+```
+ func NewSnapshotBackup() resource.Resource {
+     return &SnapshotBackup{}
+ }
+```
+
+5.  Type should implement interfaces `resource.Resource`, `resource.ResourceWithConfigure`, and `resource.ResourceWithImportState`.
+ Must use type conversion of nil to assert that the type implements the interfaces:
+
+```
+ var (
+     _ resource.Resource                = (*SnapshotBackup)(nil)
+     _ resource.ResourceWithConfigure   = (*SnapshotBackup)(nil)
+     _ resource.ResourceWithImportState = (*SnapshotBackup)(nil)
+ )
+ ```
+
+6.  Need Metadata function that sets `resp.TypeName = req.ProviderTypeName + "_<resource_name>"`.
+
+7.  Need Schema function that calls the schema function from the schema file:
+
+```
+ func (s *SnapshotBackup) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+     resp.Schema = SnapshotBackupSchema()
+ }
+```
+
+8.  Need Configure function following this pattern:
+
+```
+ func (s *SnapshotBackup) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+     if req.ProviderData == nil {
+         return
+     }
+     data, ok := req.ProviderData.(*providerschema.Data)
+     if !ok {
+         resp.Diagnostics.AddError(
+             "Unexpected Resource Configure Type",
+             fmt.Sprintf("Expected *providerschema, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+         )
+         return
+     }
+     s.Data = data
+ }
+```
+
+9.  Need ImportState function using `resource.ImportStatePassthroughID`.
+
+10. Implement CRUD methods (Create, Read, Update, Delete):
+ - Create: use create endpoint, unmarshal response, call get to populate refreshed state, set state.
+
+   Check if the create endpoint is async. In the spec look for 202 response code. If async follow steps in
+   Polling Resources section.
+
+ - Read: use get endpoint. validate IDs from state, call get endpoint, morph response to terraform state, handle ErrNotFound by removing resource from state.
+ - Update: use update endpoint. if there is no update endpoint, update handler should have empty function body.
+   leave a comment explaining that the resource does not support in-place updates, so an empty update handler will cause
+   the framework to recreate the resource. mark all user-configurable attributes that can change with the `RequiresReplace` plan modifier so that any change forces recreation.
+
+   If the create endpoint is async, follow the steps in Polling Resources section for the update endpoint as well.
+
+ - Delete: use delete endpoint, handle resource-not-found gracefully (just return without error).
+
+   If there is no delete endpoint then delete handler has empty function body.
+
+   If the create endpoint is async, follow the steps in Polling Resources section for the delete endpoint as well.
+
+11. Generate necessary API request/response structs in `internal/api/<feature>/`. Use `ClientV1` to make API calls with retry logic:
+
+```
+ response, err := s.ClientV1.ExecuteWithRetry(ctx, cfg, requestBody, s.Token, nil)
+```
+
+ Use `api.EndpointCfg` with appropriate URL, Method, and SuccessStatus.
+
+12. Create a morph function to convert API response structs to terraform schema structs. Place terraform schema structs in `internal/schema/`.
+
+13. Register the resource in `internal/provider/provider.go` in `func (p *capellaProvider) Resources`.
+
+14. Create acceptance tests in `acceptance_tests/` with format `<feature>_acceptance_test.go`.
+ - Tests should run in parallel using `resource.ParallelTest()`.
+ - Include test steps for: Create+Read, ImportState, Update, and Delete (implicit).
+ - Use `globalProtoV6ProviderFactory` for provider factories.
+ - Use helper functions like `randomStringWithPrefix` for resource names.
+ - Verify key attributes with `resource.TestCheckResourceAttr` and `resource.TestCheckResourceAttrSet`.
+
+
+
+## Polling Resources
+
+After calling the create, update or delete endpoint poll the resource until it reaches a final state. The function should be
+called checkFeatureStatus. For example if the feature is Cluster then the function is checkClusterStatus.
+Return the refreshed terraform state.
+
+The pattern is:
+
+```
+func (c *Cluster) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+
+// get plan
+
+// call create endpoint
+
+refreshedState, err = c.checkClusterStatus(ctx, organizationId, projectId, clusterResponse.Id.String())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating cluster",
+			errorMessageAfterClusterCreationInitiation+api.ParseError(err),
+		)
+		return
+	}
+
+// set state
+
+diags = resp.State.Set(ctx, refreshedState)
+	resp.Diagnostics.Append(diags...)
+
+}
+```
+
+Do not call checkClusterStatus and getCluster/retrieveCluster back-to-back as this is redundant.
+Use this pattern for Update and Delete handlers.
+
+
+Here is an example on how to poll a resource. It must return a terraform object that can be set to state.
+It should use a ticker to poll every 1 minute and a context timeout of 60 minutes. If the context times out return an error.
+
+If the resource reaches a final state return the refreshed state. If there is an error calling getCluster just try again.
+```
+func (c *Cluster) checkClusterStatus(ctx context.Context, organizationId, projectId, ClusterId string) (*providerschema.Cluster, error) {
+	const timeout = time.Minute * 60
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("cluster creation status transition timed out after initiation: %w", ctx.Err())
+		case <-ticker.C:
+			clusterResp, err := c.getCluster(ctx, organizationId, projectId, ClusterId)
+			if err != nil {
+				tflog.Info(ctx, "retrying after error polling cluster status", map[string]interface{}{"error": err.Error()})
+				continue
+			}
+
+			if clusterapi.IsFinalState(clusterResp.CurrentState) {
+				audit := providerschema.NewCouchbaseAuditData(clusterResp.Audit)
+				auditObj, diags := types.ObjectValueFrom(ctx, audit.AttributeTypes(), audit)
+				if diags.HasError() {
+					return nil, fmt.Errorf("%s: %s", errors.ErrUnableToConvertAuditData, diags.Errors())
+				}
+				refreshedState, err := providerschema.NewCluster(ctx, clusterResp, organizationId, projectId, auditObj)
+				if err != nil {
+					return nil, fmt.Errorf("%s: %w", errors.ErrRefreshingState, err)
+				}
+				return refreshedState, nil
+			}
+
+			tflog.Info(ctx, "waiting for cluster to complete the execution")
+		}
+	}
+}
+```

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ bin
 # Ignore terraform hidden folder
 .terraform
 
+# Ignore Claude local settings
+.claude/settings.local.json
+
 # General
 .DS_STORE
 .idea

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Code Review
+
+0.  stage all relevant changes (including deletions and renames), run `git add FILEPATH`
+1.  run git diff --cached main --name-only -- '*.go' ':!internal/generated/api/openapi.gen.go'
+
+    do not read the openapi.gen.go file as it will consume many tokens and fill up the context window.
+
+2.  verify new datasources and resources use ClientV1.  if not update the code to use ClientV1.
+
+3.  for each go file, look at git diff of the file compared to the one in main
+4.  Unexported symbols only need comments if they have side effects, workarounds or constraints not evident from the name and signature.
+5.  run goimports -w -local github.com/couchbasecloud/terraform-provider-couchbase-capella on the file
+6.  run go vet on the file and fix any errors
+7.  build the binary as follows
+
+get the latest git tag and assign to VERSION:
+
+```
+VERSION=$(git describe --tags --abbrev=0)
+```
+
+then build:
+
+```
+go build -ldflags "-s -w -X 'github.com/couchbasecloud/terraform-provider-couchbase-capella/version.ProviderVersion=$VERSION'" -o ./bin/terraform-provider-couchbase-capella
+```
+
+fix any errors.
+
+8.  repeat steps 5-7 until there are no errors.  retry up to 5 times.  if errors persist report them.


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-128452

## Description

migrate agent and skill markdown files to claude

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

```
/memory                                                                                                                                                               
                                                                                                                                                                        
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  Memory                                                                                                                                                                
                                                                                                                                                                        
    Auto-memory: on                                                                                                                                                     
                                                                                                                                                                        
  ❯ 1. Project memory           Checked in at ./CLAUDE.md      
```

 
```
/skills                                                                                                                                                               
       
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  Skills                                                                                                                                                              
  5 skills · Enter to use, t to sort, Esc to close                                                                                                                
                                                                                                                                                                    
  ❯ ✔ on         tf-acceptance-test-gen · project · ~32 tok                                                                                                         
    ✔ on         tf-bugfix · project · ~22 tok                                                                                                                      
    ✔ on         tf-datasource-gen · project · ~18 tok                                    
    ✔ on         tf-examples-gen · project · ~16 tok
    ✔ on         tf-resource-gen · project · ~17 tok
```

</details>

## Further comments