### PR TITLE
[AV-125170] Fix endpoint creation without CORS

### DIFF
--- a/internal/resources/app_endpoint.go
+++ b/internal/resources/app_endpoint.go
@@ -184,7 +184,7 @@ func setAppEndpointComputedAttributesToNull(ctx context.Context, plan *providers
 
 				collectionsMapValue, d := types.MapValueFrom(ctx, types.ObjectType{
 					AttrTypes: providerschema.
-					AppEndpointCollection{}.
+						AppEndpointCollection{}.
 						AttributeTypes(),
 				}, collectionsMap)
 				diags.Append(d...)
@@ -201,7 +201,7 @@ func setAppEndpointComputedAttributesToNull(ctx context.Context, plan *providers
 				"collections": types.MapType{
 					ElemType: types.ObjectType{
 						AttrTypes: providerschema.
-						AppEndpointCollection{}.
+							AppEndpointCollection{}.
 							AttributeTypes(),
 					},
 				},
@@ -218,8 +218,15 @@ func setAppEndpointComputedAttributesToNull(ctx context.Context, plan *providers
 		if plan.Cors.MaxAge.IsNull() || plan.Cors.MaxAge.IsUnknown() {
 			plan.Cors.MaxAge = types.Int64Null()
 		}
-		if plan.Cors.Disabled.IsNull() || plan.Cors.Disabled.IsUnknown() {
-			plan.Cors.Disabled = types.BoolNull()
+		plan.Cors.Disabled = types.BoolNull()
+		if plan.Cors.Origin.IsNull() || plan.Cors.Origin.IsUnknown() {
+			plan.Cors.Origin = types.SetNull(types.StringType)
+		}
+		if plan.Cors.LoginOrigin.IsNull() || plan.Cors.LoginOrigin.IsUnknown() {
+			plan.Cors.LoginOrigin = types.SetNull(types.StringType)
+		}
+		if plan.Cors.Headers.IsNull() || plan.Cors.Headers.IsUnknown() {
+			plan.Cors.Headers = types.SetNull(types.StringType)
 		}
 	}
 
@@ -554,7 +561,7 @@ func (a *AppEndpoint) refreshAppEndpoint(
 				ctx,
 				types.ObjectType{
 					AttrTypes: providerschema.
-					AppEndpointCollection{}.
+						AppEndpointCollection{}.
 						AttributeTypes(),
 				},
 				collectionsMapElements,
@@ -588,7 +595,7 @@ func (a *AppEndpoint) refreshAppEndpoint(
 			ctx,
 			types.ObjectType{
 				AttrTypes: providerschema.
-				AppEndpointScope{}.
+					AppEndpointScope{}.
 					AttributeTypes(),
 			},
 			scopesMapElements,
@@ -604,35 +611,9 @@ func (a *AppEndpoint) refreshAppEndpoint(
 		state.Cors.Disabled = types.BoolValue(appEndpoint.Cors.Disabled)
 		state.Cors.MaxAge = types.Int64Value(appEndpoint.Cors.MaxAge)
 
-		originSet, diags := types.SetValueFrom(
-			ctx,
-			types.StringType,
-			appEndpoint.Cors.Origin,
-		)
-		if diags.HasError() {
-			return nil, fmt.Errorf("error converting CORS origins: %v", diags.Errors())
-		}
-		state.Cors.Origin = originSet
-
-		loginOriginSet, diags := types.SetValueFrom(
-			ctx,
-			types.StringType,
-			appEndpoint.Cors.LoginOrigin,
-		)
-		if diags.HasError() {
-			return nil, fmt.Errorf("error converting CORS login origins: %v", diags.Errors())
-		}
-		state.Cors.LoginOrigin = loginOriginSet
-
-		headersSet, diags := types.SetValueFrom(
-			ctx,
-			types.StringType,
-			appEndpoint.Cors.Headers,
-		)
-		if diags.HasError() {
-			return nil, fmt.Errorf("error converting CORS headers: %v", diags.Errors())
-		}
-		state.Cors.Headers = headersSet
+		state.Cors.Origin = stringSliceToSetValue(ctx, appEndpoint.Cors.Origin)
+		state.Cors.LoginOrigin = stringSliceToSetValue(ctx, appEndpoint.Cors.LoginOrigin)
+		state.Cors.Headers = stringSliceToSetValue(ctx, appEndpoint.Cors.Headers)
 	}
 
 	if len(appEndpoint.Oidc) > 0 {
@@ -654,6 +635,20 @@ func (a *AppEndpoint) refreshAppEndpoint(
 	}
 
 	return state, nil
+}
+
+// stringSliceToSetValue converts a string slice to a Terraform set value.
+// Returns a null set if the slice is nil or empty.
+func stringSliceToSetValue(_ context.Context, values []string) types.Set {
+	if len(values) == 0 {
+		return types.SetNull(types.StringType)
+	}
+	elems := make([]attr.Value, len(values))
+	for i, v := range values {
+		elems[i] = types.StringValue(v)
+	}
+	set, _ := types.SetValue(types.StringType, elems)
+	return set
 }
 
 // morphToAppEndpointRequest converts the Terraform plan to the request format expected by the Capella API for creating/updating an App Endpoint.

--- a/internal/resources/app_endpoint_schema.go
+++ b/internal/resources/app_endpoint_schema.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -49,26 +48,11 @@ func AppEndpointSchema() schema.Schema {
 
 	// CORS attributes - use CORSConfig schema
 	corsAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(corsAttrs, "origin", appEndpointBuilder, &schema.SetAttribute{
-		Optional:    true,
-		ElementType: types.StringType,
-	}, "CORSConfig")
-	capellaschema.AddAttr(corsAttrs, "login_origin", appEndpointBuilder, &schema.SetAttribute{
-		Optional:    true,
-		ElementType: types.StringType,
-	}, "CORSConfig")
-	capellaschema.AddAttr(corsAttrs, "headers", appEndpointBuilder, &schema.SetAttribute{
-		Optional:    true,
-		ElementType: types.StringType,
-	}, "CORSConfig")
+	capellaschema.AddAttr(corsAttrs, "origin", appEndpointBuilder, stringSetAttribute(optional, computed, useStateForUnknown), "CORSConfig")
+	capellaschema.AddAttr(corsAttrs, "login_origin", appEndpointBuilder, stringSetAttribute(optional, computed, useStateForUnknown), "CORSConfig")
+	capellaschema.AddAttr(corsAttrs, "headers", appEndpointBuilder, stringSetAttribute(optional, computed, useStateForUnknown), "CORSConfig")
 	capellaschema.AddAttr(corsAttrs, "max_age", appEndpointBuilder, int64Attribute(optional, computed, useStateForUnknown), "CORSConfig")
-	capellaschema.AddAttr(corsAttrs, "disabled", appEndpointBuilder, &schema.BoolAttribute{
-		Optional: true,
-		Computed: true,
-		PlanModifiers: []planmodifier.Bool{
-			boolplanmodifier.UseStateForUnknown(),
-		},
-	}, "CORSConfig")
+	capellaschema.AddAttr(corsAttrs, "disabled", appEndpointBuilder, boolAttribute(optional, computed), "CORSConfig")
 
 	capellaschema.AddAttr(attrs, "cors", appEndpointBuilder, &schema.SingleNestedAttribute{
 		Optional:   true,

--- a/internal/resources/attributes.go
+++ b/internal/resources/attributes.go
@@ -263,10 +263,9 @@ func stringSetAttribute(fields ...string) *schema.SetAttribute {
 		case sensitive:
 			attribute.Sensitive = true
 		case requiresReplace:
-			var planModifiers = []planmodifier.Set{
-				setplanmodifier.RequiresReplace(),
-			}
-			attribute.PlanModifiers = planModifiers
+			attribute.PlanModifiers = append(attribute.PlanModifiers, setplanmodifier.RequiresReplace())
+		case useStateForUnknown:
+			attribute.PlanModifiers = append(attribute.PlanModifiers, setplanmodifier.UseStateForUnknown())
 		}
 	}
 	return &attribute


### PR DESCRIPTION
## Jira

* AV-125170

## Description

Aligns App Endpoint CORS schema with management API changes from [couchbase-cloud#50585](https://github.com/couchbasecloud/couchbase-cloud/pull/50585), where disabled is now always returned and origin returns [] when CORS is disabled.

- Schema: Made origin, login_origin, headers Optional+Computed+UseStateForUnknown; removed UseStateForUnknown from disabled (API always returns it now).

- State handling: Added null initialisation for computed CORS set fields; extracted stringSliceToSetValue helper to convert empty API arrays to null sets (prevents spurious diffs).

- Helpers: Added useStateForUnknown support to stringSetAttribute.

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments