### PR TITLE
[AV-131411] Adds acceptance coverage for the couchbase-capella_app_services data source

### DIFF
--- a/acceptance_tests/appservice_acceptance_test.go
+++ b/acceptance_tests/appservice_acceptance_test.go
@@ -157,23 +157,32 @@ func testAccCheckAppServicesDataSourceContainsGlobalAppService(dataSourceReferen
 				continue
 			}
 
-			for suffix, want := range map[string]string{
+			expectedAttrs := map[string]string{
 				"organization_id": globalOrgId,
-				"cluster_id":      globalClusterId,
-				"name":            globalAppServiceName,
-				"nodes":           "2",
-				"compute.cpu":     "2",
-				"compute.ram":     "4",
-			} {
+			}
+			if globalAppServiceCreated {
+				expectedAttrs["cluster_id"] = globalClusterId
+				expectedAttrs["name"] = globalAppServiceName
+				expectedAttrs["nodes"] = "2"
+				expectedAttrs["compute.cpu"] = "2"
+				expectedAttrs["compute.ram"] = "4"
+			}
+
+			for suffix, want := range expectedAttrs {
 				if err := assertAppServicesDataSourceAttr(attrs, i, suffix, want); err != nil {
 					return err
 				}
 			}
 
 			for _, suffix := range []string{
+				"cluster_id",
+				"name",
+				"nodes",
 				"cloud_provider",
 				"current_state",
 				"version",
+				"compute.cpu",
+				"compute.ram",
 				"audit.created_at",
 				"audit.modified_at",
 				"audit.version",

--- a/acceptance_tests/appservice_acceptance_test.go
+++ b/acceptance_tests/appservice_acceptance_test.go
@@ -2,6 +2,8 @@ package acceptance_tests
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -32,6 +34,43 @@ func TestAppServiceResource(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccDatasourceAppServices(t *testing.T) {
+	dataSourceName := randomStringWithPrefix("tf_acc_app_svcs_ds_")
+	dataSourceReference := "data.couchbase-capella_app_services." + dataSourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServicesDataSourceConfig(dataSourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttrSet(dataSourceReference, "data.#"),
+					testAccCheckAppServicesDataSourceContainsGlobalAppService(dataSourceReference),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceAppServicesMissingOrganization(t *testing.T) {
+	dataSourceName := randomStringWithPrefix("tf_acc_app_svcs_ds_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_app_services" "%[2]s" {}
+`, globalProviderBlock, dataSourceName),
+				ExpectError: regexp.MustCompile(`The argument "organization_id" is required`),
+			},
 		},
 	})
 }
@@ -88,6 +127,76 @@ resource "couchbase-capella_app_service" "%[4]s" {
   }
 }
 `, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, cidr)
+}
+
+func testAccAppServicesDataSourceConfig(dataSourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_app_services" "%[3]s" {
+  organization_id = "%[2]s"
+}
+`, globalProviderBlock, globalOrgId, dataSourceName)
+}
+
+func testAccCheckAppServicesDataSourceContainsGlobalAppService(dataSourceReference string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		dataSource, ok := state.RootModule().Resources[dataSourceReference]
+		if !ok {
+			return fmt.Errorf("data source %q not found in state", dataSourceReference)
+		}
+
+		attrs := dataSource.Primary.Attributes
+		count, err := strconv.Atoi(attrs["data.#"])
+		if err != nil {
+			return fmt.Errorf("invalid data.# on %q: %w", dataSourceReference, err)
+		}
+
+		for i := 0; i < count; i++ {
+			if attrs[fmt.Sprintf("data.%d.id", i)] != globalAppServiceId {
+				continue
+			}
+
+			for suffix, want := range map[string]string{
+				"organization_id": globalOrgId,
+				"cluster_id":      globalClusterId,
+				"name":            globalAppServiceName,
+				"nodes":           "2",
+				"compute.cpu":     "2",
+				"compute.ram":     "4",
+			} {
+				if err := assertAppServicesDataSourceAttr(attrs, i, suffix, want); err != nil {
+					return err
+				}
+			}
+
+			for _, suffix := range []string{
+				"cloud_provider",
+				"current_state",
+				"version",
+				"audit.created_at",
+				"audit.modified_at",
+				"audit.version",
+			} {
+				key := fmt.Sprintf("data.%d.%s", i, suffix)
+				if attrs[key] == "" {
+					return fmt.Errorf("attribute %q expected to be set on matched app service %s", key, globalAppServiceId)
+				}
+			}
+
+			return nil
+		}
+
+		return fmt.Errorf("expected app service %q in %s.data, not found across %d entries", globalAppServiceId, dataSourceReference, count)
+	}
+}
+
+func assertAppServicesDataSourceAttr(attrs map[string]string, index int, suffix, want string) error {
+	key := fmt.Sprintf("data.%d.%s", index, suffix)
+	if got := attrs[key]; got != want {
+		return fmt.Errorf("%s = %q, want %q", key, got, want)
+	}
+	return nil
 }
 
 func generateAppServiceImportId(resourceReference string) resource.ImportStateIdFunc {


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-131411](https://jira.issues.couchbase.com/browse/AV-131411)

## Description

Adds acceptance coverage for the couchbase-capella_app_services data source.

What Changed

- Added [TestAccDatasourceAppServices] to verify the App Services list data source.
- Reuses the global App Service fixture created during [TestMain] setup instead of creating an additional App Service.
- Asserts the datasource response contains the global App Service by [globalAppServiceId]
- Added [TestAccDatasourceAppServicesMissingOrganization] to verify Terraform reports a required-argument error when organization_id is omitted.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

TF_ACC=1 go test -timeout=60m -v ./acceptance_tests/ -run 'TestAccDatasourceAppServices$|TestAccDatasourceAppServicesMissingOrganization$'
2026/05/19 11:54:13 Using existing project: e752bfc8-f9e4-42a2-9721-555d4452a518
2026/05/19 11:57:16 cluster created
2026/05/19 11:58:17 bucket created
2026/05/19 11:58:17 Created bucket: default (ZGVmYXVsdA==)
2026/05/19 11:58:18 cluster created
2026/05/19 12:05:21 app service created
2026/05/19 12:06:24 app endpoint state Offline
=== RUN   TestAccDatasourceAppServices
=== PAUSE TestAccDatasourceAppServices
=== RUN   TestAccDatasourceAppServicesMissingOrganization
=== PAUSE TestAccDatasourceAppServicesMissingOrganization
=== CONT  TestAccDatasourceAppServices
=== CONT  TestAccDatasourceAppServicesMissingOrganization
--- PASS: TestAccDatasourceAppServicesMissingOrganization (1.09s)
--- PASS: TestAccDatasourceAppServices (2.50s)
PASS
ok      github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests 979.826s


## Further comments

[AV-131411]: https://couchbasecloud.atlassian.net/browse/AV-131411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ