### PR TITLE
[AV-129334] Add enum validators to cluster resource schema

### DIFF
--- a/acceptance_tests/cluster_enum_validators_acceptance_test.go
+++ b/acceptance_tests/cluster_enum_validators_acceptance_test.go
@@ -1,0 +1,182 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccClusterEnumValidators_AV_129334 verifies that schema-level enum validators
+// reject out-of-range values at plan time for the cluster resource fields:
+// availability.type, support.plan, support.timezone, service_groups[].services elements.
+func TestAccClusterEnumValidators_AV_129334(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_validators_")
+	cidr := generateRandomCIDR()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			// Invalid availability.type
+			{
+				Config:      testAccClusterConfigWithInvalidAvailabilityType(resourceName, cidr),
+				ExpectError: regexp.MustCompile(`value must be one of:`),
+			},
+			// Invalid support.plan
+			{
+				Config:      testAccClusterConfigWithInvalidSupportPlan(resourceName, cidr),
+				ExpectError: regexp.MustCompile(`value must be one of:`),
+			},
+			// Invalid support.timezone
+			{
+				Config:      testAccClusterConfigWithInvalidSupportTimezone(resourceName, cidr),
+				ExpectError: regexp.MustCompile(`value must be one of:`),
+			},
+			// Invalid service in services set
+			{
+				Config:      testAccClusterConfigWithInvalidService(resourceName, cidr),
+				ExpectError: regexp.MustCompile(`value must be one of:`),
+			},
+			// Valid configuration — accepted values for every enum field
+			{
+				Config: testAccClusterConfigWithValidEnumFields(resourceName, cidr),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("couchbase-capella_cluster."+resourceName, "availability.type", "multi"),
+					resource.TestCheckResourceAttr("couchbase-capella_cluster."+resourceName, "support.plan", "enterprise"),
+					resource.TestCheckResourceAttr("couchbase-capella_cluster."+resourceName, "support.timezone", "PT"),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterConfigWithInvalidAvailabilityType(resourceName, cidr string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_cluster" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  name            = "%[2]s"
+  cloud_provider = {
+    type   = "aws"
+    region = "us-east-1"
+    cidr   = "%[5]s"
+  }
+  service_groups = [{
+    node = {
+      compute = { cpu = 4, ram = 16 }
+      disk    = { storage = 50, type = "io2", iops = 3000 }
+    }
+    num_of_nodes = 3
+    services     = ["data", "index", "query"]
+  }]
+  availability = { type = "invalid_type" }
+  support      = { plan = "enterprise", timezone = "PT" }
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, cidr)
+}
+
+func testAccClusterConfigWithInvalidSupportPlan(resourceName, cidr string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_cluster" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  name            = "%[2]s"
+  cloud_provider = {
+    type   = "aws"
+    region = "us-east-1"
+    cidr   = "%[5]s"
+  }
+  service_groups = [{
+    node = {
+      compute = { cpu = 4, ram = 16 }
+      disk    = { storage = 50, type = "io2", iops = 3000 }
+    }
+    num_of_nodes = 3
+    services     = ["data", "index", "query"]
+  }]
+  availability = { type = "multi" }
+  support      = { plan = "invalid_plan", timezone = "PT" }
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, cidr)
+}
+
+func testAccClusterConfigWithInvalidSupportTimezone(resourceName, cidr string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_cluster" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  name            = "%[2]s"
+  cloud_provider = {
+    type   = "aws"
+    region = "us-east-1"
+    cidr   = "%[5]s"
+  }
+  service_groups = [{
+    node = {
+      compute = { cpu = 4, ram = 16 }
+      disk    = { storage = 50, type = "io2", iops = 3000 }
+    }
+    num_of_nodes = 3
+    services     = ["data", "index", "query"]
+  }]
+  availability = { type = "multi" }
+  support      = { plan = "enterprise", timezone = "EST" }
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, cidr)
+}
+
+func testAccClusterConfigWithInvalidService(resourceName, cidr string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_cluster" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  name            = "%[2]s"
+  cloud_provider = {
+    type   = "aws"
+    region = "us-east-1"
+    cidr   = "%[5]s"
+  }
+  service_groups = [{
+    node = {
+      compute = { cpu = 4, ram = 16 }
+      disk    = { storage = 50, type = "io2", iops = 3000 }
+    }
+    num_of_nodes = 3
+    services     = ["data", "invalid_service"]
+  }]
+  availability = { type = "multi" }
+  support      = { plan = "enterprise", timezone = "PT" }
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, cidr)
+}
+
+func testAccClusterConfigWithValidEnumFields(resourceName, cidr string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_cluster" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  name            = "%[2]s"
+  cloud_provider = {
+    type   = "aws"
+    region = "us-east-1"
+    cidr   = "%[5]s"
+  }
+  service_groups = [{
+    node = {
+      compute = { cpu = 4, ram = 16 }
+      disk    = { storage = 50, type = "io2", iops = 3000 }
+    }
+    num_of_nodes = 3
+    services     = ["data", "index", "query"]
+  }]
+  availability = { type = "multi" }
+  support      = { plan = "enterprise", timezone = "PT" }
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, cidr)
+}

--- a/acceptance_tests/cluster_enum_validators_acceptance_test.go
+++ b/acceptance_tests/cluster_enum_validators_acceptance_test.go
@@ -22,27 +22,27 @@ func TestAccClusterEnumValidators(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Invalid availability.type
 			{
-				Config:      testAccClusterConfigWithInvalidAvailabilityType(resourceName, cidr),
+				Config:      testAccClusterEnumConfig(resourceName, cidr, "invalid_type", "enterprise", "PT", `"data", "index", "query"`),
 				ExpectError: enumValidatorError,
 			},
 			// Invalid support.plan
 			{
-				Config:      testAccClusterConfigWithInvalidSupportPlan(resourceName, cidr),
+				Config:      testAccClusterEnumConfig(resourceName, cidr, "multi", "invalid_plan", "PT", `"data", "index", "query"`),
 				ExpectError: enumValidatorError,
 			},
 			// Invalid support.timezone
 			{
-				Config:      testAccClusterConfigWithInvalidSupportTimezone(resourceName, cidr),
+				Config:      testAccClusterEnumConfig(resourceName, cidr, "multi", "enterprise", "EST", `"data", "index", "query"`),
 				ExpectError: enumValidatorError,
 			},
 			// Invalid service in services set
 			{
-				Config:      testAccClusterConfigWithInvalidService(resourceName, cidr),
+				Config:      testAccClusterEnumConfig(resourceName, cidr, "multi", "enterprise", "PT", `"data", "invalid_service"`),
 				ExpectError: enumValidatorError,
 			},
 			// Valid configuration — accepted values for every enum field
 			{
-				Config: testAccClusterConfigWithValidEnumFields(resourceName, cidr),
+				Config: testAccClusterEnumConfig(resourceName, cidr, "multi", "enterprise", "PT", `"data", "index", "query"`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("couchbase-capella_cluster."+resourceName, "id"),
 					resource.TestCheckResourceAttrSet("couchbase-capella_cluster."+resourceName, "etag"),
@@ -55,7 +55,7 @@ func TestAccClusterEnumValidators(t *testing.T) {
 	})
 }
 
-func testAccClusterConfigWithInvalidAvailabilityType(resourceName, cidr string) string {
+func testAccClusterEnumConfig(resourceName, cidr, availabilityType, supportPlan, supportTimezone, services string) string {
 	return fmt.Sprintf(`
 %[1]s
 resource "couchbase-capella_cluster" "%[2]s" {
@@ -73,114 +73,10 @@ resource "couchbase-capella_cluster" "%[2]s" {
       disk    = { storage = 50, type = "io2", iops = 3000 }
     }
     num_of_nodes = 3
-    services     = ["data", "index", "query"]
+    services     = [%[6]s]
   }]
-  availability = { type = "invalid_type" }
-  support      = { plan = "enterprise", timezone = "PT" }
+  availability = { type = "%[7]s" }
+  support      = { plan = "%[8]s", timezone = "%[9]s" }
 }
-`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, cidr)
-}
-
-func testAccClusterConfigWithInvalidSupportPlan(resourceName, cidr string) string {
-	return fmt.Sprintf(`
-%[1]s
-resource "couchbase-capella_cluster" "%[2]s" {
-  organization_id = "%[3]s"
-  project_id      = "%[4]s"
-  name            = "%[2]s"
-  cloud_provider = {
-    type   = "aws"
-    region = "us-east-1"
-    cidr   = "%[5]s"
-  }
-  service_groups = [{
-    node = {
-      compute = { cpu = 4, ram = 16 }
-      disk    = { storage = 50, type = "io2", iops = 3000 }
-    }
-    num_of_nodes = 3
-    services     = ["data", "index", "query"]
-  }]
-  availability = { type = "multi" }
-  support      = { plan = "invalid_plan", timezone = "PT" }
-}
-`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, cidr)
-}
-
-func testAccClusterConfigWithInvalidSupportTimezone(resourceName, cidr string) string {
-	return fmt.Sprintf(`
-%[1]s
-resource "couchbase-capella_cluster" "%[2]s" {
-  organization_id = "%[3]s"
-  project_id      = "%[4]s"
-  name            = "%[2]s"
-  cloud_provider = {
-    type   = "aws"
-    region = "us-east-1"
-    cidr   = "%[5]s"
-  }
-  service_groups = [{
-    node = {
-      compute = { cpu = 4, ram = 16 }
-      disk    = { storage = 50, type = "io2", iops = 3000 }
-    }
-    num_of_nodes = 3
-    services     = ["data", "index", "query"]
-  }]
-  availability = { type = "multi" }
-  support      = { plan = "enterprise", timezone = "EST" }
-}
-`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, cidr)
-}
-
-func testAccClusterConfigWithInvalidService(resourceName, cidr string) string {
-	return fmt.Sprintf(`
-%[1]s
-resource "couchbase-capella_cluster" "%[2]s" {
-  organization_id = "%[3]s"
-  project_id      = "%[4]s"
-  name            = "%[2]s"
-  cloud_provider = {
-    type   = "aws"
-    region = "us-east-1"
-    cidr   = "%[5]s"
-  }
-  service_groups = [{
-    node = {
-      compute = { cpu = 4, ram = 16 }
-      disk    = { storage = 50, type = "io2", iops = 3000 }
-    }
-    num_of_nodes = 3
-    services     = ["data", "invalid_service"]
-  }]
-  availability = { type = "multi" }
-  support      = { plan = "enterprise", timezone = "PT" }
-}
-`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, cidr)
-}
-
-func testAccClusterConfigWithValidEnumFields(resourceName, cidr string) string {
-	return fmt.Sprintf(`
-%[1]s
-resource "couchbase-capella_cluster" "%[2]s" {
-  organization_id = "%[3]s"
-  project_id      = "%[4]s"
-  name            = "%[2]s"
-  cloud_provider = {
-    type   = "aws"
-    region = "us-east-1"
-    cidr   = "%[5]s"
-  }
-  service_groups = [{
-    node = {
-      compute = { cpu = 4, ram = 16 }
-      disk    = { storage = 50, type = "io2", iops = 3000 }
-    }
-    num_of_nodes = 3
-    services     = ["data", "index", "query"]
-  }]
-  availability = { type = "multi" }
-  support      = { plan = "enterprise", timezone = "PT" }
-}
-`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, cidr)
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, cidr, services, availabilityType, supportPlan, supportTimezone)
 }

--- a/acceptance_tests/cluster_enum_validators_acceptance_test.go
+++ b/acceptance_tests/cluster_enum_validators_acceptance_test.go
@@ -44,6 +44,8 @@ func TestAccClusterEnumValidators(t *testing.T) {
 			{
 				Config: testAccClusterConfigWithValidEnumFields(resourceName, cidr),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("couchbase-capella_cluster."+resourceName, "id"),
+					resource.TestCheckResourceAttrSet("couchbase-capella_cluster."+resourceName, "etag"),
 					resource.TestCheckResourceAttr("couchbase-capella_cluster."+resourceName, "availability.type", "multi"),
 					resource.TestCheckResourceAttr("couchbase-capella_cluster."+resourceName, "support.plan", "enterprise"),
 					resource.TestCheckResourceAttr("couchbase-capella_cluster."+resourceName, "support.timezone", "PT"),

--- a/acceptance_tests/cluster_enum_validators_acceptance_test.go
+++ b/acceptance_tests/cluster_enum_validators_acceptance_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// TestAccClusterEnumValidators_AV_129334 verifies that schema-level enum validators
+var enumValidatorError = regexp.MustCompile(`value must be one of:`)
+
+// TestAccClusterEnumValidators verifies that schema-level enum validators
 // reject out-of-range values at plan time for the cluster resource fields:
 // availability.type, support.plan, support.timezone, service_groups[].services elements.
-func TestAccClusterEnumValidators_AV_129334(t *testing.T) {
+func TestAccClusterEnumValidators(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_validators_")
 	cidr := generateRandomCIDR()
 
@@ -21,22 +23,22 @@ func TestAccClusterEnumValidators_AV_129334(t *testing.T) {
 			// Invalid availability.type
 			{
 				Config:      testAccClusterConfigWithInvalidAvailabilityType(resourceName, cidr),
-				ExpectError: regexp.MustCompile(`value must be one of:`),
+				ExpectError: enumValidatorError,
 			},
 			// Invalid support.plan
 			{
 				Config:      testAccClusterConfigWithInvalidSupportPlan(resourceName, cidr),
-				ExpectError: regexp.MustCompile(`value must be one of:`),
+				ExpectError: enumValidatorError,
 			},
 			// Invalid support.timezone
 			{
 				Config:      testAccClusterConfigWithInvalidSupportTimezone(resourceName, cidr),
-				ExpectError: regexp.MustCompile(`value must be one of:`),
+				ExpectError: enumValidatorError,
 			},
 			// Invalid service in services set
 			{
 				Config:      testAccClusterConfigWithInvalidService(resourceName, cidr),
-				ExpectError: regexp.MustCompile(`value must be one of:`),
+				ExpectError: enumValidatorError,
 			},
 			// Valid configuration — accepted values for every enum field
 			{

--- a/internal/resources/cluster_schema.go
+++ b/internal/resources/cluster_schema.go
@@ -1,9 +1,12 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
@@ -75,7 +78,11 @@ func ClusterSchema() schema.Schema {
 		Attributes: nodeAttrs,
 	})
 	capellaschema.AddAttr(serviceGroupAttrs, "num_of_nodes", clusterBuilder, int64Attribute(required))
-	capellaschema.AddAttr(serviceGroupAttrs, "services", clusterBuilder, stringSetAttribute(required))
+	servicesAttr := stringSetAttribute(required)
+	servicesAttr.Validators = []validator.Set{
+		setvalidator.ValueStringsAre(stringvalidator.OneOf("data", "query", "index", "search", "analytics", "eventing")),
+	}
+	capellaschema.AddAttr(serviceGroupAttrs, "services", clusterBuilder, servicesAttr)
 
 	capellaschema.AddAttr(attrs, "service_groups", clusterBuilder, &schema.SetNestedAttribute{
 		Required: true,
@@ -85,7 +92,8 @@ func ClusterSchema() schema.Schema {
 	})
 
 	availabilityAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(availabilityAttrs, "type", clusterBuilder, stringAttribute([]string{required}), "Availability")
+	capellaschema.AddAttr(availabilityAttrs, "type", clusterBuilder, stringAttribute([]string{required},
+		stringvalidator.OneOf("single", "multi")), "Availability")
 
 	capellaschema.AddAttr(attrs, "availability", clusterBuilder, &schema.SingleNestedAttribute{
 		Required:   true,
@@ -96,8 +104,10 @@ func ClusterSchema() schema.Schema {
 	})
 
 	supportAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(supportAttrs, "plan", clusterBuilder, stringAttribute([]string{required}), "Support")
-	capellaschema.AddAttr(supportAttrs, "timezone", clusterBuilder, stringAttribute([]string{computed, optional}), "Support")
+	capellaschema.AddAttr(supportAttrs, "plan", clusterBuilder, stringAttribute([]string{required},
+		stringvalidator.OneOf("basic", "developer pro", "enterprise")), "Support")
+	capellaschema.AddAttr(supportAttrs, "timezone", clusterBuilder, stringAttribute([]string{computed, optional},
+		stringvalidator.OneOf("ET", "GMT", "IST", "PT")), "Support")
 
 	capellaschema.AddAttr(attrs, "support", clusterBuilder, &schema.SingleNestedAttribute{
 		Required:   true,


### PR DESCRIPTION
## Jira

* AV-129334

## Description

- Added OneOf validators to availability.type, support.plan, support.timezone, and setvalidator.ValueStringsAre to service_groups[].services in cluster_schema.go

- New cluster_enum_validators_acceptance_test.go


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments