### PR TITLE
[AV-129338] Add enum validator to app_service_log_streaming schema

### DIFF
--- a/acceptance_tests/app_service_log_streaming_acceptance_test.go
+++ b/acceptance_tests/app_service_log_streaming_acceptance_test.go
@@ -324,6 +324,66 @@ resource "couchbase-capella_app_service_log_streaming" "%[6]s" {
 	)
 }
 
+// TestAccAppServiceLogStreamingInvalidOutputType_AV_129338 verifies that the output_type
+// enum validator rejects values not in the allowed set at plan time.
+func TestAccAppServiceLogStreamingInvalidOutputType_AV_129338(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_log_streaming_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			// Invalid output_type — rejected by schema validator before reaching the API
+			{
+				Config:      testAccAppServiceLogStreamingInvalidOutputTypeConfig(resourceName),
+				ExpectError: re.MustCompile(`value must be one of:`),
+			},
+			// Valid output_type — validator passes; existing lifecycle tests cover the full apply path
+			{
+				Config: testAccAppServiceLogStreamingResourceConfig(
+					resourceName,
+					"https://example.com/logs",
+					"test_user",
+					"test_password",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("couchbase-capella_app_service_log_streaming."+resourceName, "output_type", "generic_http"),
+				),
+			},
+		},
+	})
+}
+
+// testAccAppServiceLogStreamingInvalidOutputTypeConfig returns an HCL config where
+// output_type is not one of the accepted enum values.
+func testAccAppServiceLogStreamingInvalidOutputTypeConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_app_service_log_streaming" "%[6]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  app_service_id  = "%[5]s"
+  output_type     = "invalid_output"
+
+  credentials = {
+    generic_http = {
+      url      = "https://example.com/logs"
+      user     = "test_user"
+      password = "test_password"
+    }
+  }
+}
+`,
+		globalProviderBlock,
+		globalOrgId,
+		globalProjectId,
+		globalClusterId,
+		globalAppServiceId,
+		resourceName,
+	)
+}
+
 // generateAppServiceLogStreamingImportId generates the import ID string
 // from the Terraform state for the app_service_log_streaming resource.
 func generateAppServiceLogStreamingImportId(resourceReference string) resource.ImportStateIdFunc {

--- a/internal/resources/app_service_log_streaming_schema.go
+++ b/internal/resources/app_service_log_streaming_schema.go
@@ -21,7 +21,9 @@ func AppServiceLogStreamingSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "app_service_id", appServiceLogStreamingBuilder, requiredUUIDStringAttribute())
 
 	// User configured attributes
-	capellaschema.AddAttr(attrs, "output_type", appServiceLogStreamingBuilder, stringAttribute([]string{required, requiresReplace}, validator.String(stringvalidator.LengthAtLeast(1))))
+	capellaschema.AddAttr(attrs, "output_type", appServiceLogStreamingBuilder, stringAttribute([]string{required, requiresReplace},
+		validator.String(stringvalidator.LengthAtLeast(1)),
+		stringvalidator.OneOf("datadog", "generic_http", "sumologic", "loki", "elastic", "splunk", "dynatrace")))
 	capellaschema.AddAttr(attrs, "credentials", appServiceLogStreamingBuilder, &schema.SingleNestedAttribute{
 		Required:   true,
 		Sensitive:  true,


### PR DESCRIPTION
## Jira

* AV-129338

## Description

- Added OneOf for all 7 output types to output_type in app_service_log_streaming_schema.go; 

- Added TestAccAppServiceLogStreamingInvalidOutputType_AV_129338 to existing test

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments