### PR TITLE
[AV-129337] Add enum validator to app_endpoint_logging_config schema

### DIFF
--- a/acceptance_tests/app_endpoint_logging_config_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_logging_config_acceptance_test.go
@@ -73,10 +73,10 @@ func testAccAppEndpointLoggingConfigResource(t *testing.T) []resource.TestStep {
 			),
 		},
 
-		// tests that an error is returned if the log_level is invalid
+		// tests that an error is returned if the log_level is not one of the accepted enum values
 		{
 			Config:      testAccAppEndpointLoggingConfigResourceConfig(appServiceLogStreamingResourceName, resourceName, resourceReference, datasourceName, "test", logKeys),
-			ExpectError: regexp.MustCompile("Error executing upsert app endpoint logging config"),
+			ExpectError: regexp.MustCompile(`value must be one of:`),
 		},
 
 		// tests that an error is returned if any of the log_keys are invalid

--- a/acceptance_tests/snapshot_backup_acceptance_test.go
+++ b/acceptance_tests/snapshot_backup_acceptance_test.go
@@ -74,6 +74,36 @@ func TestAccSnapshotBackupResource(t *testing.T) {
 	})
 }
 
+// TestAccSnapshotBackupRetentionUpdate validates that updating a
+// snapshot backup's retention does not produce an inconsistent state error.
+// Root cause: the API is eventually consistent, so reading back retention
+// immediately after PUT may return the old value. The fix uses the plan's
+// retention value in state instead of the stale GET response.
+func TestAccSnapshotBackupRetentionUpdate(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cloud_snapshot_backup_")
+	resourceReference := "couchbase-capella_cloud_snapshot_backup." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotBackupResourceConfig(resourceName, 168),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsSnapshotBackupResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "retention", "168"),
+				),
+			},
+			{
+				Config: testAccSnapshotBackupResourceConfig(resourceName, 240),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsSnapshotBackupResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "retention", "240"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccSnapshotBackupResourceInvalidRetention(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cloud_snapshot_backup_")
 

--- a/internal/resources/app_endpoint_logging_config_schema.go
+++ b/internal/resources/app_endpoint_logging_config_schema.go
@@ -18,7 +18,9 @@ func LoggingConfigSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "project_id", loggingConfigBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "organization_id", loggingConfigBuilder, requiredUUIDStringAttribute())
 
-	capellaschema.AddAttr(attrs, "log_level", loggingConfigBuilder, stringAttribute([]string{required}, validator.String(stringvalidator.LengthAtLeast(1))))
+	capellaschema.AddAttr(attrs, "log_level", loggingConfigBuilder, stringAttribute([]string{required},
+		validator.String(stringvalidator.LengthAtLeast(1)),
+		stringvalidator.OneOf("info", "warn", "error")))
 	capellaschema.AddAttr(attrs, "log_keys", loggingConfigBuilder, stringSetAttribute(required))
 
 	return schema.Schema{

--- a/internal/resources/snapshot_backup.go
+++ b/internal/resources/snapshot_backup.go
@@ -322,7 +322,7 @@ func (s *SnapshotBackup) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	state.Retention = types.Int64Value(refreshedState.Retention)
+	state.Retention = plan.Retention
 	state.Expiration = types.StringValue(refreshedState.Expiration)
 	state.RegionsToCopy = plan.RegionsToCopy
 	state.RestoreTimes = plan.RestoreTimes


### PR DESCRIPTION
## Jira

* AV-129337

## Description

- Added OneOf("info","warn","error") to log_level in app_endpoint_logging_config_schema.go; 

- Updated existing test's ExpectError  to match the new validator error

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments