### PR TITLE
[AV-128217] Enforced cors.origin as required for capella_app_endpoint when a cors block is present

### DIFF
--- a/acceptance_tests/app_endpoint_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_acceptance_test.go
@@ -226,11 +226,10 @@ func testAccAppEndpointComputedAttrs(resourceReference string) resource.TestChec
 	)
 }
 
-// ── S4: cors.disabled=false without origin — API 422 "App Endpoint CORS Origin is empty" ──
-// Provider schema marks origin as Optional but the API requires it when a cors
-// block is present and disabled=false.
+// ── AV-128217: cors.disabled=false without origin must fail provider validation ──
+// The API rejects empty/missing origin when a cors block is present.
+// Provider schema must reject this before issuing the API request.
 func TestAccAppEndpointCorsDisabledFalseNoOrigin(t *testing.T) {
-	t.Skip("AV-128217: cors.disabled=false without origin should be valid once the bug is fixed")
 	ensureFixtureBucketByName(t, globalCorsDisabledFalseEPBucketName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
@@ -240,7 +239,8 @@ func TestAccAppEndpointCorsDisabledFalseNoOrigin(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
+				Config:      testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
+				ExpectError: re.MustCompile(`(?s).*origin.*required.*`),
 			},
 		},
 	})
@@ -701,7 +701,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 }
 
 // testAccAppEndpointCorsDisabledFalseResourceConfig creates an endpoint with
-// cors { disabled=false } and no origin field. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin (S4, skipped).
+// cors { disabled=false } and no origin field. Used by: TestAccAppEndpoint_AV_128217.
 func testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, endpointName, bucketName string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/acceptance_tests/app_endpoint_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_acceptance_test.go
@@ -233,6 +233,7 @@ func TestAccAppEndpointCorsDisabledFalseNoOrigin(t *testing.T) {
 	ensureFixtureBucketByName(t, globalCorsDisabledFalseEPBucketName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
+	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -240,11 +241,18 @@ func TestAccAppEndpointCorsDisabledFalseNoOrigin(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
-				ExpectError: re.MustCompile(`(?s).*origin.*required.*`),
+				ExpectError: re.MustCompile(`(?s).*cors\.origin.*at least 1 value.*`),
 			},
 			{
 				Config:      testAccAppEndpointCorsEmptyOriginResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
-				ExpectError: re.MustCompile(`(?s).*origin.*at least 1.*`),
+				ExpectError: re.MustCompile(`(?s).*cors\.origin.*at least 1 value.*`),
+			},
+			{
+				Config: testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAppEndpointComputedAttrs(resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "cors.disabled", "true"),
+				),
 			},
 		},
 	})
@@ -720,6 +728,44 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 
 	cors = {
 		disabled = false
+	}
+
+	scopes = {
+		"_default" = {
+			collections = {
+				"_default" = {}
+			}
+		}
+	}
+}
+`,
+		globalProviderBlock,
+		resourceName,
+		globalOrgId,
+		globalProjectId,
+		appEndpointClusterId,
+		appEndpointAppServiceId,
+		bucketName,
+		endpointName,
+	)
+}
+
+// testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig creates an endpoint with
+// cors { disabled=true } and no origin field. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin.
+func testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, endpointName, bucketName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_app_endpoint" "%[2]s" {
+	organization_id = "%[3]s"
+	project_id      = "%[4]s"
+	cluster_id      = "%[5]s"
+	app_service_id  = "%[6]s"
+	bucket          = "%[7]s"
+	name            = "%[8]s"
+
+	cors = {
+		disabled = true
 	}
 
 	scopes = {

--- a/acceptance_tests/app_endpoint_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_acceptance_test.go
@@ -242,6 +242,10 @@ func TestAccAppEndpointCorsDisabledFalseNoOrigin(t *testing.T) {
 				Config:      testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
 				ExpectError: re.MustCompile(`(?s).*origin.*required.*`),
 			},
+			{
+				Config:      testAccAppEndpointCorsEmptyOriginResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
+				ExpectError: re.MustCompile(`(?s).*origin.*at least 1.*`),
+			},
 		},
 	})
 }
@@ -716,6 +720,45 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 
 	cors = {
 		disabled = false
+	}
+
+	scopes = {
+		"_default" = {
+			collections = {
+				"_default" = {}
+			}
+		}
+	}
+}
+`,
+		globalProviderBlock,
+		resourceName,
+		globalOrgId,
+		globalProjectId,
+		appEndpointClusterId,
+		appEndpointAppServiceId,
+		bucketName,
+		endpointName,
+	)
+}
+
+// testAccAppEndpointCorsEmptyOriginResourceConfig creates an endpoint with
+// cors { disabled=false, origin=[] }. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin.
+func testAccAppEndpointCorsEmptyOriginResourceConfig(resourceName, endpointName, bucketName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_app_endpoint" "%[2]s" {
+	organization_id = "%[3]s"
+	project_id      = "%[4]s"
+	cluster_id      = "%[5]s"
+	app_service_id  = "%[6]s"
+	bucket          = "%[7]s"
+	name            = "%[8]s"
+
+	cors = {
+		disabled = false
+		origin   = []
 	}
 
 	scopes = {

--- a/acceptance_tests/app_endpoint_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_acceptance_test.go
@@ -701,7 +701,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 }
 
 // testAccAppEndpointCorsDisabledFalseResourceConfig creates an endpoint with
-// cors { disabled=false } and no origin field. Used by: TestAccAppEndpoint_AV_128217.
+// cors { disabled=false } and no origin field. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin.
 func testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, endpointName, bucketName string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/internal/resources/app_endpoint.go
+++ b/internal/resources/app_endpoint.go
@@ -23,9 +23,10 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &AppEndpoint{}
-	_ resource.ResourceWithConfigure   = &AppEndpoint{}
-	_ resource.ResourceWithImportState = &AppEndpoint{}
+	_ resource.Resource                   = &AppEndpoint{}
+	_ resource.ResourceWithConfigure      = &AppEndpoint{}
+	_ resource.ResourceWithImportState    = &AppEndpoint{}
+	_ resource.ResourceWithValidateConfig = &AppEndpoint{}
 )
 
 const errorAppEndpointCreation = "There is an error during App Endpoint creation. unexpected error: "
@@ -53,6 +54,41 @@ func (a *AppEndpoint) Metadata(_ context.Context, req resource.MetadataRequest, 
 // Schema defines the schema for AppEndpoint.
 func (a *AppEndpoint) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = AppEndpointSchema()
+}
+
+// ValidateConfig enforces that CORS origins are configured unless CORS is explicitly disabled.
+func (a *AppEndpoint) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config providerschema.AppEndpoint
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.Cors == nil {
+		return
+	}
+
+	// Defer validation until Terraform resolves expressions that determine whether CORS is disabled.
+	if config.Cors.Disabled.IsUnknown() {
+		return
+	}
+
+	if !config.Cors.Disabled.IsNull() && !config.Cors.Disabled.IsUnknown() && config.Cors.Disabled.ValueBool() {
+		return
+	}
+
+	// Origin may be populated by an expression that is unknown during config validation.
+	if config.Cors.Origin.IsUnknown() {
+		return
+	}
+
+	if config.Cors.Origin.IsNull() || len(config.Cors.Origin.Elements()) == 0 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("cors").AtName("origin"),
+			"Missing Attribute Configuration",
+			"Expected cors.origin to be configured with at least 1 value when cors.disabled is not true.",
+		)
+	}
 }
 
 // Create creates a new App Endpoint.
@@ -133,6 +169,8 @@ func (a *AppEndpoint) Create(ctx context.Context, req resource.CreateRequest, re
 	// Terraform detecting an unexpected new value.
 	if plan.Cors == nil {
 		state.Cors = nil
+	} else {
+		preserveDisabledCorsOrigin(&plan, state)
 	}
 
 	diags = resp.State.Set(ctx, state)
@@ -315,6 +353,8 @@ func (a *AppEndpoint) Read(ctx context.Context, req resource.ReadRequest, resp *
 	isImport := state.OrganizationId.IsNull()
 	if state.Cors == nil && !isImport {
 		newstate.Cors = nil
+	} else if !isImport {
+		preserveDisabledCorsOrigin(&state, newstate)
 	}
 
 	diags = resp.State.Set(ctx, newstate)
@@ -389,10 +429,26 @@ func (a *AppEndpoint) Update(ctx context.Context, req resource.UpdateRequest, re
 	// If the plan did not include CORS, keep it null in state.
 	if plan.Cors == nil {
 		refreshedState.Cors = nil
+	} else {
+		preserveDisabledCorsOrigin(&plan, refreshedState)
 	}
-
 	diags = resp.State.Set(ctx, refreshedState)
 	resp.Diagnostics.Append(diags...)
+}
+
+// preserveDisabledCorsOrigin keeps omitted origin absent from state when CORS is disabled.
+func preserveDisabledCorsOrigin(config *providerschema.AppEndpoint, state *providerschema.AppEndpoint) {
+	if config.Cors == nil || state.Cors == nil {
+		return
+	}
+
+	if config.Cors.Disabled.IsNull() || config.Cors.Disabled.IsUnknown() || !config.Cors.Disabled.ValueBool() {
+		return
+	}
+
+	if config.Cors.Origin.IsNull() {
+		state.Cors.Origin = types.SetNull(types.StringType)
+	}
 }
 
 // Delete deletes an existing App Endpoint.

--- a/internal/resources/app_endpoint_schema.go
+++ b/internal/resources/app_endpoint_schema.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
@@ -50,8 +51,11 @@ func AppEndpointSchema() schema.Schema {
 	// CORS attributes - use CORSConfig schema
 	corsAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(corsAttrs, "origin", appEndpointBuilder, &schema.SetAttribute{
-		Optional:    true,
+		Required:    true,
 		ElementType: types.StringType,
+		Validators: []validator.Set{
+			setvalidator.SizeAtLeast(1),
+		},
 	}, "CORSConfig")
 	capellaschema.AddAttr(corsAttrs, "login_origin", appEndpointBuilder, &schema.SetAttribute{
 		Optional:    true,

--- a/internal/resources/app_endpoint_schema.go
+++ b/internal/resources/app_endpoint_schema.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
@@ -51,11 +50,8 @@ func AppEndpointSchema() schema.Schema {
 	// CORS attributes - use CORSConfig schema
 	corsAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(corsAttrs, "origin", appEndpointBuilder, &schema.SetAttribute{
-		Required:    true,
+		Optional:    true,
 		ElementType: types.StringType,
-		Validators: []validator.Set{
-			setvalidator.SizeAtLeast(1),
-		},
 	}, "CORSConfig")
 	capellaschema.AddAttr(corsAttrs, "login_origin", appEndpointBuilder, &schema.SetAttribute{
 		Optional:    true,


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-128217

## Description

<img width="1728" height="943" alt="Screenshot 2026-05-11 at 4 52 31 PM" src="https://github.com/user-attachments/assets/b8ed9671-0a9e-468e-8b78-5b34c1b14d47" />

<img width="1728" height="941" alt="Screenshot 2026-05-11 at 7 13 14 PM" src="https://github.com/user-attachments/assets/e409a0fe-07df-410a-a8da-bd6109c8854e" />

- Enforced [cors.origin]as required for couchbase-capella_app_endpoint when a cors block is present:
Changed [origin] from [Optional] to [Required]
Added non-empty validator [setvalidator.SizeAtLeast(1)] to reject [origin = []]

- Added acceptance regression coverage for this bug:
Replaced skipped scenario with active test [TestAccAppEndpointCorsDisabledFalseNoOrigin]
Test now expects provider-side validation error for cors { disabled = false } without [origin]

- Why this fixes the bug
The provider now rejects both:
missing [cors.origin](schema [Required]
empty [cors.origin] (size validator)

So invalid configs fail during Terraform validation instead of reaching Capella and returning API 422.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

TF_ACC=1 go test -timeout=120m -v ./acceptance_tests/ -run '^TestAccAppEndpointCorsDisabledFalseNoOrigin$'
2026/05/11 16:33:20 Using existing project: e752bfc8-f9e4-42a2-9721-555d4452a518
2026/05/11 16:33:20 Using existing cluster: ce4a301c-cff3-4d40-8e8a-1f813e0d7dbc
2026/05/11 16:33:21 Using existing bucket: default (ZGVmYXVsdA==)
2026/05/11 16:33:21 Using existing app service: 62e00e58-8fc3-4aae-b435-206c70d5d077
2026/05/11 16:33:21 App endpoint 'tf_acc_test_app_endpoint_common' already exists
2026/05/11 16:33:22 app endpoint state Offline
=== RUN   TestAccAppEndpointCorsDisabledFalseNoOrigin
2026/05/11 16:36:24 app endpoint test cluster created
2026/05/11 16:41:28 app endpoint test app service created
2026/05/11 16:42:30 app endpoint state Offline
=== PAUSE TestAccAppEndpointCorsDisabledFalseNoOrigin
=== CONT  TestAccAppEndpointCorsDisabledFalseNoOrigin
--- PASS: TestAccAppEndpointCorsDisabledFalseNoOrigin (552.43s)
PASS
ok      github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests 740.082s


## Further comments