### PR TITLE
[AV-131401] Fix TestAccBackupScheduleResourceInvalidType regex for new validator

### DIFF
--- a/acceptance_tests/backup_schedule_acceptance_test.go
+++ b/acceptance_tests/backup_schedule_acceptance_test.go
@@ -103,8 +103,13 @@ func TestAccBackupScheduleResourceInvalidType(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccBackupScheduleResourceConfig(resourceName, "yearly", "sunday", 10, 4, "30days", false),
-				ExpectError: regexp.MustCompile("There is an error during backup schedule creation"),
+				Config: testAccBackupScheduleResourceConfig(resourceName, "yearly", "sunday", 10, 4, "30days", false),
+				// The schema validator rejects type values outside the
+				// allowed enum at plan time, so the test no longer reaches
+				// the API. Match the validator's diagnostic instead of the
+				// previous server-side "error during backup schedule
+				// creation" message.
+				ExpectError: regexp.MustCompile(`Attribute type value must be one of: \["weekly"\]`),
 			},
 		},
 	})

--- a/acceptance_tests/backup_schedule_acceptance_test.go
+++ b/acceptance_tests/backup_schedule_acceptance_test.go
@@ -103,13 +103,7 @@ func TestAccBackupScheduleResourceInvalidType(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupScheduleResourceConfig(resourceName, "yearly", "sunday", 10, 4, "30days", false),
-				// The schema validator rejects type values outside the
-				// allowed enum at plan time, so the test no longer reaches
-				// the API. Match the validator's diagnostic prefix (and the
-				// attribute name) but not the literal enum list — that lets
-				// the test keep passing if the allowed set is later expanded
-				// (e.g. monthly added) without churning the regex.
+				Config:      testAccBackupScheduleResourceConfig(resourceName, "yearly", "sunday", 10, 4, "30days", false),
 				ExpectError: regexp.MustCompile(`Attribute type value must be one of`),
 			},
 		},

--- a/acceptance_tests/backup_schedule_acceptance_test.go
+++ b/acceptance_tests/backup_schedule_acceptance_test.go
@@ -106,10 +106,11 @@ func TestAccBackupScheduleResourceInvalidType(t *testing.T) {
 				Config: testAccBackupScheduleResourceConfig(resourceName, "yearly", "sunday", 10, 4, "30days", false),
 				// The schema validator rejects type values outside the
 				// allowed enum at plan time, so the test no longer reaches
-				// the API. Match the validator's diagnostic instead of the
-				// previous server-side "error during backup schedule
-				// creation" message.
-				ExpectError: regexp.MustCompile(`Attribute type value must be one of: \["weekly"\]`),
+				// the API. Match the validator's diagnostic prefix (and the
+				// attribute name) but not the literal enum list — that lets
+				// the test keep passing if the allowed set is later expanded
+				// (e.g. monthly added) without churning the regex.
+				ExpectError: regexp.MustCompile(`Attribute type value must be one of`),
 			},
 		},
 	})


### PR DESCRIPTION
## Jira

* [AV-131401](https://jira.issues.couchbase.com/browse/AV-131401) — `TestAccBackupScheduleResourceInvalidType` ExpectError regex doesn't match new schema validator output

## Description

`TestAccBackupScheduleResourceInvalidType` fails on every acceptance test run because its `ExpectError` regex matches an apply-time API error that the test no longer reaches.

The `couchbase-capella_backup_schedule.type` schema attribute now has a `OneOf(["weekly"])` validator. When the test config sets `type = "yearly"`, the validator rejects it at **plan time** with the diagnostic:

```
Attribute type value must be one of: ["weekly"], got: "yearly"
```

The previous regex matched a server-side message (`There is an error during backup schedule creation`) that the test never reaches anymore, so the test fails with `expected an error with pattern, no match on: ...`.

### Fix

Update the test's `ExpectError` regex in [`acceptance_tests/backup_schedule_acceptance_test.go`](acceptance_tests/backup_schedule_acceptance_test.go) to match the validator's diagnostic prefix:

```regex
Attribute type value must be one of
```

The full `["weekly"]` enum list is intentionally left out of the regex — if the allowed set is later expanded (e.g. monthly added) or framework formatting shifts, the test should not break for the wrong reason.

The test's intent (provider rejects invalid `type`) is preserved; the error just now surfaces earlier (plan time) instead of later (apply time).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

* `go build ./...` clean
* `go vet ./...` clean
* `go test -c ./acceptance_tests` clean
* `TestAccBackupScheduleResourceInvalidType` PASSED in **0.14 s** on CI ([run 26098969387](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/actions/runs/26098969387)).

</details>

## Further comments

* Reference failure before the fix: [Jenkins terraform-test job 1311](http://qe-jenkins1.sc.couchbase.com/job/terraform-test/1311/testReport/) and every recent GHA Acceptance Tests run.
* The only remaining "Build" failure on this PR's CI is the unrelated `TestAccAppServiceLogStreaming/App_Endpoint_Logging_Config` `log_keys` validator flake — not in this PR's scope.

[AV-131401]: https://couchbasecloud.atlassian.net/browse/AV-131401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ