### PR TITLE
[AV-129755] Fix App Service CIDR data source and add testing

### DIFF
--- a/acceptance_tests/app_services_cidr_datasource_test.go
+++ b/acceptance_tests/app_services_cidr_datasource_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -19,12 +20,14 @@ func TestAccAppServicesCIDRDataSource(t *testing.T) {
 	// Generate a random CIDR block for testing. This ensures that the test is not dependent on any pre-existing data and can be run multiple times without conflicts.
 	// This is used as an allowed IP on the App Service for purposes of testing the data source.
 	allowedCIDR := fmt.Sprintf("172.16.%d.%d/32", rand.Intn(256), rand.Intn(256)) // #nosec G404
+	comment := "terraform app services cidr datasource acceptance test"
+	expiresAt := time.Now().Add(time.Hour * 6).Format(time.RFC3339)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppServicesCIDRDataSourceConfig(resourceName, dataSourceName, allowedCIDR),
+				Config: testAccAppServicesCIDRDataSourceConfig(resourceName, dataSourceName, allowedCIDR, comment, expiresAt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "cidr", allowedCIDR),
 					resource.TestCheckResourceAttrSet(resourceReference, "id"),
@@ -35,7 +38,8 @@ func TestAccAppServicesCIDRDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceReference, "app_service_id", globalAppServiceId),
 					resource.TestCheckResourceAttrSet(dataSourceReference, "data.#"),
 					resource.TestCheckTypeSetElemNestedAttrs(dataSourceReference, "data.*", map[string]string{
-						"cidr": allowedCIDR,
+						"cidr":    allowedCIDR,
+						"comment": comment,
 					}),
 				),
 			},
@@ -61,7 +65,7 @@ data "couchbase-capella_app_services_cidr" "%[2]s" {}
 	})
 }
 
-func testAccAppServicesCIDRDataSourceConfig(resourceName, dataSourceName, cidr string) string {
+func testAccAppServicesCIDRDataSourceConfig(resourceName, dataSourceName, cidr, comment, expiresAt string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -71,7 +75,8 @@ resource "couchbase-capella_app_services_cidr" "%[6]s" {
   cluster_id      = "%[4]s"
   app_service_id  = "%[5]s"
   cidr            = "%[8]s"
-  comment         = "terraform app services cidr datasource acceptance test"
+  comment         = "%[9]s"
+  expires_at      = "%[10]s"
 }
 
 data "couchbase-capella_app_services_cidr" "%[7]s" {
@@ -91,5 +96,7 @@ data "couchbase-capella_app_services_cidr" "%[7]s" {
 		resourceName,
 		dataSourceName,
 		cidr,
+		comment,
+		expiresAt,
 	)
 }

--- a/acceptance_tests/app_services_cidr_datasource_test.go
+++ b/acceptance_tests/app_services_cidr_datasource_test.go
@@ -1,0 +1,95 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccAppServicesCIDRDataSource(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_app_services_cidr_")
+	resourceReference := "couchbase-capella_app_services_cidr." + resourceName
+
+	dataSourceName := randomStringWithPrefix("tf_acc_app_services_cidr_ds_")
+	dataSourceReference := "data.couchbase-capella_app_services_cidr." + dataSourceName
+
+	// Generate a random CIDR block for testing. This ensures that the test is not dependent on any pre-existing data and can be run multiple times without conflicts.
+	// This is used as an allowed IP on the App Service for purposes of testing the data source.
+	allowedCIDR := fmt.Sprintf("172.16.%d.%d/32", rand.Intn(256), rand.Intn(256)) // #nosec G404
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServicesCIDRDataSourceConfig(resourceName, dataSourceName, allowedCIDR),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "cidr", allowedCIDR),
+					resource.TestCheckResourceAttrSet(resourceReference, "id"),
+
+					resource.TestCheckResourceAttr(dataSourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dataSourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dataSourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(dataSourceReference, "app_service_id", globalAppServiceId),
+					resource.TestCheckResourceAttrSet(dataSourceReference, "data.#"),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceReference, "data.*", map[string]string{
+						"cidr": allowedCIDR,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAppServicesCIDRDataSourceMissingRequiredFields(t *testing.T) {
+	dataSourceName := randomStringWithPrefix("tf_acc_app_services_cidr_ds_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_app_services_cidr" "%[2]s" {}
+`, globalProviderBlock, dataSourceName),
+				ExpectError: regexp.MustCompile(`The argument "(organization_id|project_id|cluster_id|app_service_id)" is required`),
+			},
+		},
+	})
+}
+
+func testAccAppServicesCIDRDataSourceConfig(resourceName, dataSourceName, cidr string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_app_services_cidr" "%[6]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  app_service_id  = "%[5]s"
+  cidr            = "%[8]s"
+  comment         = "terraform app services cidr datasource acceptance test"
+}
+
+data "couchbase-capella_app_services_cidr" "%[7]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  app_service_id  = "%[5]s"
+
+  depends_on = [couchbase-capella_app_services_cidr.%[6]s]
+}
+`,
+		globalProviderBlock,
+		globalOrgId,
+		globalProjectId,
+		globalClusterId,
+		globalAppServiceId,
+		resourceName,
+		dataSourceName,
+		cidr,
+	)
+}

--- a/internal/datasources/app_services_cidr_schema.go
+++ b/internal/datasources/app_services_cidr_schema.go
@@ -20,10 +20,6 @@ func AppServicesCidrSchema() schema.Schema {
 	// Build data attributes
 	dataAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(dataAttrs, "id", appServicesCidrBuilder, computedString())
-	capellaschema.AddAttr(dataAttrs, "organization_id", appServicesCidrBuilder, computedString())
-	capellaschema.AddAttr(dataAttrs, "project_id", appServicesCidrBuilder, computedString())
-	capellaschema.AddAttr(dataAttrs, "cluster_id", appServicesCidrBuilder, computedString())
-	capellaschema.AddAttr(dataAttrs, "app_service_id", appServicesCidrBuilder, computedString())
 	capellaschema.AddAttr(dataAttrs, "cidr", appServicesCidrBuilder, computedString())
 	capellaschema.AddAttr(dataAttrs, "comment", appServicesCidrBuilder, computedString())
 	capellaschema.AddAttr(dataAttrs, "expires_at", appServicesCidrBuilder, computedString())

--- a/internal/datasources/app_services_cidr_schema.go
+++ b/internal/datasources/app_services_cidr_schema.go
@@ -12,6 +12,11 @@ var appServicesCidrBuilder = capellaschema.NewSchemaBuilder("appServicesCidr")
 func AppServicesCidrSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
 
+	capellaschema.AddAttr(attrs, "organization_id", appServicesCidrBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "project_id", appServicesCidrBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "cluster_id", appServicesCidrBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "app_service_id", appServicesCidrBuilder, requiredString())
+
 	// Build data attributes
 	dataAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(dataAttrs, "id", appServicesCidrBuilder, computedString())

--- a/internal/schema/app_service_cidr.go
+++ b/internal/schema/app_service_cidr.go
@@ -67,7 +67,7 @@ type AppServiceCIDRs struct {
 
 // Validate is used to verify that all the fields in the datasource
 // have been populated.
-func (a *AppServiceCIDRs) Validate() (clusterId, projectId, organizationId, appserviceId string, err error) {
+func (a *AppServiceCIDRs) Validate() (organizationId, projectId, clusterId, appserviceId string, err error) {
 	if a.OrganizationId.IsNull() {
 		return "", "", "", "", errors.ErrOrganizationIdMissing
 	}
@@ -80,7 +80,7 @@ func (a *AppServiceCIDRs) Validate() (clusterId, projectId, organizationId, apps
 	if a.AppServiceId.IsNull() {
 		return "", "", "", "", errors.ErrAppServiceIdMissing
 	}
-	return a.ClusterId.ValueString(), a.ProjectId.ValueString(), a.OrganizationId.ValueString(), a.AppServiceId.ValueString(), nil
+	return a.OrganizationId.ValueString(), a.ProjectId.ValueString(), a.ClusterId.ValueString(), a.AppServiceId.ValueString(), nil
 }
 
 // Validate is used to verify that all the fields in the datasource


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-129755

## Description

- Fix App Service CIDR data source by 
	- making the schema fields for organisation ID, project ID, cluster ID, and App Service ID all required instead of computed
	- making the validate function return the ids in the correct order
- Added acceptance test for the data source

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

```
$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/isaaclambat/dev/terraform/providers
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.couchbase-capella_app_services_cidr.app-cidr: Reading...
data.couchbase-capella_app_services_cidr.app-cidr: Read complete after 0s

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```


```
  "resources": [
    {
      "mode": "data",
      "type": "couchbase-capella_app_services_cidr",
      "name": "app-cidr",
      "provider": "provider[\"registry.terraform.io/couchbasecloud/couchbase-capella\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "app_service_id": "c34f8cc4-5ac7-4ecb-86c0-fdba8333ec52",
            "cluster_id": "22a88aaf-e97a-4755-986d-3a32ad528c8c",
            "data": [
              {
                "audit": {
                  "created_at": "2026-05-13 13:06:24.143117341 +0000 UTC",
                  "created_by": "f1575aad-0e8f-4add-b9ae-de660553cc96",
                  "modified_at": "2026-05-13 13:06:24.143117341 +0000 UTC",
                  "modified_by": "f1575aad-0e8f-4add-b9ae-de660553cc96",
                  "version": 1
                },
                "cidr": "172.16.227.0/32",
                "comment": null,
                "expires_at": null,
                "id": "8c16e585-fc7d-47be-89c9-c8fac801a744"
              }
            ],
            "organization_id": "adb4fb4c-1d98-4287-ac33-230742d2cc76",
            "project_id": "c09035e8-3971-4b79-a6ec-bccd9056041f"
          },
          "sensitive_attributes": [],
          "identity_schema_version": 0
        }
      ]
    }
  ],

```

  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments