### PR TITLE
[AV-129960] Serialize bucket creation to prevent 500 errors

### DIFF
--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -204,4 +204,3 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, timezone)
 }
-

--- a/acceptance_tests/endpoint_setup.go
+++ b/acceptance_tests/endpoint_setup.go
@@ -26,10 +26,16 @@ type fixtBucketState struct {
 var (
 	fixtBucketMu     sync.Mutex
 	fixtBucketStates = map[string]*fixtBucketState{}
+
+	// fixtBucketCreateMu serialises all bucket creation operations across
+	// different bucket names. Concurrent bucket creates on the same cluster
+	// cause 500 errors due to rebalancing conflicts on the server side.
+	fixtBucketCreateMu sync.Mutex
 )
 
 // ensureFixtureBucketByName creates the named bucket exactly once per test
-// process. Safe to call from parallel tests.
+// process. Safe to call from parallel tests. Bucket creation is globally
+// serialised to avoid concurrent rebalance conflicts on the cluster.
 func ensureFixtureBucketByName(t *testing.T, name string) {
 	t.Helper()
 	ensureAppEndpointTestEnvironment(t)
@@ -39,12 +45,14 @@ func ensureFixtureBucketByName(t *testing.T, name string) {
 		state = &fixtBucketState{}
 		fixtBucketStates[name] = state
 	}
-	// Unlock immediately — the mutex only guards the map. Bucket creation is
-	// serialised per-name by state.once (sync.Once), so parallel tests for
-	// different buckets are not blocked behind each other.
 	fixtBucketMu.Unlock()
 
 	state.once.Do(func() {
+		// Acquire the global creation mutex so only one bucket is created at a
+		// time, preventing concurrent rebalance-related 500 errors.
+		fixtBucketCreateMu.Lock()
+		defer fixtBucketCreateMu.Unlock()
+
 		ctx := context.Background()
 		state.created, state.err = createFixtureBucket(ctx, globalClient, name)
 	})
@@ -88,8 +96,11 @@ func ensureFixtureEndpoint(t *testing.T, endpointName, bucketName, description s
 	fixtEndpointMu.Unlock()
 
 	state.once.Do(func() {
+		// Acquire the global bucket creation mutex to avoid concurrent rebalance errors.
+		fixtBucketCreateMu.Lock()
 		ctx := context.Background()
 		bucketCreated, err := createFixtureBucket(ctx, globalClient, bucketName)
+		fixtBucketCreateMu.Unlock()
 		if err != nil {
 			state.err = err
 			return
@@ -155,7 +166,18 @@ func createFixtureBucket(ctx context.Context, client *api.Client, name string) (
 		return false, err
 	}
 
-	return true, waitForFixtureBucket(ctx, client, bucketResp.Id)
+	if err = waitForFixtureBucket(ctx, client, bucketResp.Id); err != nil {
+		return true, err
+	}
+
+	// Bucket creation triggers a cluster rebalance. Wait for the cluster to
+	// return to healthy before returning, so any subsequent bucket create
+	// (serialised by fixtBucketCreateMu) does not race with rebalancing.
+	if err = waitForAppEndpointTestCluster(ctx, client, false); err != nil {
+		return true, fmt.Errorf("waiting for cluster health after bucket %q creation: %w", name, err)
+	}
+
+	return true, nil
 }
 
 // deleteBucketWithRetry retries the bucket DELETE on 412 (App Service not yet

--- a/acceptance_tests/endpoint_setup.go
+++ b/acceptance_tests/endpoint_setup.go
@@ -170,13 +170,6 @@ func createFixtureBucket(ctx context.Context, client *api.Client, name string) (
 		return true, err
 	}
 
-	// Bucket creation triggers a cluster rebalance. Wait for the cluster to
-	// return to healthy before returning, so any subsequent bucket create
-	// (serialised by fixtBucketCreateMu) does not race with rebalancing.
-	if err = waitForAppEndpointTestCluster(ctx, client, false); err != nil {
-		return true, fmt.Errorf("waiting for cluster health after bucket %q creation: %w", name, err)
-	}
-
 	return true, nil
 }
 


### PR DESCRIPTION
## Jira

* AV-129960

## Description

Serialize bucket creation to prevent 500 errors during concurrent operations

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments