### PR TITLE
[AV-129887] Require tenant_id in Azure configuration and update documentation

### DIFF
--- a/docs/resources/network_peer.md
+++ b/docs/resources/network_peer.md
@@ -120,12 +120,12 @@ Read-Only:
 Required:
 
 - `cidr` (String)
+- `tenant_id` (String)
 
 Optional:
 
 - `resource_group` (String)
 - `subscription_id` (String)
-- `tenant_id` (String)
 - `vnet_id` (String)
 
 Read-Only:

--- a/internal/resources/network_peer.go
+++ b/internal/resources/network_peer.go
@@ -380,6 +380,12 @@ func (n *NetworkPeer) validateCreateNetworkPeer(plan providerschema.NetworkPeer)
 		return errors.ErrClusterIdMissing
 	}
 
+	if plan.ProviderConfig != nil && plan.ProviderConfig.AzureConfig != nil {
+		if plan.ProviderConfig.AzureConfig.AzureTenantId.IsNull() || plan.ProviderConfig.AzureConfig.AzureTenantId.ValueString() == "" {
+			return fmt.Errorf("azure_config.tenant_id must be set when azure_config is provided")
+		}
+	}
+
 	return n.validateNetworkPeerAttributesTrimmed(plan)
 }
 

--- a/internal/resources/network_peer.go
+++ b/internal/resources/network_peer.go
@@ -381,8 +381,8 @@ func (n *NetworkPeer) validateCreateNetworkPeer(plan providerschema.NetworkPeer)
 	}
 
 	if plan.ProviderConfig != nil && plan.ProviderConfig.AzureConfig != nil {
-		if plan.ProviderConfig.AzureConfig.AzureTenantId.IsNull() || plan.ProviderConfig.AzureConfig.AzureTenantId.ValueString() == "" {
-			return fmt.Errorf("azure_config.tenant_id must be set when azure_config is provided")
+		if err := plan.ProviderConfig.AzureConfig.Validate(); err != nil {
+			return err
 		}
 	}
 

--- a/internal/resources/network_peer_schema.go
+++ b/internal/resources/network_peer_schema.go
@@ -47,7 +47,7 @@ func NetworkPeerSchema() schema.Schema {
 	capellaschema.AddAttr(gcpConfigAttrs, "provider_id", networkPeerBuilder, stringAttribute([]string{computed}))
 
 	azureConfigAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(azureConfigAttrs, "tenant_id", networkPeerBuilder, stringAttribute([]string{optional}))
+	capellaschema.AddAttr(azureConfigAttrs, "tenant_id", networkPeerBuilder, stringAttribute([]string{required}))
 	capellaschema.AddAttr(azureConfigAttrs, "cidr", networkPeerBuilder, stringAttribute([]string{required}))
 	capellaschema.AddAttr(azureConfigAttrs, "resource_group", networkPeerBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(azureConfigAttrs, "subscription_id", networkPeerBuilder, stringAttribute([]string{optional}))

--- a/internal/schema/network_peer.go
+++ b/internal/schema/network_peer.go
@@ -136,6 +136,14 @@ type AzureConfig struct {
 	ProviderId types.String `tfsdk:"provider_id"`
 }
 
+// Validate checks that required Azure config fields are set.
+func (a *AzureConfig) Validate() error {
+	if a.AzureTenantId.IsNull() || a.AzureTenantId.ValueString() == "" {
+		return fmt.Errorf("azure_config.tenant_id must be set when azure_config is provided")
+	}
+	return nil
+}
+
 // NetworkPeers defines structure based on the response received from V4 Capella Public API when asked to list network peers.
 type NetworkPeers struct {
 	// OrganizationId is the organizationId of the capella.


### PR DESCRIPTION
## Jira

* AV-129887

## Description

The ask is to add validation that the Azure tenant field is populated (i.e. make this non-optional), in cases where azure_config is present during Azure Network Peering

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments