### PR TITLE
[AV-129390] Add get_cluster and get_project datasource examples

### DIFF
--- a/examples/cluster/get_cluster.tf
+++ b/examples/cluster/get_cluster.tf
@@ -1,0 +1,9 @@
+output "existing_cluster" {
+  value = data.couchbase-capella_cluster.existing_cluster
+}
+
+data "couchbase-capella_cluster" "existing_cluster" {
+  organization_id = var.organization_id
+  project_id      = var.project_id
+  id              = var.cluster_id
+}

--- a/examples/cluster/terraform.template.tfvars
+++ b/examples/cluster/terraform.template.tfvars
@@ -1,6 +1,7 @@
 auth_token      = "<v4-api-key-secret>"
 organization_id = "<organization_id>"
 project_id      = "<project_id>"
+cluster_id      = "<cluster_id>"
 
 cloud_provider = {
   name   = "aws",

--- a/examples/cluster/variables.tf
+++ b/examples/cluster/variables.tf
@@ -60,3 +60,7 @@ variable "support" {
     timezone = string
   })
 }
+
+variable "cluster_id" {
+  description = "Cluster ID"
+}

--- a/examples/project/get_project.tf
+++ b/examples/project/get_project.tf
@@ -1,0 +1,8 @@
+output "existing_project" {
+  value = data.couchbase-capella_project.existing_project
+}
+
+data "couchbase-capella_project" "existing_project" {
+  organization_id = var.organization_id
+  id              = var.project_id
+}

--- a/examples/project/terraform.template.tfvars
+++ b/examples/project/terraform.template.tfvars
@@ -1,2 +1,3 @@
 auth_token      = "<v4-api-key-secret>"
 organization_id = "<organization_id>"
+project_id      = "<project_id>"

--- a/examples/project/variables.tf
+++ b/examples/project/variables.tf
@@ -11,3 +11,7 @@ variable "project_name" {
   default     = "terraform-couchbasecapella-project"
   description = "Project Name for Project Created via Terraform"
 }
+
+variable "project_id" {
+  description = "Project ID"
+}


### PR DESCRIPTION
[AV-129390](https://couchbasecloud.atlassian.net/browse/AV-129390) 

## Summary

- Adds `get_cluster.tf` to `examples/cluster/` — demonstrates the `couchbase-capella_cluster` datasource for fetching a single cluster by ID
- Adds `get_project.tf` to `examples/project/` — demonstrates the `couchbase-capella_project` datasource for fetching a single project by ID
- Updates `variables.tf` and `terraform.template.tfvars` in both example directories to include the new `cluster_id` / `project_id` input variables

## Test plan

- [ ] Run `terraform validate` inside `examples/cluster/` (after `terraform init` against a dev build)
- [ ] Run `terraform validate` inside `examples/project/` (after `terraform init` against a dev build)
- [ ] Confirm `data.couchbase-capella_cluster.existing_cluster` output matches a real cluster when applied
- [ ] Confirm `data.couchbase-capella_project.existing_project` output matches a real project when applied

[AV-129390]: https://couchbasecloud.atlassian.net/browse/AV-129390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ