### PR TITLE
[AV-128910] Pre-install Terraform CLI in CI

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -37,5 +37,9 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: cache-${{ github.run_id }}
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: 1.14.9
+          terraform_wrapper: false
       - name: Run acceptance tests
         run: make testacc


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-128910

## Description

This change makes Acceptance Test workflow setup Terraform using the `hashicorp/setup-terraform` Github action. This pins the latest TF version (1.14.9), which should be updated periodically.

This should prevent us running in to this GPG expiration issues in the future. Details on the GPG expiration can be found at: https://discuss.hashicorp.com/t/hcsec-2026-03-hashicorp-gpg-key-72d7468f-update/77237 .

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

Acceptance tests pass: https://github.com/couchbasecloud/terraform-provider-couchbase-capella/actions/runs/25045726139/job/73360163991?pr=567

</details>

## Further comments