### PR TITLE
[AV-129390] Add datasource examples for cluster and project

### DIFF
--- a/examples/cluster/get_cluster.tf
+++ b/examples/cluster/get_cluster.tf
@@ -1,0 +1,9 @@
+output "existing_cluster" {
+  value = data.couchbase-capella_cluster.existing_cluster
+}
+
+data "couchbase-capella_cluster" "existing_cluster" {
+  organization_id = var.organization_id
+  project_id      = var.project_id
+  id              = var.cluster_id
+}

--- a/examples/cluster/terraform.template.tfvars
+++ b/examples/cluster/terraform.template.tfvars
@@ -1,6 +1,7 @@
 auth_token      = "<v4-api-key-secret>"
 organization_id = "<organization_id>"
 project_id      = "<project_id>"
+cluster_id      = "<cluster_id>"
 
 cloud_provider = {
   name   = "aws",

--- a/examples/cluster/variables.tf
+++ b/examples/cluster/variables.tf
@@ -60,3 +60,7 @@ variable "support" {
     timezone = string
   })
 }
+
+variable "cluster_id" {
+  description = "Cluster ID"
+}

--- a/examples/project/get_project.tf
+++ b/examples/project/get_project.tf
@@ -1,0 +1,8 @@
+output "existing_project" {
+  value = data.couchbase-capella_project.existing_project
+}
+
+data "couchbase-capella_project" "existing_project" {
+  organization_id = var.organization_id
+  id              = var.project_id
+}

--- a/examples/project/terraform.template.tfvars
+++ b/examples/project/terraform.template.tfvars
@@ -1,2 +1,3 @@
 auth_token      = "<v4-api-key-secret>"
 organization_id = "<organization_id>"
+project_id      = "<project_id>"

--- a/examples/project/variables.tf
+++ b/examples/project/variables.tf
@@ -11,3 +11,7 @@ variable "project_name" {
   default     = "terraform-couchbasecapella-project"
   description = "Project Name for Project Created via Terraform"
 }
+
+variable "project_id" {
+  description = "Project ID"
+}


### PR DESCRIPTION
## Jira

* AV-129390

## Description

- Adds get_cluster.tf to examples/cluster/ — demonstrates the couchbase-capella_cluster datasource for fetching a single cluster by ID

- Adds get_project.tf to examples/project/ — demonstrates the couchbase-capella_project datasource for fetching a single project by ID

- Updates variables.tf and terraform.template.tfvars in both example directories to include the new cluster_id / project_id input variables

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [x] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [x] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments