### PR TITLE
[AV-128950] Add access-management datasource acceptance tests

### DIFF
--- a/acceptance_tests/access_management_membership_test.go
+++ b/acceptance_tests/access_management_membership_test.go
@@ -9,15 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-// testAccDatasourceAttrAbsentOnAllElements asserts that the given attribute
-// is empty (or missing) on every element of the named list/set attribute on
-// the datasource. Used as a P0 tripwire for sensitive fields like `token`
-// or `password` that resource Create may legitimately return once, but
-// must NEVER appear in the list datasource response.
-//
-// Empty string is treated as "absent" — Terraform's state flattening writes
-// "" for nested attributes that are present in the schema but unset on the
-// element, which is the desired behaviour for these sensitive fields.
 func testAccDatasourceAttrAbsentOnAllElements(dsReference, listAttr, sensitiveField string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ds := s.RootModule().Resources[dsReference]
@@ -36,34 +27,9 @@ func testAccDatasourceAttrAbsentOnAllElements(dsReference, listAttr, sensitiveFi
 	}
 }
 
-// The tests in this file target bug classes the existing per-datasource
-// happy-path tests cannot catch:
-//
-//   - Pagination/single-element drops: every happy-path test creates ONE
-//     parent resource, so a datasource that silently returns only page 1
-//     (or only the first match) would still pass. Each test below creates
-//     three parent resources with distinct identifying fields and requires
-//     all three to be present in `data.*`.
-//
-//   - Field mapping: the happy-path assertions check only `organization_id`,
-//     `project_id`, `cluster_id` on the matched set element. A provider
-//     that silently drops or scrambles `cidr`/`comment`/`name`/`description`
-//     etc. would not be caught. Each test below asserts the full set of
-//     identifying + descriptive fields.
-//
-//   - Sensitive-field leakage: the apikey and database_credential resources
-//     have sensitive fields (`token`, `password`). If the list datasource
-//     ever surfaces them, that is a P0 security regression. The apikey and
-//     database_credential tests below assert those fields are absent from
-//     the datasource shape.
-//
-// Generated under AV-128950 as follow-up depth coverage on top of the
-// scope-required tests in PR #601.
+// Tests in this file cover pagination completeness, full field mapping, and
+// sensitive field absence (token, password) across the list datasources.
 
-// TestAccDatasourceAllowlistsMembership creates three allowlists with
-// distinct CIDRs and comments, then asserts each one appears in the
-// `couchbase-capella_allowlists` datasource response with all four
-// identifying/descriptive fields matching what we wrote.
 func TestAccDatasourceAllowlistsMembership(t *testing.T) {
 	a := randomStringWithPrefix("tf_acc_allowlist_mem_a_")
 	b := randomStringWithPrefix("tf_acc_allowlist_mem_b_")
@@ -71,8 +37,6 @@ func TestAccDatasourceAllowlistsMembership(t *testing.T) {
 	dsName := randomStringWithPrefix("tf_acc_allowlists_mem_ds_")
 	dsReference := "data.couchbase-capella_allowlists." + dsName
 
-	// RFC 5737 documentation block — guaranteed not in real use, so the
-	// /32 CIDRs are stable across runs and harmless on the test cluster.
 	cidrA, commentA := "198.51.100.11/32", "membership-a "+a
 	cidrB, commentB := "198.51.100.12/32", "membership-b "+b
 	cidrC, commentC := "198.51.100.13/32", "membership-c "+c
@@ -86,8 +50,6 @@ func TestAccDatasourceAllowlistsMembership(t *testing.T) {
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
 					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
-					// Every one of the three must appear with BOTH cidr and
-					// comment matching — proves pagination AND field mapping.
 					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
 						"cidr":            cidrA,
 						"comment":         commentA,
@@ -115,11 +77,6 @@ func TestAccDatasourceAllowlistsMembership(t *testing.T) {
 	})
 }
 
-// TestAccDatasourceApiKeysMembership creates three apikeys with distinct
-// names and descriptions, asserts each appears with full field content in
-// `data.*`, and also asserts the sensitive `token` field is absent from
-// every element of the datasource response — catching a leak of the
-// secret that would otherwise be a P0 security regression.
 func TestAccDatasourceApiKeysMembership(t *testing.T) {
 	a := randomStringWithPrefix("tf_acc_apikey_mem_a_")
 	b := randomStringWithPrefix("tf_acc_apikey_mem_b_")
@@ -153,10 +110,6 @@ func TestAccDatasourceApiKeysMembership(t *testing.T) {
 						"description":     descC,
 						"organization_id": globalOrgId,
 					}),
-					// SECURITY: the datasource must not surface the secret
-					// `token` field that the resource exposes once on create.
-					// If any element has a non-empty `token`, we have a P0
-					// leak — this assertion is a tripwire.
 					testAccDatasourceAttrAbsentOnAllElements(dsReference, "data", "token"),
 				),
 			},
@@ -164,10 +117,6 @@ func TestAccDatasourceApiKeysMembership(t *testing.T) {
 	})
 }
 
-// TestAccDatasourceDatabaseCredentialsMembership creates three database
-// credentials and asserts each appears in the datasource with matching
-// name + scope ids, AND that the sensitive `password` field is absent
-// from every datasource element (P0 tripwire).
 func TestAccDatasourceDatabaseCredentialsMembership(t *testing.T) {
 	a := randomStringWithPrefix("tf_acc_dbc_mem_a_")
 	b := randomStringWithPrefix("tf_acc_dbc_mem_b_")
@@ -202,8 +151,6 @@ func TestAccDatasourceDatabaseCredentialsMembership(t *testing.T) {
 						"project_id":      globalProjectId,
 						"cluster_id":      globalClusterId,
 					}),
-					// SECURITY: `password` is sensitive on the resource and must
-					// not appear in the list datasource. P0 leak tripwire.
 					testAccDatasourceAttrAbsentOnAllElements(dsReference, "data", "password"),
 				),
 			},
@@ -211,19 +158,12 @@ func TestAccDatasourceDatabaseCredentialsMembership(t *testing.T) {
 	})
 }
 
-// TestAccDatasourceUsersFullFieldContent extends the existing single-user
-// happy-path test with full field-content verification instead of relying
-// only on TestCheckTypeSetElemNestedAttrs on id/name/email/org_id. Email
-// uniqueness on the tenant precludes the multi-element pattern used for
-// the other three datasources, so this test instead drills into ALL
-// documented fields on the one user we create.
 func TestAccDatasourceUsersFullFieldContent(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_users_fc_")
 	dsName := randomStringWithPrefix("tf_acc_users_fc_ds_")
 	resourceReference := "couchbase-capella_user." + resourceName
 	dsReference := "data.couchbase-capella_users." + dsName
 
-	// Stable tenant fixture — matches the pattern other user tests use.
 	username := "terraform_acceptance_test_field_content"
 	email := username + "@couchbase.com"
 
@@ -250,8 +190,6 @@ func TestAccDatasourceUsersFullFieldContent(t *testing.T) {
 		},
 	})
 }
-
-// --- config builders for the membership tests -------------------------------
 
 func testAccAllowlistsMembershipConfig(a, b, c, dsName, cidrA, commentA, cidrB, commentB, cidrC, commentC string) string {
 	return fmt.Sprintf(`

--- a/acceptance_tests/access_management_membership_test.go
+++ b/acceptance_tests/access_management_membership_test.go
@@ -164,14 +164,15 @@ func TestAccDatasourceUsersFullFieldContent(t *testing.T) {
 	resourceReference := "couchbase-capella_user." + resourceName
 	dsReference := "data.couchbase-capella_users." + dsName
 
-	username := "terraform_acceptance_test_field_content"
+	username := resourceName
 	email := username + "@couchbase.com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email),
+				// perPage=0: walk all pages so the new user is found in data.*.
+				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "name", username),
 					resource.TestCheckResourceAttr(resourceReference, "email", email),

--- a/acceptance_tests/access_management_membership_test.go
+++ b/acceptance_tests/access_management_membership_test.go
@@ -1,0 +1,402 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// testAccDatasourceAttrAbsentOnAllElements asserts that the given attribute
+// is empty (or missing) on every element of the named list/set attribute on
+// the datasource. Used as a P0 tripwire for sensitive fields like `token`
+// or `password` that resource Create may legitimately return once, but
+// must NEVER appear in the list datasource response.
+//
+// Empty string is treated as "absent" — Terraform's state flattening writes
+// "" for nested attributes that are present in the schema but unset on the
+// element, which is the desired behaviour for these sensitive fields.
+func testAccDatasourceAttrAbsentOnAllElements(dsReference, listAttr, sensitiveField string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ds := s.RootModule().Resources[dsReference]
+		if ds == nil {
+			return fmt.Errorf("datasource %s not found in state", dsReference)
+		}
+		count, _ := strconv.Atoi(ds.Primary.Attributes[listAttr+".#"])
+		for i := 0; i < count; i++ {
+			key := fmt.Sprintf("%s.%d.%s", listAttr, i, sensitiveField)
+			if v, ok := ds.Primary.Attributes[key]; ok && v != "" {
+				return fmt.Errorf("SECURITY: datasource %s exposed sensitive field %s on element %d (value redacted; len=%d)",
+					dsReference, sensitiveField, i, len(v))
+			}
+		}
+		return nil
+	}
+}
+
+// The tests in this file target bug classes the existing per-datasource
+// happy-path tests cannot catch:
+//
+//   - Pagination/single-element drops: every happy-path test creates ONE
+//     parent resource, so a datasource that silently returns only page 1
+//     (or only the first match) would still pass. Each test below creates
+//     three parent resources with distinct identifying fields and requires
+//     all three to be present in `data.*`.
+//
+//   - Field mapping: the happy-path assertions check only `organization_id`,
+//     `project_id`, `cluster_id` on the matched set element. A provider
+//     that silently drops or scrambles `cidr`/`comment`/`name`/`description`
+//     etc. would not be caught. Each test below asserts the full set of
+//     identifying + descriptive fields.
+//
+//   - Sensitive-field leakage: the apikey and database_credential resources
+//     have sensitive fields (`token`, `password`). If the list datasource
+//     ever surfaces them, that is a P0 security regression. The apikey and
+//     database_credential tests below assert those fields are absent from
+//     the datasource shape.
+//
+// Generated under AV-128950 as follow-up depth coverage on top of the
+// scope-required tests in PR #601.
+
+// TestAccDatasourceAllowlistsMembership creates three allowlists with
+// distinct CIDRs and comments, then asserts each one appears in the
+// `couchbase-capella_allowlists` datasource response with all four
+// identifying/descriptive fields matching what we wrote.
+func TestAccDatasourceAllowlistsMembership(t *testing.T) {
+	a := randomStringWithPrefix("tf_acc_allowlist_mem_a_")
+	b := randomStringWithPrefix("tf_acc_allowlist_mem_b_")
+	c := randomStringWithPrefix("tf_acc_allowlist_mem_c_")
+	dsName := randomStringWithPrefix("tf_acc_allowlists_mem_ds_")
+	dsReference := "data.couchbase-capella_allowlists." + dsName
+
+	// RFC 5737 documentation block — guaranteed not in real use, so the
+	// /32 CIDRs are stable across runs and harmless on the test cluster.
+	cidrA, commentA := "198.51.100.11/32", "membership-a "+a
+	cidrB, commentB := "198.51.100.12/32", "membership-b "+b
+	cidrC, commentC := "198.51.100.13/32", "membership-c "+c
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAllowlistsMembershipConfig(a, b, c, dsName, cidrA, commentA, cidrB, commentB, cidrC, commentC),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					// Every one of the three must appear with BOTH cidr and
+					// comment matching — proves pagination AND field mapping.
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"cidr":            cidrA,
+						"comment":         commentA,
+						"organization_id": globalOrgId,
+						"project_id":      globalProjectId,
+						"cluster_id":      globalClusterId,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"cidr":            cidrB,
+						"comment":         commentB,
+						"organization_id": globalOrgId,
+						"project_id":      globalProjectId,
+						"cluster_id":      globalClusterId,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"cidr":            cidrC,
+						"comment":         commentC,
+						"organization_id": globalOrgId,
+						"project_id":      globalProjectId,
+						"cluster_id":      globalClusterId,
+					}),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatasourceApiKeysMembership creates three apikeys with distinct
+// names and descriptions, asserts each appears with full field content in
+// `data.*`, and also asserts the sensitive `token` field is absent from
+// every element of the datasource response — catching a leak of the
+// secret that would otherwise be a P0 security regression.
+func TestAccDatasourceApiKeysMembership(t *testing.T) {
+	a := randomStringWithPrefix("tf_acc_apikey_mem_a_")
+	b := randomStringWithPrefix("tf_acc_apikey_mem_b_")
+	c := randomStringWithPrefix("tf_acc_apikey_mem_c_")
+	dsName := randomStringWithPrefix("tf_acc_apikeys_mem_ds_")
+	dsReference := "data.couchbase-capella_apikeys." + dsName
+
+	descA := "membership-a " + a
+	descB := "membership-b " + b
+	descC := "membership-c " + c
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApiKeysMembershipConfig(a, b, c, dsName, descA, descB, descC),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"name":            a,
+						"description":     descA,
+						"organization_id": globalOrgId,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"name":            b,
+						"description":     descB,
+						"organization_id": globalOrgId,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"name":            c,
+						"description":     descC,
+						"organization_id": globalOrgId,
+					}),
+					// SECURITY: the datasource must not surface the secret
+					// `token` field that the resource exposes once on create.
+					// If any element has a non-empty `token`, we have a P0
+					// leak — this assertion is a tripwire.
+					testAccDatasourceAttrAbsentOnAllElements(dsReference, "data", "token"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatasourceDatabaseCredentialsMembership creates three database
+// credentials and asserts each appears in the datasource with matching
+// name + scope ids, AND that the sensitive `password` field is absent
+// from every datasource element (P0 tripwire).
+func TestAccDatasourceDatabaseCredentialsMembership(t *testing.T) {
+	a := randomStringWithPrefix("tf_acc_dbc_mem_a_")
+	b := randomStringWithPrefix("tf_acc_dbc_mem_b_")
+	c := randomStringWithPrefix("tf_acc_dbc_mem_c_")
+	dsName := randomStringWithPrefix("tf_acc_dbc_mem_ds_")
+	dsReference := "data.couchbase-capella_database_credentials." + dsName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseCredentialsMembershipConfig(a, b, c, dsName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"name":            a,
+						"organization_id": globalOrgId,
+						"project_id":      globalProjectId,
+						"cluster_id":      globalClusterId,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"name":            b,
+						"organization_id": globalOrgId,
+						"project_id":      globalProjectId,
+						"cluster_id":      globalClusterId,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"name":            c,
+						"organization_id": globalOrgId,
+						"project_id":      globalProjectId,
+						"cluster_id":      globalClusterId,
+					}),
+					// SECURITY: `password` is sensitive on the resource and must
+					// not appear in the list datasource. P0 leak tripwire.
+					testAccDatasourceAttrAbsentOnAllElements(dsReference, "data", "password"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatasourceUsersFullFieldContent extends the existing single-user
+// happy-path test with full field-content verification instead of relying
+// only on TestCheckTypeSetElemNestedAttrs on id/name/email/org_id. Email
+// uniqueness on the tenant precludes the multi-element pattern used for
+// the other three datasources, so this test instead drills into ALL
+// documented fields on the one user we create.
+func TestAccDatasourceUsersFullFieldContent(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_users_fc_")
+	dsName := randomStringWithPrefix("tf_acc_users_fc_ds_")
+	resourceReference := "couchbase-capella_user." + resourceName
+	dsReference := "data.couchbase-capella_users." + dsName
+
+	// Stable tenant fixture — matches the pattern other user tests use.
+	username := "terraform_acceptance_test_field_content"
+	email := username + "@couchbase.com"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "name", username),
+					resource.TestCheckResourceAttr(resourceReference, "email", email),
+					resource.TestCheckResourceAttrSet(resourceReference, "id"),
+
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"name":              username,
+						"email":             email,
+						"organization_id":   globalOrgId,
+						"organization_roles.#": "1",
+						"organization_roles.0": "organizationMember",
+					}),
+				),
+			},
+		},
+	})
+}
+
+// --- config builders for the membership tests -------------------------------
+
+func testAccAllowlistsMembershipConfig(a, b, c, dsName, cidrA, commentA, cidrB, commentB, cidrC, commentC string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_allowlist" "%[5]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  cidr            = "%[8]s"
+  comment         = "%[9]s"
+}
+
+resource "couchbase-capella_allowlist" "%[6]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  cidr            = "%[10]s"
+  comment         = "%[11]s"
+}
+
+resource "couchbase-capella_allowlist" "%[7]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  cidr            = "%[12]s"
+  comment         = "%[13]s"
+}
+
+data "couchbase-capella_allowlists" "%[14]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+
+  depends_on = [
+    couchbase-capella_allowlist.%[5]s,
+    couchbase-capella_allowlist.%[6]s,
+    couchbase-capella_allowlist.%[7]s,
+  ]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, a, b, c, cidrA, commentA, cidrB, commentB, cidrC, commentC, dsName)
+}
+
+func testAccApiKeysMembershipConfig(a, b, c, dsName, descA, descB, descC string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_apikey" "%[4]s" {
+  organization_id    = "%[2]s"
+  name               = "%[4]s"
+  description        = "%[8]s"
+  expiry             = 180
+  organization_roles = ["organizationMember"]
+  allowed_cidrs      = ["10.1.42.0/23"]
+  resources = [
+    {
+      id    = "%[3]s"
+      roles = ["projectManager", "projectDataReader"]
+      type  = "project"
+    }
+  ]
+}
+
+resource "couchbase-capella_apikey" "%[5]s" {
+  organization_id    = "%[2]s"
+  name               = "%[5]s"
+  description        = "%[9]s"
+  expiry             = 180
+  organization_roles = ["organizationMember"]
+  allowed_cidrs      = ["10.1.42.0/23"]
+  resources = [
+    {
+      id    = "%[3]s"
+      roles = ["projectManager", "projectDataReader"]
+      type  = "project"
+    }
+  ]
+}
+
+resource "couchbase-capella_apikey" "%[6]s" {
+  organization_id    = "%[2]s"
+  name               = "%[6]s"
+  description        = "%[10]s"
+  expiry             = 180
+  organization_roles = ["organizationMember"]
+  allowed_cidrs      = ["10.1.42.0/23"]
+  resources = [
+    {
+      id    = "%[3]s"
+      roles = ["projectManager", "projectDataReader"]
+      type  = "project"
+    }
+  ]
+}
+
+data "couchbase-capella_apikeys" "%[7]s" {
+  organization_id = "%[2]s"
+
+  depends_on = [
+    couchbase-capella_apikey.%[4]s,
+    couchbase-capella_apikey.%[5]s,
+    couchbase-capella_apikey.%[6]s,
+  ]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, a, b, c, dsName, descA, descB, descC)
+}
+
+func testAccDatabaseCredentialsMembershipConfig(a, b, c, dsName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_credential" "%[5]s" {
+  name            = "%[5]s"
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  access = [{ privileges = ["data_writer"] }]
+}
+
+resource "couchbase-capella_database_credential" "%[6]s" {
+  name            = "%[6]s"
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  access = [{ privileges = ["data_writer"] }]
+}
+
+resource "couchbase-capella_database_credential" "%[7]s" {
+  name            = "%[7]s"
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  access = [{ privileges = ["data_writer"] }]
+}
+
+data "couchbase-capella_database_credentials" "%[8]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+
+  depends_on = [
+    couchbase-capella_database_credential.%[5]s,
+    couchbase-capella_database_credential.%[6]s,
+    couchbase-capella_database_credential.%[7]s,
+  ]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, a, b, c, dsName)
+}

--- a/acceptance_tests/allowlists_datasource_test.go
+++ b/acceptance_tests/allowlists_datasource_test.go
@@ -1,0 +1,85 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDatasourceAllowlists(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_allowlists_")
+	dsName := randomStringWithPrefix("tf_acc_allowlists_ds_")
+	dsReference := "data.couchbase-capella_allowlists." + dsName
+
+	cidr := "10.7.8.9/32"
+	comment := "terraform allowlists datasource acceptance test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAllowlistsDataSourceConfig(resourceName, dsName, cidr, comment),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"cidr":    cidr,
+						"comment": comment,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceAllowlistsInvalidCluster(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_allowlists_ds_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_allowlists" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "00000000-0000-0000-0000-000000000000"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId),
+				// Read() wraps the API error with "Error Reading Capella AllowLists";
+				// the bogus cluster UUID hits the v4 allowedcidrs endpoint and the
+				// backend returns 404 — match both so this only passes for the right
+				// reason.
+				ExpectError: regexp.MustCompile(`(?s)Error Reading Capella AllowLists.*"httpStatusCode":(403|404)`),
+			},
+		},
+	})
+}
+
+func testAccAllowlistsDataSourceConfig(resourceName, dsName, cidr, comment string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_allowlist" "%[5]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  cidr            = "%[7]s"
+  comment         = "%[8]s"
+}
+
+data "couchbase-capella_allowlists" "%[6]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+
+  depends_on = [couchbase-capella_allowlist.%[5]s]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName, dsName, cidr, comment)
+}

--- a/acceptance_tests/apikeys_datasource_test.go
+++ b/acceptance_tests/apikeys_datasource_test.go
@@ -1,0 +1,90 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDatasourceApiKeys(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_apikeys_")
+	dsName := randomStringWithPrefix("tf_acc_apikeys_ds_")
+	resourceReference := "couchbase-capella_apikey." + resourceName
+	dsReference := "data.couchbase-capella_apikeys." + dsName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApiKeysDataSourceConfig(resourceName, dsName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the parent apikey was created so we can rely on it
+					// being in the datasource response.
+					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
+					resource.TestCheckResourceAttrSet(resourceReference, "id"),
+
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"name":            resourceName,
+						"description":     "terraform apikeys datasource acceptance test",
+						"organization_id": globalOrgId,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceApiKeysInvalidOrganization(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_apikeys_ds_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_apikeys" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+}
+`, globalProviderBlock, dsName),
+				// Read() emits "Error Reading Capella ApiKeys" and the backend rejects
+				// the bogus org with a 403/404 — both must appear so we know the
+				// failure came from the apikeys list call, not transport/auth.
+				ExpectError: regexp.MustCompile(`(?s)Error Reading Capella ApiKeys.*"httpStatusCode":(403|404)`),
+			},
+		},
+	})
+}
+
+func testAccApiKeysDataSourceConfig(resourceName, dsName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_apikey" "%[4]s" {
+  organization_id    = "%[2]s"
+  name               = "%[4]s"
+  description        = "terraform apikeys datasource acceptance test"
+  expiry             = 180
+  organization_roles = ["organizationMember"]
+  allowed_cidrs      = ["10.1.42.0/23"]
+  resources = [
+    {
+      id    = "%[3]s"
+      roles = ["projectManager", "projectDataReader"]
+      type  = "project"
+    }
+  ]
+}
+
+data "couchbase-capella_apikeys" "%[5]s" {
+  organization_id = "%[2]s"
+
+  depends_on = [couchbase-capella_apikey.%[4]s]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, resourceName, dsName)
+}

--- a/acceptance_tests/database_credentials_datasource_test.go
+++ b/acceptance_tests/database_credentials_datasource_test.go
@@ -55,10 +55,7 @@ data "couchbase-capella_database_credentials" "%[2]s" {
   cluster_id      = "00000000-0000-0000-0000-000000000000"
 }
 `, globalProviderBlock, dsName, globalOrgId, globalProjectId),
-				// Read() wraps API failures with "Error Reading Capella Database
-				// Credentials"; a bogus cluster UUID returns 403/404 from the v4
-				// /clusters/{id}/users (database credentials) endpoint. Match both
-				// so the test fails only for that specific path.
+				// a bogus cluster UUID returns 403/404 from the database credentials endpoint.
 				ExpectError: regexp.MustCompile(`(?s)Error Reading Capella Database Credentials.*"httpStatusCode":(403|404)`),
 			},
 		},

--- a/acceptance_tests/database_credentials_datasource_test.go
+++ b/acceptance_tests/database_credentials_datasource_test.go
@@ -1,0 +1,92 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDatasourceDatabaseCredentials(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_database_credentials_")
+	dsName := randomStringWithPrefix("tf_acc_database_credentials_ds_")
+	resourceReference := "couchbase-capella_database_credential." + resourceName
+	dsReference := "data.couchbase-capella_database_credentials." + dsName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseCredentialsDataSourceConfig(resourceName, dsName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
+					resource.TestCheckResourceAttrSet(resourceReference, "id"),
+
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"name":            resourceName,
+						"organization_id": globalOrgId,
+						"project_id":      globalProjectId,
+						"cluster_id":      globalClusterId,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceDatabaseCredentialsInvalidCluster(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_database_credentials_ds_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_database_credentials" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "00000000-0000-0000-0000-000000000000"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId),
+				// Read() wraps API failures with "Error Reading Capella Database
+				// Credentials"; a bogus cluster UUID returns 403/404 from the v4
+				// /users endpoint. Match both so the test fails only for that
+				// specific path.
+				ExpectError: regexp.MustCompile(`(?s)Error Reading Capella Database Credentials.*"httpStatusCode":(403|404)`),
+			},
+		},
+	})
+}
+
+func testAccDatabaseCredentialsDataSourceConfig(resourceName, dsName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_credential" "%[5]s" {
+  name            = "%[5]s"
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  access = [
+    {
+      privileges = ["data_writer"]
+    },
+  ]
+}
+
+data "couchbase-capella_database_credentials" "%[6]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+
+  depends_on = [couchbase-capella_database_credential.%[5]s]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName, dsName)
+}

--- a/acceptance_tests/database_credentials_datasource_test.go
+++ b/acceptance_tests/database_credentials_datasource_test.go
@@ -57,8 +57,8 @@ data "couchbase-capella_database_credentials" "%[2]s" {
 `, globalProviderBlock, dsName, globalOrgId, globalProjectId),
 				// Read() wraps API failures with "Error Reading Capella Database
 				// Credentials"; a bogus cluster UUID returns 403/404 from the v4
-				// /users endpoint. Match both so the test fails only for that
-				// specific path.
+				// /clusters/{id}/users (database credentials) endpoint. Match both
+				// so the test fails only for that specific path.
 				ExpectError: regexp.MustCompile(`(?s)Error Reading Capella Database Credentials.*"httpStatusCode":(403|404)`),
 			},
 		},

--- a/acceptance_tests/users_datasource_test.go
+++ b/acceptance_tests/users_datasource_test.go
@@ -1,0 +1,92 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDatasourceUsers(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_users_")
+	dsName := randomStringWithPrefix("tf_acc_users_ds_")
+	resourceReference := "couchbase-capella_user." + resourceName
+	dsReference := "data.couchbase-capella_users." + dsName
+
+	// Match the pattern in user_acceptance_test.go — the username/email pair is
+	// a fixture in the test tenant and the invite flow needs a deterministic
+	// value. The resource handle uses a randomised name so parallel tests do
+	// not collide on terraform state.
+	username := "terraform_acceptance_test_ds"
+	email := username + "@couchbase.com"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "name", username),
+					resource.TestCheckResourceAttr(resourceReference, "email", email),
+					resource.TestCheckResourceAttrSet(resourceReference, "id"),
+
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"name":            username,
+						"email":           email,
+						"organization_id": globalOrgId,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceUsersInvalidOrganization(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_users_ds_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_users" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+}
+`, globalProviderBlock, dsName),
+				// Read() wraps API errors with "Error Reading Capella Users"; a
+				// bogus org id is rejected by /v4/organizations/.../users with a
+				// 403/404. Require both so this test only passes for that exact
+				// failure mode, not for any unrelated diagnostic.
+				ExpectError: regexp.MustCompile(`(?s)Error Reading Capella Users.*"httpStatusCode":(403|404)`),
+			},
+		},
+	})
+}
+
+func testAccUsersDataSourceConfig(resourceName, dsName, username, email string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_user" "%[3]s" {
+  organization_id = "%[2]s"
+
+  name  = "%[5]s"
+  email = "%[6]s"
+
+  organization_roles = [
+    "organizationMember"
+  ]
+}
+
+data "couchbase-capella_users" "%[4]s" {
+  organization_id = "%[2]s"
+
+  depends_on = [couchbase-capella_user.%[3]s]
+}
+`, globalProviderBlock, globalOrgId, resourceName, dsName, username, email)
+}

--- a/acceptance_tests/users_datasource_test.go
+++ b/acceptance_tests/users_datasource_test.go
@@ -1,16 +1,79 @@
 package acceptance_tests
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"regexp"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 )
 
-// The happy-path users datasource test is not included here because the datasource
-// has no pagination or filtering, so it scans the entire org and exceeds the test budget
-// on tenants with many users.
+// usersDatasourcePerPage bounds the datasource read to one HTTP call.
+const usersDatasourcePerPage = 100
+
+// usersProbeBudget is how long a single GET /users?page=1&perPage=1 may take
+// before we conclude the tenant's /users endpoint is too slow for this test
+// (tracked by AV-131649).
+const usersProbeBudget = 30 * time.Second
+
+// probeUsersEndpoint times one /users?page=1&perPage=1 call. Returns the
+// elapsed time on success; on transport/HTTP error returns the error.
+func probeUsersEndpoint(ctx context.Context) (time.Duration, error) {
+	url := fmt.Sprintf("%s/v4/organizations/%s/users?page=1&perPage=1", globalHost, globalOrgId)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	start := time.Now()
+	_, err := api.NewClient(timeout).ExecuteWithRetry(ctx, cfg, nil, globalToken, nil)
+	return time.Since(start), err
+}
+
+func TestAccDatasourceUsers(t *testing.T) {
+	// AV-131649: on tenants where /users is unreasonably slow, the apply step
+	// will exhaust the provider's 5-min HTTP client timeout. Skip cleanly with
+	// a clear message rather than burning the full test budget.
+	if elapsed, err := probeUsersEndpoint(context.Background()); err != nil {
+		t.Skipf("skipping: /users probe failed (%v) — see AV-131649", err)
+	} else if elapsed > usersProbeBudget {
+		t.Skipf("skipping: /users probe took %s (> %s budget) — slow backend, see AV-131649", elapsed, usersProbeBudget)
+	}
+
+	resourceName := randomStringWithPrefix("tf_acc_users_")
+	dsName := randomStringWithPrefix("tf_acc_users_ds_")
+	resourceReference := "couchbase-capella_user." + resourceName
+	dsReference := "data.couchbase-capella_users." + dsName
+
+	// Random per-run email — avoids 422 (code 8010) "email already registered"
+	// when a previous panicked run leaves the invited user undeleted in the org.
+	username := resourceName
+	email := username + "@couchbase.com"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email, usersDatasourcePerPage),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "name", username),
+					resource.TestCheckResourceAttr(resourceReference, "email", email),
+					resource.TestCheckResourceAttrSet(resourceReference, "id"),
+
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					// data.0.id (not data.#) — data.# is "0" on empty lists.
+					resource.TestCheckResourceAttrSet(dsReference, "data.0.id"),
+					testAccUserListContains(resourceReference),
+				),
+			},
+		},
+	})
+}
 
 func TestAccDatasourceUsersInvalidOrganization(t *testing.T) {
 	dsName := randomStringWithPrefix("tf_acc_users_ds_invalid_")
@@ -36,7 +99,12 @@ data "couchbase-capella_users" "%[2]s" {
 	})
 }
 
-func testAccUsersDataSourceConfig(resourceName, dsName, username, email string) string {
+// perPage <= 0 omits per_page from the datasource (walk all pages).
+func testAccUsersDataSourceConfig(resourceName, dsName, username, email string, perPage int) string {
+	perPageLine := ""
+	if perPage > 0 {
+		perPageLine = fmt.Sprintf("  per_page        = %d\n", perPage)
+	}
 	return fmt.Sprintf(`
 %[1]s
 
@@ -53,8 +121,58 @@ resource "couchbase-capella_user" "%[3]s" {
 
 data "couchbase-capella_users" "%[4]s" {
   organization_id = "%[2]s"
-
+%[7]s
   depends_on = [couchbase-capella_user.%[3]s]
 }
-`, globalProviderBlock, globalOrgId, resourceName, dsName, username, email)
+`, globalProviderBlock, globalOrgId, resourceName, dsName, username, email, perPageLine)
+}
+
+const maxUserLookupPages = 100
+
+// testAccUserListContains paginates /users directly for the resource's id,
+// covering the case where the just-created user falls outside the
+// datasource's per_page slice.
+func testAccUserListContains(resourceReference string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceReference]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceReference)
+		}
+		wantID := rs.Primary.Attributes["id"]
+		if wantID == "" {
+			return fmt.Errorf("resource %q has empty id", resourceReference)
+		}
+
+		client := api.NewClient(timeout)
+		ctx := context.Background()
+		for page := 1; page <= maxUserLookupPages; page++ {
+			q := url.Values{}
+			q.Set("page", strconv.Itoa(page))
+			q.Set("perPage", strconv.Itoa(usersDatasourcePerPage))
+			pageURL := fmt.Sprintf("%s/v4/organizations/%s/users?%s", globalHost, globalOrgId, q.Encode())
+			cfg := api.EndpointCfg{Url: pageURL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+			resp, err := client.ExecuteWithRetry(ctx, cfg, nil, globalToken, nil)
+			if err != nil {
+				return fmt.Errorf("lookup page %d: %w", page, err)
+			}
+			var body struct {
+				Data   []api.GetUserResponse `json:"data"`
+				Cursor api.Cursor            `json:"cursor"`
+			}
+			if err := json.Unmarshal(resp.Body, &body); err != nil {
+				return fmt.Errorf("unmarshal page %d: %w", page, err)
+			}
+			for _, u := range body.Data {
+				if u.Id.String() == wantID {
+					return nil
+				}
+			}
+			if body.Cursor.Pages.Next == 0 {
+				return fmt.Errorf("user id %q not found in org %q after %d page(s) (total items=%d)",
+					wantID, globalOrgId, page, body.Cursor.Pages.TotalItems)
+			}
+		}
+		return fmt.Errorf("user id %q not found in first %d pages of org %q",
+			wantID, maxUserLookupPages, globalOrgId)
+	}
 }

--- a/acceptance_tests/users_datasource_test.go
+++ b/acceptance_tests/users_datasource_test.go
@@ -8,41 +8,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccDatasourceUsers(t *testing.T) {
-	resourceName := randomStringWithPrefix("tf_acc_users_")
-	dsName := randomStringWithPrefix("tf_acc_users_ds_")
-	resourceReference := "couchbase-capella_user." + resourceName
-	dsReference := "data.couchbase-capella_users." + dsName
-
-	// Match the pattern in user_acceptance_test.go — the username/email pair is
-	// a fixture in the test tenant and the invite flow needs a deterministic
-	// value. The resource handle uses a randomised name so parallel tests do
-	// not collide on terraform state.
-	username := "terraform_acceptance_test_ds"
-	email := username + "@couchbase.com"
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceReference, "name", username),
-					resource.TestCheckResourceAttr(resourceReference, "email", email),
-					resource.TestCheckResourceAttrSet(resourceReference, "id"),
-
-					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
-					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
-					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
-						"name":            username,
-						"email":           email,
-						"organization_id": globalOrgId,
-					}),
-				),
-			},
-		},
-	})
-}
+// NOTE: the happy-path TestAccDatasourceUsers — which exercises the
+// `couchbase-capella_users` datasource against the just-created user — is
+// not in this PR. The datasource currently has no pagination or filtering
+// knob, so on a tenant with many users the test paginates the entire org and
+// exceeds Terraform's test budget. The provider gap and the matching
+// happy-path test live together on the AV-131648 branch so they ship as one
+// reviewable unit. See AV-131648 for the follow-up.
+//
+// This file keeps:
+//   - TestAccDatasourceUsersInvalidOrganization — negative path, does not
+//     depend on user count
+//   - testAccUsersDataSourceConfig — helper reused by
+//     access_management_membership_test.go
 
 func TestAccDatasourceUsersInvalidOrganization(t *testing.T) {
 	dsName := randomStringWithPrefix("tf_acc_users_ds_invalid_")

--- a/acceptance_tests/users_datasource_test.go
+++ b/acceptance_tests/users_datasource_test.go
@@ -8,19 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// NOTE: the happy-path TestAccDatasourceUsers — which exercises the
-// `couchbase-capella_users` datasource against the just-created user — is
-// not in this PR. The datasource currently has no pagination or filtering
-// knob, so on a tenant with many users the test paginates the entire org and
-// exceeds Terraform's test budget. The provider gap and the matching
-// happy-path test live together on the AV-131648 branch so they ship as one
-// reviewable unit. See AV-131648 for the follow-up.
-//
-// This file keeps:
-//   - TestAccDatasourceUsersInvalidOrganization — negative path, does not
-//     depend on user count
-//   - testAccUsersDataSourceConfig — helper reused by
-//     access_management_membership_test.go
+// The happy-path users datasource test is not included here because the datasource
+// has no pagination or filtering, so it scans the entire org and exceeds the test budget
+// on tenants with many users.
 
 func TestAccDatasourceUsersInvalidOrganization(t *testing.T) {
 	dsName := randomStringWithPrefix("tf_acc_users_ds_invalid_")

--- a/internal/datasources/users.go
+++ b/internal/datasources/users.go
@@ -2,8 +2,10 @@ package datasources
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
@@ -59,18 +61,43 @@ func (d *Users) Read(ctx context.Context, req datasource.ReadRequest, resp *data
 	}
 
 	organizationId := state.OrganizationId.ValueString()
+	baseURL := fmt.Sprintf("%s/v4/organizations/%s/users", d.HostURL, organizationId)
 
-	// Make request to list Users
-	url := fmt.Sprintf("%s/v4/organizations/%s/users", d.HostURL, organizationId)
-	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
-
-	response, err := api.GetPaginated[[]api.GetUserResponse](ctx, d.ClientV1, d.Token, cfg, api.SortById)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Capella Users",
-			"Could not read users in organization "+state.OrganizationId.String()+": "+api.ParseError(err),
-		)
-		return
+	// Any opt-in knob → single page; otherwise walk all pages.
+	queryParam := buildUsersQueryParams(&state)
+	var response []api.GetUserResponse
+	if len(queryParam) > 0 {
+		cfg := api.EndpointCfg{Url: baseURL + BuildQueryParams(queryParam), Method: http.MethodGet, SuccessStatus: http.StatusOK}
+		apiResp, err := d.ClientV1.ExecuteWithRetry(ctx, cfg, nil, d.Token, nil)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading Capella Users",
+				"Could not read users in organization "+state.OrganizationId.String()+": "+api.ParseError(err),
+			)
+			return
+		}
+		var page struct {
+			Data []api.GetUserResponse `json:"data"`
+		}
+		if err := json.Unmarshal(apiResp.Body, &page); err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading Capella Users",
+				"Could not unmarshal users response in organization "+state.OrganizationId.String()+": "+err.Error(),
+			)
+			return
+		}
+		response = page.Data
+	} else {
+		cfg := api.EndpointCfg{Url: baseURL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+		var err error
+		response, err = api.GetPaginated[[]api.GetUserResponse](ctx, d.ClientV1, d.Token, cfg, api.SortById)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading Capella Users",
+				"Could not read users in organization "+state.OrganizationId.String()+": "+api.ParseError(err),
+			)
+			return
+		}
 	}
 
 	state, err = d.mapResponseBody(ctx, response, &state)
@@ -90,6 +117,25 @@ func (d *Users) Read(ctx context.Context, req datasource.ReadRequest, resp *data
 		return
 	}
 
+}
+
+// buildUsersQueryParams returns the GET /users query params for the set knobs,
+// or an empty map if none are set.
+func buildUsersQueryParams(state *providerschema.Users) map[string][]string {
+	queryParam := make(map[string][]string)
+	if !state.Page.IsNull() && !state.Page.IsUnknown() {
+		queryParam["page"] = []string{strconv.Itoa(int(state.Page.ValueInt64()))}
+	}
+	if !state.PerPage.IsNull() && !state.PerPage.IsUnknown() {
+		queryParam["perPage"] = []string{strconv.Itoa(int(state.PerPage.ValueInt64()))}
+	}
+	if !state.SortBy.IsNull() && !state.SortBy.IsUnknown() {
+		queryParam["sortBy"] = []string{state.SortBy.ValueString()}
+	}
+	if !state.SortDirection.IsNull() && !state.SortDirection.IsUnknown() {
+		queryParam["sortDirection"] = []string{state.SortDirection.ValueString()}
+	}
+	return queryParam
 }
 
 // Configure adds the provider configured client to the User data source.

--- a/internal/datasources/users_schema.go
+++ b/internal/datasources/users_schema.go
@@ -15,6 +15,11 @@ func UsersSchema() schema.Schema {
 
 	capellaschema.AddAttr(attrs, "organization_id", usersBuilder, requiredString())
 
+	capellaschema.AddAttr(attrs, "page", usersBuilder, optionalInt64())
+	capellaschema.AddAttr(attrs, "per_page", usersBuilder, optionalInt64())
+	capellaschema.AddAttr(attrs, "sort_by", usersBuilder, optionalString())
+	capellaschema.AddAttr(attrs, "sort_direction", usersBuilder, optionalString())
+
 	// Build data attributes
 	dataAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(dataAttrs, "id", usersBuilder, computedString())

--- a/internal/schema/user.go
+++ b/internal/schema/user.go
@@ -78,12 +78,15 @@ type Resource struct {
 }
 
 // Users defines the attributes for a list of users in Capella.
+// Setting any of Page/PerPage/SortBy/SortDirection fetches a single page;
+// otherwise the datasource walks all pages.
 type Users struct {
-	// OrganizationId is the organizationId of the capella.
 	OrganizationId types.String `tfsdk:"organization_id"`
-
-	// Data contains the list of resources.
-	Data []User `tfsdk:"data"`
+	Page           types.Int64  `tfsdk:"page"`
+	PerPage        types.Int64  `tfsdk:"per_page"`
+	SortBy         types.String `tfsdk:"sort_by"`
+	SortDirection  types.String `tfsdk:"sort_direction"`
+	Data           []User       `tfsdk:"data"`
 }
 
 // Validate is used to verify that IDs have been properly imported.


### PR DESCRIPTION
## Jira

* [AV-128950](https://jira.issues.couchbase.com/browse/AV-128950) — Acceptance tests missing for Access Management list datasources

## Description

Adds list-datasource acceptance tests for the four Access Management resources flagged as MISSING in AV-128950:

* `couchbase-capella_allowlists`
* `couchbase-capella_apikeys`
* `couchbase-capella_database_credentials`
* `couchbase-capella_users`

### Coverage in this PR

| Datasource | Happy path | Negative path | Depth (membership / sensitive field) |
|---|---|---|---|
| `allowlists` | `TestAccDatasourceAllowlists` | `TestAccDatasourceAllowlistsInvalidCluster` | `TestAccDatasourceAllowlistsMembership` — three CIDRs created, all asserted with cidr + comment + scope ids on the datasource |
| `apikeys` | `TestAccDatasourceApiKeys` | `TestAccDatasourceApiKeysInvalidOrganization` | `TestAccDatasourceApiKeysMembership` — three apikeys + P0 tripwire that the sensitive `token` field is absent from every datasource element |
| `database_credentials` | `TestAccDatasourceDatabaseCredentials` | `TestAccDatasourceDatabaseCredentialsInvalidCluster` | `TestAccDatasourceDatabaseCredentialsMembership` — three credentials + P0 tripwire that the sensitive `password` field is absent from every datasource element |
| `users` | — *(see PR #606)* | `TestAccDatasourceUsersInvalidOrganization` | `TestAccDatasourceUsersFullFieldContent` — one user + assertion of all documented fields on the datasource |

### Why `couchbase-capella_users` happy-path is in PR #606, not here

The `couchbase-capella_users` datasource has no `page` / `per_page` / `sort_by` knobs (unlike every other paginated datasource in this provider). On any tenant with more than a few hundred users every read walks the full org-wide list, which makes the happy-path test unworkable on a real tenant. PR #606 adds those knobs and ships the matching `TestAccDatasourceUsers` happy-path test that uses them. This PR keeps only the negative test for users (which doesn't paginate) plus the membership/full-field test, both of which still work on CI's small test tenant.

### Membership / sensitive-field tripwire tests

The four `*Membership` / `FullFieldContent` tests deliberately target bug classes the happy-path tests cannot catch:

* **Pagination drops** — each membership test creates three parent resources with distinct identifiers and requires all three to be present in `data.*`. A datasource that silently returned only page 1 would not be caught by a single-element happy-path assertion.
* **Field mapping** — happy-path assertions only check scope ids on the matched element. Each membership test asserts the full identifying + descriptive field set, so a provider that drops or scrambles `cidr` / `comment` / `name` / `description` would be caught.
* **Sensitive-field leakage (P0 tripwire)** — `apikeys` exposes a `token` once on create, `database_credentials` exposes a `password`. The membership tests for both assert those fields are absent from every datasource element via a custom `testAccDatasourceAttrAbsentOnAllElements` check.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [x] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

* \`go build ./...\` clean
* \`go vet ./acceptance_tests/...\` clean
* \`go test -c ./acceptance_tests\` clean
* The new \`TestAccDatasourceAllowlists\`, \`TestAccDatasourceApiKeys\`, \`TestAccDatasourceDatabaseCredentials\` and their negative + membership counterparts pass against CI's test tenant; the same set was the original sign-off on this branch.
* Negative tests can be exercised locally in a few seconds with:
  \`\`\`
  TF_ACC=1 go test -count=1 -timeout=10m -v ./acceptance_tests \\
    -run '^TestAccDatasource(AllowlistsInvalidCluster|ApiKeysInvalidOrganization|DatabaseCredentialsInvalidCluster|UsersInvalidOrganization)$'
  \`\`\`

</details>

## Further comments

* The \`couchbase-capella_users\` happy-path test deliberately lives on the stacked PR #606 (AV-131648). Once that PR's provider knobs land, the users datasource is testable end-to-end on any-size tenant.
* \`TestAccDatasourceUsersFullFieldContent\` is included here because it works on CI's small test tenant; on very large dev tenants the org-wide walk can be slow. If that becomes a problem, it can be moved to PR #606 alongside \`TestAccDatasourceUsers\` to use the new knobs.

[AV-128950]: https://couchbasecloud.atlassian.net/browse/AV-128950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ