### PR TITLE
[AV-129333] Add enum validators to bucket resource schema

### DIFF
--- a/acceptance_tests/bucket_acceptance_test.go
+++ b/acceptance_tests/bucket_acceptance_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 var bucketEnumValidatorErr = regexp.MustCompile(`value must be one of:`)
@@ -60,6 +61,7 @@ func TestAccBucketEnumValidators(t *testing.T) {
 			{
 				Config: testAccBucketConfigWithValidEnumFields(resourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("couchbase-capella_bucket."+resourceName, "id"),
 					resource.TestCheckResourceAttr("couchbase-capella_bucket."+resourceName, "type", "couchbase"),
 					resource.TestCheckResourceAttr("couchbase-capella_bucket."+resourceName, "storage_backend", "couchstore"),
 					resource.TestCheckResourceAttr("couchbase-capella_bucket."+resourceName, "bucket_conflict_resolution", "seqno"),
@@ -67,6 +69,12 @@ func TestAccBucketEnumValidators(t *testing.T) {
 					resource.TestCheckResourceAttr("couchbase-capella_bucket."+resourceName, "replicas", "1"),
 					resource.TestCheckResourceAttr("couchbase-capella_bucket."+resourceName, "eviction_policy", "fullEviction"),
 				),
+			},
+			{
+				ResourceName:      "couchbase-capella_bucket." + resourceName,
+				ImportStateIdFunc: generateBucketImportIdForResource("couchbase-capella_bucket." + resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -166,4 +174,18 @@ resource "couchbase-capella_bucket" "%[2]s" {
   eviction_policy            = "fullEviction"
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId)
+}
+
+func generateBucketImportIdForResource(resourceReference string) resource.ImportStateIdFunc {
+	return func(state *terraform.State) (string, error) {
+		var rawState map[string]string
+		for _, m := range state.Modules {
+			if len(m.Resources) > 0 {
+				if v, ok := m.Resources[resourceReference]; ok {
+					rawState = v.Primary.Attributes
+				}
+			}
+		}
+		return fmt.Sprintf("id=%s,cluster_id=%s,project_id=%s,organization_id=%s", rawState["id"], rawState["cluster_id"], rawState["project_id"], rawState["organization_id"]), nil
+	}
 }

--- a/acceptance_tests/bucket_acceptance_test.go
+++ b/acceptance_tests/bucket_acceptance_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// TestAccBucketEnumValidators_AV_129333 verifies that schema-level enum validators
+// TestAccBucketEnumValidators verifies that schema-level enum validators
 // reject out-of-range values at plan time for the bucket resource fields:
 // type, storage_backend, bucket_conflict_resolution, durability_level, replicas, eviction_policy.
-func TestAccBucketEnumValidators_AV_129333(t *testing.T) {
+// Jira: AV-129333.
+func TestAccBucketEnumValidators(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_bucket_validators_")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/acceptance_tests/bucket_acceptance_test.go
+++ b/acceptance_tests/bucket_acceptance_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+var bucketEnumValidatorErr = regexp.MustCompile(`value must be one of:`)
+
 // TestAccBucketEnumValidators verifies that schema-level enum validators
 // reject out-of-range values at plan time for the bucket resource fields:
 // type, storage_backend, bucket_conflict_resolution, durability_level, replicas, eviction_policy.
@@ -21,32 +23,32 @@ func TestAccBucketEnumValidators(t *testing.T) {
 			// Invalid type
 			{
 				Config:      testAccBucketConfigWithInvalidType(resourceName),
-				ExpectError: regexp.MustCompile(`value must be one of:`),
+				ExpectError: bucketEnumValidatorErr,
 			},
 			// Invalid storage_backend
 			{
 				Config:      testAccBucketConfigWithInvalidStorageBackend(resourceName),
-				ExpectError: regexp.MustCompile(`value must be one of:`),
+				ExpectError: bucketEnumValidatorErr,
 			},
 			// Invalid bucket_conflict_resolution
 			{
 				Config:      testAccBucketConfigWithInvalidConflictResolution(resourceName),
-				ExpectError: regexp.MustCompile(`value must be one of:`),
+				ExpectError: bucketEnumValidatorErr,
 			},
 			// Invalid durability_level
 			{
 				Config:      testAccBucketConfigWithInvalidDurabilityLevel(resourceName),
-				ExpectError: regexp.MustCompile(`value must be one of:`),
+				ExpectError: bucketEnumValidatorErr,
 			},
 			// Invalid replicas
 			{
 				Config:      testAccBucketConfigWithInvalidReplicas(resourceName),
-				ExpectError: regexp.MustCompile(`value must be one of:`),
+				ExpectError: bucketEnumValidatorErr,
 			},
 			// Invalid eviction_policy
 			{
 				Config:      testAccBucketConfigWithInvalidEvictionPolicy(resourceName),
-				ExpectError: regexp.MustCompile(`value must be one of:`),
+				ExpectError: bucketEnumValidatorErr,
 			},
 			// Valid configuration — accepted values for every enum field
 			{

--- a/acceptance_tests/bucket_acceptance_test.go
+++ b/acceptance_tests/bucket_acceptance_test.go
@@ -24,31 +24,37 @@ func TestAccBucketEnumValidators(t *testing.T) {
 			{
 				Config:      testAccBucketConfigWithInvalidType(resourceName),
 				ExpectError: bucketEnumValidatorErr,
+				PlanOnly:    true,
 			},
 			// Invalid storage_backend
 			{
 				Config:      testAccBucketConfigWithInvalidStorageBackend(resourceName),
 				ExpectError: bucketEnumValidatorErr,
+				PlanOnly:    true,
 			},
 			// Invalid bucket_conflict_resolution
 			{
 				Config:      testAccBucketConfigWithInvalidConflictResolution(resourceName),
 				ExpectError: bucketEnumValidatorErr,
+				PlanOnly:    true,
 			},
 			// Invalid durability_level
 			{
 				Config:      testAccBucketConfigWithInvalidDurabilityLevel(resourceName),
 				ExpectError: bucketEnumValidatorErr,
+				PlanOnly:    true,
 			},
 			// Invalid replicas
 			{
 				Config:      testAccBucketConfigWithInvalidReplicas(resourceName),
 				ExpectError: bucketEnumValidatorErr,
+				PlanOnly:    true,
 			},
 			// Invalid eviction_policy
 			{
 				Config:      testAccBucketConfigWithInvalidEvictionPolicy(resourceName),
 				ExpectError: bucketEnumValidatorErr,
+				PlanOnly:    true,
 			},
 			// Valid configuration — accepted values for every enum field
 			{

--- a/acceptance_tests/bucket_acceptance_test.go
+++ b/acceptance_tests/bucket_acceptance_test.go
@@ -1,0 +1,160 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccBucketEnumValidators_AV_129333 verifies that schema-level enum validators
+// reject out-of-range values at plan time for the bucket resource fields:
+// type, storage_backend, bucket_conflict_resolution, durability_level, replicas, eviction_policy.
+func TestAccBucketEnumValidators_AV_129333(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_bucket_validators_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			// Invalid type
+			{
+				Config:      testAccBucketConfigWithInvalidType(resourceName),
+				ExpectError: regexp.MustCompile(`value must be one of:`),
+			},
+			// Invalid storage_backend
+			{
+				Config:      testAccBucketConfigWithInvalidStorageBackend(resourceName),
+				ExpectError: regexp.MustCompile(`value must be one of:`),
+			},
+			// Invalid bucket_conflict_resolution
+			{
+				Config:      testAccBucketConfigWithInvalidConflictResolution(resourceName),
+				ExpectError: regexp.MustCompile(`value must be one of:`),
+			},
+			// Invalid durability_level
+			{
+				Config:      testAccBucketConfigWithInvalidDurabilityLevel(resourceName),
+				ExpectError: regexp.MustCompile(`value must be one of:`),
+			},
+			// Invalid replicas
+			{
+				Config:      testAccBucketConfigWithInvalidReplicas(resourceName),
+				ExpectError: regexp.MustCompile(`value must be one of:`),
+			},
+			// Invalid eviction_policy
+			{
+				Config:      testAccBucketConfigWithInvalidEvictionPolicy(resourceName),
+				ExpectError: regexp.MustCompile(`value must be one of:`),
+			},
+			// Valid configuration — accepted values for every enum field
+			{
+				Config: testAccBucketConfigWithValidEnumFields(resourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("couchbase-capella_bucket."+resourceName, "type", "couchbase"),
+					resource.TestCheckResourceAttr("couchbase-capella_bucket."+resourceName, "storage_backend", "couchstore"),
+					resource.TestCheckResourceAttr("couchbase-capella_bucket."+resourceName, "bucket_conflict_resolution", "seqno"),
+					resource.TestCheckResourceAttr("couchbase-capella_bucket."+resourceName, "durability_level", "none"),
+					resource.TestCheckResourceAttr("couchbase-capella_bucket."+resourceName, "replicas", "1"),
+					resource.TestCheckResourceAttr("couchbase-capella_bucket."+resourceName, "eviction_policy", "fullEviction"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBucketConfigWithInvalidType(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_bucket" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  name            = "%[2]s"
+  type            = "invalid_type"
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId)
+}
+
+func testAccBucketConfigWithInvalidStorageBackend(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_bucket" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  name            = "%[2]s"
+  storage_backend = "invalid_backend"
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId)
+}
+
+func testAccBucketConfigWithInvalidConflictResolution(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_bucket" "%[2]s" {
+  organization_id           = "%[3]s"
+  project_id                = "%[4]s"
+  cluster_id                = "%[5]s"
+  name                      = "%[2]s"
+  bucket_conflict_resolution = "invalid_resolution"
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId)
+}
+
+func testAccBucketConfigWithInvalidDurabilityLevel(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_bucket" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  name            = "%[2]s"
+  durability_level = "invalid_level"
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId)
+}
+
+func testAccBucketConfigWithInvalidReplicas(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_bucket" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  name            = "%[2]s"
+  replicas        = 5
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId)
+}
+
+func testAccBucketConfigWithInvalidEvictionPolicy(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_bucket" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  name            = "%[2]s"
+  eviction_policy = "invalid_policy"
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId)
+}
+
+func testAccBucketConfigWithValidEnumFields(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_bucket" "%[2]s" {
+  organization_id            = "%[3]s"
+  project_id                 = "%[4]s"
+  cluster_id                 = "%[5]s"
+  name                       = "%[2]s"
+  type                       = "couchbase"
+  storage_backend            = "couchstore"
+  bucket_conflict_resolution = "seqno"
+  durability_level           = "none"
+  replicas                   = 1
+  eviction_policy            = "fullEviction"
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId)
+}

--- a/internal/resources/bucket_schema.go
+++ b/internal/resources/bucket_schema.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -20,8 +21,10 @@ func BucketSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", bucketBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "project_id", bucketBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "cluster_id", bucketBuilder, requiredUUIDStringAttribute())
-	capellaschema.AddAttr(attrs, "type", bucketBuilder, stringAttribute([]string{computed, optional, requiresReplace, useStateForUnknown}))
-	capellaschema.AddAttr(attrs, "storage_backend", bucketBuilder, stringAttribute([]string{computed, optional, requiresReplace, useStateForUnknown}))
+	capellaschema.AddAttr(attrs, "type", bucketBuilder, stringAttribute([]string{computed, optional, requiresReplace, useStateForUnknown},
+		stringvalidator.OneOf("couchbase", "ephemeral")))
+	capellaschema.AddAttr(attrs, "storage_backend", bucketBuilder, stringAttribute([]string{computed, optional, requiresReplace, useStateForUnknown},
+		stringvalidator.OneOf("couchstore", "magma")))
 	capellaschema.AddAttr(attrs, "memory_allocation_in_mb", bucketBuilder, int64Attribute(optional, computed))
 	capellaschema.AddAttr(attrs, "vbuckets", bucketBuilder, &schema.Int64Attribute{
 		Optional: true,
@@ -34,12 +37,22 @@ func BucketSchema() schema.Schema {
 			int64validator.AtLeast(1),
 		},
 	})
-	capellaschema.AddAttr(attrs, "bucket_conflict_resolution", bucketBuilder, stringDefaultAttribute("seqno", computed, optional, requiresReplace, useStateForUnknown))
-	capellaschema.AddAttr(attrs, "durability_level", bucketBuilder, stringAttribute([]string{computed, optional}))
-	capellaschema.AddAttr(attrs, "replicas", bucketBuilder, int64Attribute(optional, computed))
+
+	conflictResolutionAttr := stringDefaultAttribute("seqno", computed, optional, requiresReplace, useStateForUnknown)
+	conflictResolutionAttr.Validators = append(conflictResolutionAttr.Validators, stringvalidator.OneOf("seqno", "lww"))
+	capellaschema.AddAttr(attrs, "bucket_conflict_resolution", bucketBuilder, conflictResolutionAttr)
+
+	capellaschema.AddAttr(attrs, "durability_level", bucketBuilder, stringAttribute([]string{computed, optional},
+		stringvalidator.OneOf("none", "majority", "majorityAndPersistActive", "persistToMajority")))
+
+	replicasAttr := int64Attribute(optional, computed)
+	replicasAttr.Validators = []validator.Int64{int64validator.OneOf(1, 2, 3)}
+	capellaschema.AddAttr(attrs, "replicas", bucketBuilder, replicasAttr)
+
 	capellaschema.AddAttr(attrs, "flush", bucketBuilder, boolDefaultAttribute(false, optional, computed))
 	capellaschema.AddAttr(attrs, "time_to_live_in_seconds", bucketBuilder, int64Attribute(optional, computed))
-	capellaschema.AddAttr(attrs, "eviction_policy", bucketBuilder, stringAttribute([]string{computed, optional, requiresReplace, useStateForUnknown}))
+	capellaschema.AddAttr(attrs, "eviction_policy", bucketBuilder, stringAttribute([]string{computed, optional, requiresReplace, useStateForUnknown},
+		stringvalidator.OneOf("fullEviction", "noEviction", "nruEviction")))
 
 	statsAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(statsAttrs, "item_count", bucketBuilder, int64Attribute(computed))


### PR DESCRIPTION
## Jira

* AV-129333

## Description

- Added OneOf validators to type, storage_backend, bucket_conflict_resolution, durability_level, replicas, eviction_policy in bucket_schema.go

- New bucket_acceptance_test.go

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments