### PR TITLE
[AV-129336] Add enum validator to backup resource schema

### DIFF
--- a/acceptance_tests/backup_acceptance_test.go
+++ b/acceptance_tests/backup_acceptance_test.go
@@ -21,12 +21,11 @@ func TestAccBackupEnumValidators_AV_129336(t *testing.T) {
 				Config:      testAccBackupConfigWithInvalidReplaceTTL(resourceName),
 				ExpectError: regexp.MustCompile(`value must be one of:`),
 			},
-			// Valid replace_ttl = "none" — validator passes; resource creation proceeds to API
+			// Valid replace_ttl = "none" — validator passes at plan time; PlanOnly avoids
+			// checking post-apply state since Create does not persist the restore block.
 			{
-				Config: testAccBackupConfigWithValidReplaceTTL(resourceName, "none"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("couchbase-capella_backup."+resourceName, "restore.replace_ttl", "none"),
-				),
+				Config:   testAccBackupConfigWithValidReplaceTTL(resourceName, "none"),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/acceptance_tests/backup_acceptance_test.go
+++ b/acceptance_tests/backup_acceptance_test.go
@@ -1,0 +1,71 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccBackupEnumValidators_AV_129336 verifies that the schema-level enum validator
+// rejects out-of-range values at plan time for the backup resource's restore.replace_ttl field.
+func TestAccBackupEnumValidators_AV_129336(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_backup_validators_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			// Invalid replace_ttl — rejected by schema validator before reaching the API
+			{
+				Config:      testAccBackupConfigWithInvalidReplaceTTL(resourceName),
+				ExpectError: regexp.MustCompile(`value must be one of:`),
+			},
+			// Valid replace_ttl = "none" — validator passes; resource creation proceeds to API
+			{
+				Config: testAccBackupConfigWithValidReplaceTTL(resourceName, "none"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("couchbase-capella_backup."+resourceName, "restore.replace_ttl", "none"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBackupConfigWithInvalidReplaceTTL(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_backup" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_id       = "%[6]s"
+
+  restore = {
+    target_cluster_id = "%[5]s"
+    source_cluster_id = "%[5]s"
+    services          = ["data"]
+    replace_ttl       = "invalid_ttl"
+  }
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, globalBucketId)
+}
+
+func testAccBackupConfigWithValidReplaceTTL(resourceName, replaceTTL string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "couchbase-capella_backup" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_id       = "%[6]s"
+
+  restore = {
+    target_cluster_id = "%[5]s"
+    source_cluster_id = "%[5]s"
+    services          = ["data"]
+    replace_ttl       = "%[7]s"
+  }
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, globalBucketId, replaceTTL)
+}

--- a/acceptance_tests/backup_acceptance_test.go
+++ b/acceptance_tests/backup_acceptance_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// TestAccBackupEnumValidators_AV_129336 verifies that the schema-level enum validator
+// TestAccBackupEnumValidators verifies that the schema-level enum validator
 // rejects out-of-range values at plan time for the backup resource's restore.replace_ttl field.
-func TestAccBackupEnumValidators_AV_129336(t *testing.T) {
+func TestAccBackupEnumValidators(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_backup_validators_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,9 +23,12 @@ func TestAccBackupEnumValidators_AV_129336(t *testing.T) {
 			},
 			// Valid replace_ttl = "none" — validator passes at plan time; PlanOnly avoids
 			// checking post-apply state since Create does not persist the restore block.
+			// ExpectNonEmptyPlan because step 1 errored (no state written), so the plan
+			// will always show a create; we only care that no validation error fires.
 			{
-				Config:   testAccBackupConfigWithValidReplaceTTL(resourceName, "none"),
-				PlanOnly: true,
+				Config:             testAccBackupConfigWithValidReplaceTTL(resourceName, "none"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/resources/backup_schema.go
+++ b/internal/resources/backup_schema.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -72,7 +73,8 @@ func BackupSchema() schema.Schema {
 	capellaschema.AddAttr(restoreAttrs, "include_data", backupBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(restoreAttrs, "exclude_data", backupBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(restoreAttrs, "map_data", backupBuilder, stringAttribute([]string{optional}))
-	capellaschema.AddAttr(restoreAttrs, "replace_ttl", backupBuilder, stringAttribute([]string{optional}))
+	capellaschema.AddAttr(restoreAttrs, "replace_ttl", backupBuilder, stringAttribute([]string{optional},
+		stringvalidator.OneOf("none", "all", "expired")))
 	capellaschema.AddAttr(restoreAttrs, "replace_ttl_with", backupBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(restoreAttrs, "status", backupBuilder, stringAttribute([]string{computed}))
 


### PR DESCRIPTION
## Jira

* AV-129336

## Description

- Added OneOf("none","all","expired") to restore.replace_ttl in  backup_schema.go

- New backup_acceptance_test.go

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments