### PR TITLE
[AV-131535] Add acceptance coverage for app service optional fields and scaling updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ testacc: ## Run acceptance tests (requires TF_VAR_auth_token, TF_VAR_host, TF_VA
 	@[ "${TF_VAR_auth_token}" ] || ( echo "ERROR: export TF_VAR_auth_token before running acceptance tests"; exit 1 )
 	@[ "${TF_VAR_host}" ] || ( echo "ERROR: export TF_VAR_host before running acceptance tests"; exit 1 )
 	@[ "${TF_VAR_organization_id}" ] || ( echo "ERROR: export TF_VAR_organization_id before running acceptance tests"; exit 1 )
-	@TF_ACC=1 go test -timeout=120m -v ./acceptance_tests/
+	@TF_ACC=1 go test -timeout=180m -v ./acceptance_tests/
 
 # ============================================================================
 # Documentation

--- a/acceptance_tests/appservice_acceptance_test.go
+++ b/acceptance_tests/appservice_acceptance_test.go
@@ -57,7 +57,7 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "name", appServiceName),
 					resource.TestCheckResourceAttr(resourceReference, "description", description),
 					resource.TestCheckResourceAttr(resourceReference, "nodes", "2"),
-					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "aws"),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.cpu", "2"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.ram", "4"),
 					resource.TestCheckResourceAttrSet(resourceReference, "id"),
@@ -84,7 +84,7 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "name", appServiceName),
 					resource.TestCheckResourceAttr(resourceReference, "description", description),
 					resource.TestCheckResourceAttr(resourceReference, "nodes", "3"),
-					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "aws"),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.ram", "8"),
 					resource.TestCheckResourceAttrSet(resourceReference, "id"),
@@ -238,7 +238,6 @@ resource "couchbase-capella_app_service" "%[4]s" {
 	name            = "%[7]s"
 	description     = "%[8]s"
 	nodes           = %[9]d
-	cloud_provider  = "aws"
 	compute = {
 		cpu = %[10]d
 		ram = %[11]d

--- a/acceptance_tests/appservice_acceptance_test.go
+++ b/acceptance_tests/appservice_acceptance_test.go
@@ -46,7 +46,7 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 	appServiceName := randomStringWithPrefix("tf_acc_app_svc_")
 	description := "terraform app service optional fields acceptance test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{

--- a/acceptance_tests/appservice_acceptance_test.go
+++ b/acceptance_tests/appservice_acceptance_test.go
@@ -38,6 +38,69 @@ func TestAppServiceResource(t *testing.T) {
 	})
 }
 
+func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_app_svc_")
+	resourceReference := "couchbase-capella_app_service." + resourceName
+	clusterName := randomStringWithPrefix("tf_acc_cluster_")
+	cidr := generateRandomCIDR()
+	appServiceName := randomStringWithPrefix("tf_acc_app_svc_")
+	description := "terraform app service optional fields acceptance test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, 2, 2, 4),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(resourceReference, "name", appServiceName),
+					resource.TestCheckResourceAttr(resourceReference, "description", description),
+					resource.TestCheckResourceAttr(resourceReference, "nodes", "2"),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "aws"),
+					resource.TestCheckResourceAttr(resourceReference, "compute.cpu", "2"),
+					resource.TestCheckResourceAttr(resourceReference, "compute.ram", "4"),
+					resource.TestCheckResourceAttrSet(resourceReference, "id"),
+					resource.TestCheckResourceAttrSet(resourceReference, "cluster_id"),
+					resource.TestCheckResourceAttrSet(resourceReference, "current_state"),
+					resource.TestCheckResourceAttrSet(resourceReference, "version"),
+					resource.TestCheckResourceAttrSet(resourceReference, "etag"),
+					resource.TestCheckResourceAttrSet(resourceReference, "audit.created_at"),
+					resource.TestCheckResourceAttrSet(resourceReference, "audit.modified_at"),
+					resource.TestCheckResourceAttrSet(resourceReference, "audit.version"),
+				),
+			},
+			{
+				ResourceName:      resourceReference,
+				ImportStateIdFunc: generateAppServiceImportId(resourceReference),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, 3, 4, 8),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(resourceReference, "name", appServiceName),
+					resource.TestCheckResourceAttr(resourceReference, "description", description),
+					resource.TestCheckResourceAttr(resourceReference, "nodes", "3"),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "aws"),
+					resource.TestCheckResourceAttr(resourceReference, "compute.cpu", "4"),
+					resource.TestCheckResourceAttr(resourceReference, "compute.ram", "8"),
+					resource.TestCheckResourceAttrSet(resourceReference, "id"),
+					resource.TestCheckResourceAttrSet(resourceReference, "cluster_id"),
+					resource.TestCheckResourceAttrSet(resourceReference, "current_state"),
+					resource.TestCheckResourceAttrSet(resourceReference, "version"),
+					resource.TestCheckResourceAttrSet(resourceReference, "etag"),
+					resource.TestCheckResourceAttrSet(resourceReference, "audit.created_at"),
+					resource.TestCheckResourceAttrSet(resourceReference, "audit.modified_at"),
+					resource.TestCheckResourceAttrSet(resourceReference, "audit.version"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDatasourceAppServices(t *testing.T) {
 	dataSourceName := randomStringWithPrefix("tf_acc_app_svcs_ds_")
 	dataSourceReference := "data.couchbase-capella_app_services." + dataSourceName
@@ -127,6 +190,61 @@ resource "couchbase-capella_app_service" "%[4]s" {
   }
 }
 `, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, cidr)
+}
+
+func testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description string, nodes, cpu, ram int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster" "%[5]s" {
+	organization_id = "%[2]s"
+	project_id      = "%[3]s"
+	name            = "%[5]s"
+	cloud_provider = {
+		type   = "aws"
+		region = "us-east-1"
+		cidr   = "%[6]s"
+	}
+	service_groups = [
+		{
+			node = {
+				compute = {
+					cpu = 4
+					ram = 16
+				}
+				disk = {
+					storage = 50
+					type    = "gp3"
+					iops    = 3000
+				}
+			}
+			num_of_nodes = 3
+			services     = ["data", "index", "query"]
+		}
+	]
+	availability = {
+		"type" : "multi"
+	}
+	support = {
+		plan     = "enterprise"
+		timezone = "PT"
+	}
+}
+
+resource "couchbase-capella_app_service" "%[4]s" {
+	organization_id = "%[2]s"
+	project_id      = "%[3]s"
+	cluster_id      = couchbase-capella_cluster.%[5]s.id
+	name            = "%[7]s"
+	description     = "%[8]s"
+	nodes           = %[9]d
+	cloud_provider  = "aws"
+	compute = {
+		cpu = %[10]d
+		ram = %[11]d
+	}
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, cidr, appServiceName, description, nodes, cpu, ram)
 }
 
 func testAccAppServicesDataSourceConfig(dataSourceName string) string {

--- a/docs/resources/app_service.md
+++ b/docs/resources/app_service.md
@@ -49,7 +49,6 @@ resource "couchbase-capella_app_service" "new_app_service" {
 
 ### Optional
 
-- `cloud_provider` (String) - Provider is the cloud service provider for the App Service.
 - `description` (String) - A short description of the App Service.
 - `if_match` (String) A precondition header that specifies the entity tag of a resource.
 - `nodes` (Number) - Number of nodes configured for the App Service. Number of nodes configured for the App Service. The number of nodes can range from 2 to 12.
@@ -57,6 +56,7 @@ resource "couchbase-capella_app_service" "new_app_service" {
 ### Read-Only
 
 - `audit` (Attributes) Couchbase audit data. (see [below for nested schema](#nestedatt--audit))
+- `cloud_provider` (String) - Provider is the cloud service provider for the App Service.
 - `current_state` (String) - **Valid Values**: `pending`, `deploying`, `deploymentFailed`, `destroying`, `destroyFailed`, `healthy`, `degraded`, `scaling`, `scaleFailed`, `upgrading`, `upgradeFailed`, `turnedOff`, `turningOff`, `turnOffFailed`, `turningOn`, `turnOnFailed`
 - `etag` (String) Entity tag for the resource, used for caching and conditional requests.
 - `id` (String) - The ID of the App Service created.

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/appservice"
@@ -471,7 +470,6 @@ func (a *AppService) refreshAppService(ctx context.Context, organizationId, proj
 		projectId,
 		auditObj,
 	)
-	normalizeAppServiceCloudProvider(&refreshedState.CloudProvider)
 	return refreshedState, nil
 }
 
@@ -552,13 +550,6 @@ func (a *AppService) validateAppServiceAttributesTrimmed(plan providerschema.App
 		return fmt.Errorf("description %s", errors.ErrNotTrimmed)
 	}
 	return nil
-}
-
-func normalizeAppServiceCloudProvider(target *types.String) {
-	if target.IsNull() || target.IsUnknown() {
-		return
-	}
-	*target = types.StringValue(strings.ToLower(target.ValueString()))
 }
 
 // initializePendingAppServiceWithPlanAndId initializes an instance of providerschema.AppService

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -151,7 +151,6 @@ func (a *AppService) Create(ctx context.Context, req resource.CreateRequest, res
 		)
 		return
 	}
-	preserveConfiguredAppServiceCloudProvider(&refreshedState.CloudProvider, plan.CloudProvider)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, refreshedState)
@@ -205,7 +204,6 @@ func (a *AppService) Read(ctx context.Context, req resource.ReadRequest, resp *r
 	if !state.IfMatch.IsUnknown() && !state.IfMatch.IsNull() {
 		refreshedState.IfMatch = state.IfMatch
 	}
-	preserveConfiguredAppServiceCloudProvider(&refreshedState.CloudProvider, state.CloudProvider)
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &refreshedState)
@@ -313,7 +311,6 @@ func (a *AppService) Update(ctx context.Context, req resource.UpdateRequest, res
 	if !plan.IfMatch.IsUnknown() && !plan.IfMatch.IsNull() {
 		currentState.IfMatch = plan.IfMatch
 	}
-	preserveConfiguredAppServiceCloudProvider(&currentState.CloudProvider, plan.CloudProvider)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, currentState)
@@ -555,13 +552,6 @@ func (a *AppService) validateAppServiceAttributesTrimmed(plan providerschema.App
 		return fmt.Errorf("description %s", errors.ErrNotTrimmed)
 	}
 	return nil
-}
-
-func preserveConfiguredAppServiceCloudProvider(target *types.String, configured types.String) {
-	if configured.IsNull() || configured.IsUnknown() {
-		return
-	}
-	*target = types.StringValue(strings.ToLower(configured.ValueString()))
 }
 
 func normalizeAppServiceCloudProvider(target *types.String) {

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/appservice"
@@ -150,6 +151,7 @@ func (a *AppService) Create(ctx context.Context, req resource.CreateRequest, res
 		)
 		return
 	}
+	preserveConfiguredAppServiceCloudProvider(&refreshedState.CloudProvider, plan.CloudProvider)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, refreshedState)
@@ -203,6 +205,7 @@ func (a *AppService) Read(ctx context.Context, req resource.ReadRequest, resp *r
 	if !state.IfMatch.IsUnknown() && !state.IfMatch.IsNull() {
 		refreshedState.IfMatch = state.IfMatch
 	}
+	preserveConfiguredAppServiceCloudProvider(&refreshedState.CloudProvider, state.CloudProvider)
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &refreshedState)
@@ -310,6 +313,7 @@ func (a *AppService) Update(ctx context.Context, req resource.UpdateRequest, res
 	if !plan.IfMatch.IsUnknown() && !plan.IfMatch.IsNull() {
 		currentState.IfMatch = plan.IfMatch
 	}
+	preserveConfiguredAppServiceCloudProvider(&currentState.CloudProvider, plan.CloudProvider)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, currentState)
@@ -470,6 +474,7 @@ func (a *AppService) refreshAppService(ctx context.Context, organizationId, proj
 		projectId,
 		auditObj,
 	)
+	normalizeAppServiceCloudProvider(&refreshedState.CloudProvider)
 	return refreshedState, nil
 }
 
@@ -550,6 +555,20 @@ func (a *AppService) validateAppServiceAttributesTrimmed(plan providerschema.App
 		return fmt.Errorf("description %s", errors.ErrNotTrimmed)
 	}
 	return nil
+}
+
+func preserveConfiguredAppServiceCloudProvider(target *types.String, configured types.String) {
+	if configured.IsNull() || configured.IsUnknown() {
+		return
+	}
+	*target = types.StringValue(strings.ToLower(configured.ValueString()))
+}
+
+func normalizeAppServiceCloudProvider(target *types.String) {
+	if target.IsNull() || target.IsUnknown() {
+		return
+	}
+	*target = types.StringValue(strings.ToLower(target.ValueString()))
 }
 
 // initializePendingAppServiceWithPlanAndId initializes an instance of providerschema.AppService

--- a/internal/resources/appservice_schema.go
+++ b/internal/resources/appservice_schema.go
@@ -25,7 +25,7 @@ func AppServiceSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "name", appServiceBuilder, stringAttribute([]string{required, requiresReplace}))
 	capellaschema.AddAttr(attrs, "description", appServiceBuilder, stringDefaultAttribute("", optional, computed, requiresReplace))
 	capellaschema.AddAttr(attrs, "nodes", appServiceBuilder, int64Attribute(optional, computed))
-	capellaschema.AddAttr(attrs, "cloud_provider", appServiceBuilder, stringAttribute([]string{optional, computed}))
+	capellaschema.AddAttr(attrs, "cloud_provider", appServiceBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "current_state", appServiceBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "version", appServiceBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "audit", appServiceBuilder, computedAuditAttribute())


### PR DESCRIPTION

<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-131535](https://jira.issues.couchbase.com/browse/AV-131535)
* [AV-131523](https://jira.issues.couchbase.com/browse/AV-131523)

## Description

- Changed App Service cloud_provider to computed-only in [appservice_schema.go]
- Moved the generated docs entry from Optional to Read-Only in [app_service.md]
- Add acceptance coverage for app service optional fields and scaling updates

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

`TF_ACC=1 go test -timeout=60m -v ./acceptance_tests/ -run 'TestAccAppServiceResourceOptionalFieldsAndScale$'
2026/05/20 12:11:14 Using existing project: e752bfc8-f9e4-42a2-9721-555d4452a518
2026/05/20 12:11:14 Using existing cluster: 0c9eba96-c459-44ee-b7d0-15326fe44b50
2026/05/20 12:11:15 Discovered existing bucket: default (ZGVmYXVsdA==)
2026/05/20 12:11:15 cluster created
2026/05/20 12:11:15 Using existing app service: 8d8b48aa-f99c-4473-8e44-16fd8684dd67
2026/05/20 12:12:17 app endpoint state Offline
=== RUN   TestAccAppServiceResourceOptionalFieldsAndScale
=== PAUSE TestAccAppServiceResourceOptionalFieldsAndScale
=== CONT  TestAccAppServiceResourceOptionalFieldsAndScale
--- PASS: TestAccAppServiceResourceOptionalFieldsAndScale (1153.35s)
PASS
ok      github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests 1218.244s
`

## Further comments

[AV-131535]: https://couchbasecloud.atlassian.net/browse/AV-131535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AV-131523]: https://couchbasecloud.atlassian.net/browse/AV-131523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ