### PR TITLE
[AV-131648] Add pagination/sort knobs to couchbase-capella_users datasource

### DIFF
--- a/acceptance_tests/access_management_membership_test.go
+++ b/acceptance_tests/access_management_membership_test.go
@@ -171,7 +171,7 @@ func TestAccDatasourceUsersFullFieldContent(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email),
+				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email, usersDatasourcePerPage),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "name", username),
 					resource.TestCheckResourceAttr(resourceReference, "email", email),

--- a/acceptance_tests/access_management_membership_test.go
+++ b/acceptance_tests/access_management_membership_test.go
@@ -171,11 +171,7 @@ func TestAccDatasourceUsersFullFieldContent(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				// perPage = 0 means "don't set per_page on the datasource" —
-				// the datasource walks every page so the just-created user is
-				// reliably found by the data.* membership check below,
-				// regardless of which page it lands on. See
-				// testAccUsersDataSourceConfig.
+				// perPage=0: walk all pages so the new user is found in data.*.
 				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "name", username),

--- a/acceptance_tests/access_management_membership_test.go
+++ b/acceptance_tests/access_management_membership_test.go
@@ -171,7 +171,12 @@ func TestAccDatasourceUsersFullFieldContent(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email, usersDatasourcePerPage),
+				// perPage = 0 means "don't set per_page on the datasource" —
+				// the datasource walks every page so the just-created user is
+				// reliably found by the data.* membership check below,
+				// regardless of which page it lands on. See
+				// testAccUsersDataSourceConfig.
+				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "name", username),
 					resource.TestCheckResourceAttr(resourceReference, "email", email),

--- a/acceptance_tests/access_management_membership_test.go
+++ b/acceptance_tests/access_management_membership_test.go
@@ -164,7 +164,7 @@ func TestAccDatasourceUsersFullFieldContent(t *testing.T) {
 	resourceReference := "couchbase-capella_user." + resourceName
 	dsReference := "data.couchbase-capella_users." + dsName
 
-	username := "terraform_acceptance_test_field_content"
+	username := resourceName
 	email := username + "@couchbase.com"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/acceptance_tests/users_datasource_test.go
+++ b/acceptance_tests/users_datasource_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -19,7 +20,31 @@ import (
 // usersDatasourcePerPage bounds the datasource read to one HTTP call.
 const usersDatasourcePerPage = 100
 
+// usersProbeBudget is how long a single GET /users?page=1&perPage=1 may take
+// before we conclude the tenant's /users endpoint is too slow for this test
+// (tracked by AV-131649).
+const usersProbeBudget = 30 * time.Second
+
+// probeUsersEndpoint times one /users?page=1&perPage=1 call. Returns the
+// elapsed time on success; on transport/HTTP error returns the error.
+func probeUsersEndpoint(ctx context.Context) (time.Duration, error) {
+	url := fmt.Sprintf("%s/v4/organizations/%s/users?page=1&perPage=1", globalHost, globalOrgId)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	start := time.Now()
+	_, err := api.NewClient(timeout).ExecuteWithRetry(ctx, cfg, nil, globalToken, nil)
+	return time.Since(start), err
+}
+
 func TestAccDatasourceUsers(t *testing.T) {
+	// AV-131649: on tenants where /users is unreasonably slow, the apply step
+	// will exhaust the provider's 5-min HTTP client timeout. Skip cleanly with
+	// a clear message rather than burning the full test budget.
+	if elapsed, err := probeUsersEndpoint(context.Background()); err != nil {
+		t.Skipf("skipping: /users probe failed (%v) — see AV-131649", err)
+	} else if elapsed > usersProbeBudget {
+		t.Skipf("skipping: /users probe took %s (> %s budget) — slow backend, see AV-131649", elapsed, usersProbeBudget)
+	}
+
 	resourceName := randomStringWithPrefix("tf_acc_users_")
 	dsName := randomStringWithPrefix("tf_acc_users_ds_")
 	resourceReference := "couchbase-capella_user." + resourceName

--- a/acceptance_tests/users_datasource_test.go
+++ b/acceptance_tests/users_datasource_test.go
@@ -16,9 +16,7 @@ import (
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 )
 
-// usersDatasourcePerPage caps the page size the test asks the
-// couchbase-capella_users datasource for. Bounds the datasource read's work
-// to a single HTTP call regardless of how many users the tenant has.
+// usersDatasourcePerPage bounds the datasource read to one HTTP call.
 const usersDatasourcePerPage = 100
 
 func TestAccDatasourceUsers(t *testing.T) {
@@ -45,18 +43,8 @@ func TestAccDatasourceUsers(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceReference, "id"),
 
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
-					// data.# is set even when the list is empty (Terraform
-					// stores the count "0"), so TestCheckResourceAttrSet would
-					// pass on an empty response. Assert at least one element
-					// is present via data.0.id to actually prove the datasource
-					// returned users.
+					// data.0.id (not data.#) — data.# is "0" on empty lists.
 					resource.TestCheckResourceAttrSet(dsReference, "data.0.id"),
-					// Confirm the just-created user is present somewhere in the
-					// org. The datasource itself returns at most per_page users
-					// (the just-created one may sit on a later page) — so the
-					// custom check walks /users directly looking for our id.
-					// Bounded by maxUserLookupPages so a runaway loop can't
-					// blow the test budget.
 					testAccUserListContains(resourceReference),
 				),
 			},
@@ -88,12 +76,7 @@ data "couchbase-capella_users" "%[2]s" {
 	})
 }
 
-// testAccUsersDataSourceConfig emits HCL for the user resource + users
-// datasource. A perPage of 0 (or negative) means "do not constrain the
-// datasource" — callers that need every page to find the just-created user
-// via data.* membership assertions (e.g. the membership test) should pass 0.
-// Callers that bound the datasource read to a single page (and verify
-// membership via a separate paginated lookup) should pass a positive value.
+// perPage <= 0 omits per_page from the datasource (walk all pages).
 func testAccUsersDataSourceConfig(resourceName, dsName, username, email string, perPage int) string {
 	perPageLine := ""
 	if perPage > 0 {
@@ -121,17 +104,11 @@ data "couchbase-capella_users" "%[4]s" {
 `, globalProviderBlock, globalOrgId, resourceName, dsName, username, email, perPageLine)
 }
 
-// maxUserLookupPages caps how many pages testAccUserListContains will scan
-// looking for the just-created user. At perPage=100 this covers the first
-// 10,000 users — generous for any realistic tenant.
 const maxUserLookupPages = 100
 
-// testAccUserListContains looks up the resource's id from state, then walks
-// /v4/organizations/{org}/users in pages of 100 (independent of the datasource
-// under test) until it finds that id or exhausts the lookup budget. This is
-// the only way to assert "our user is in the org" without relying on
-// server-side email/name filtering on the /users endpoint (filed as a
-// follow-up against AV-131648).
+// testAccUserListContains paginates /users directly for the resource's id,
+// covering the case where the just-created user falls outside the
+// datasource's per_page slice.
 func testAccUserListContains(resourceReference string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceReference]

--- a/acceptance_tests/users_datasource_test.go
+++ b/acceptance_tests/users_datasource_test.go
@@ -1,16 +1,63 @@
 package acceptance_tests
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 )
 
-// The happy-path users datasource test is not included here because the datasource
-// has no pagination or filtering, so it scans the entire org and exceeds the test budget
-// on tenants with many users.
+// usersDatasourcePerPage caps the page size the test asks the
+// couchbase-capella_users datasource for. Bounds the datasource read's work
+// to a single HTTP call regardless of how many users the tenant has.
+const usersDatasourcePerPage = 100
+
+func TestAccDatasourceUsers(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_users_")
+	dsName := randomStringWithPrefix("tf_acc_users_ds_")
+	resourceReference := "couchbase-capella_user." + resourceName
+	dsReference := "data.couchbase-capella_users." + dsName
+
+	// Match the pattern in user_acceptance_test.go — the username/email pair is
+	// a fixture in the test tenant and the invite flow needs a deterministic
+	// value. The resource handle uses a randomised name so parallel tests do
+	// not collide on terraform state.
+	username := "terraform_acceptance_test_ds"
+	email := username + "@couchbase.com"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUsersDataSourceConfig(resourceName, dsName, username, email, usersDatasourcePerPage),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "name", username),
+					resource.TestCheckResourceAttr(resourceReference, "email", email),
+					resource.TestCheckResourceAttrSet(resourceReference, "id"),
+
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+					// Confirm the just-created user is present somewhere in the
+					// org. The datasource itself returns at most per_page users
+					// (the just-created one may sit on a later page) — so the
+					// custom check walks /users directly looking for our id.
+					// Bounded by maxUserLookupPages so a runaway loop can't
+					// blow the test budget.
+					testAccUserListContains(t, resourceReference),
+				),
+			},
+		},
+	})
+}
 
 func TestAccDatasourceUsersInvalidOrganization(t *testing.T) {
 	dsName := randomStringWithPrefix("tf_acc_users_ds_invalid_")
@@ -36,7 +83,7 @@ data "couchbase-capella_users" "%[2]s" {
 	})
 }
 
-func testAccUsersDataSourceConfig(resourceName, dsName, username, email string) string {
+func testAccUsersDataSourceConfig(resourceName, dsName, username, email string, perPage int) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -53,8 +100,65 @@ resource "couchbase-capella_user" "%[3]s" {
 
 data "couchbase-capella_users" "%[4]s" {
   organization_id = "%[2]s"
+  per_page        = %[7]d
 
   depends_on = [couchbase-capella_user.%[3]s]
 }
-`, globalProviderBlock, globalOrgId, resourceName, dsName, username, email)
+`, globalProviderBlock, globalOrgId, resourceName, dsName, username, email, perPage)
+}
+
+// maxUserLookupPages caps how many pages testAccUserListContains will scan
+// looking for the just-created user. At perPage=100 this covers the first
+// 10,000 users — generous for any realistic tenant.
+const maxUserLookupPages = 100
+
+// testAccUserListContains looks up the resource's id from state, then walks
+// /v4/organizations/{org}/users in pages of 100 (independent of the datasource
+// under test) until it finds that id or exhausts the lookup budget. This is
+// the only way to assert "our user is in the org" without relying on
+// server-side email/name filtering on the /users endpoint (filed as a
+// follow-up against AV-131648).
+func testAccUserListContains(t *testing.T, resourceReference string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceReference]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceReference)
+		}
+		wantID := rs.Primary.Attributes["id"]
+		if wantID == "" {
+			return fmt.Errorf("resource %q has empty id", resourceReference)
+		}
+
+		client := api.NewClient(timeout)
+		ctx := context.Background()
+		for page := 1; page <= maxUserLookupPages; page++ {
+			q := url.Values{}
+			q.Set("page", strconv.Itoa(page))
+			q.Set("perPage", strconv.Itoa(usersDatasourcePerPage))
+			pageURL := fmt.Sprintf("%s/v4/organizations/%s/users?%s", globalHost, globalOrgId, q.Encode())
+			cfg := api.EndpointCfg{Url: pageURL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+			resp, err := client.ExecuteWithRetry(ctx, cfg, nil, globalToken, nil)
+			if err != nil {
+				return fmt.Errorf("lookup page %d: %w", page, err)
+			}
+			var body struct {
+				Data   []api.GetUserResponse `json:"data"`
+				Cursor api.Cursor            `json:"cursor"`
+			}
+			if err := json.Unmarshal(resp.Body, &body); err != nil {
+				return fmt.Errorf("unmarshal page %d: %w", page, err)
+			}
+			for _, u := range body.Data {
+				if u.Id.String() == wantID {
+					return nil
+				}
+			}
+			if body.Cursor.Pages.Next == 0 {
+				return fmt.Errorf("user id %q not found in org %q after %d page(s) (total items=%d)",
+					wantID, globalOrgId, page, body.Cursor.Pages.TotalItems)
+			}
+		}
+		return fmt.Errorf("user id %q not found in first %d pages of org %q",
+			wantID, maxUserLookupPages, globalOrgId)
+	}
 }

--- a/acceptance_tests/users_datasource_test.go
+++ b/acceptance_tests/users_datasource_test.go
@@ -45,14 +45,19 @@ func TestAccDatasourceUsers(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceReference, "id"),
 
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
-					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+					// data.# is set even when the list is empty (Terraform
+					// stores the count "0"), so TestCheckResourceAttrSet would
+					// pass on an empty response. Assert at least one element
+					// is present via data.0.id to actually prove the datasource
+					// returned users.
+					resource.TestCheckResourceAttrSet(dsReference, "data.0.id"),
 					// Confirm the just-created user is present somewhere in the
 					// org. The datasource itself returns at most per_page users
 					// (the just-created one may sit on a later page) — so the
 					// custom check walks /users directly looking for our id.
 					// Bounded by maxUserLookupPages so a runaway loop can't
 					// blow the test budget.
-					testAccUserListContains(t, resourceReference),
+					testAccUserListContains(resourceReference),
 				),
 			},
 		},
@@ -83,7 +88,17 @@ data "couchbase-capella_users" "%[2]s" {
 	})
 }
 
+// testAccUsersDataSourceConfig emits HCL for the user resource + users
+// datasource. A perPage of 0 (or negative) means "do not constrain the
+// datasource" — callers that need every page to find the just-created user
+// via data.* membership assertions (e.g. the membership test) should pass 0.
+// Callers that bound the datasource read to a single page (and verify
+// membership via a separate paginated lookup) should pass a positive value.
 func testAccUsersDataSourceConfig(resourceName, dsName, username, email string, perPage int) string {
+	perPageLine := ""
+	if perPage > 0 {
+		perPageLine = fmt.Sprintf("  per_page        = %d\n", perPage)
+	}
 	return fmt.Sprintf(`
 %[1]s
 
@@ -100,11 +115,10 @@ resource "couchbase-capella_user" "%[3]s" {
 
 data "couchbase-capella_users" "%[4]s" {
   organization_id = "%[2]s"
-  per_page        = %[7]d
-
+%[7]s
   depends_on = [couchbase-capella_user.%[3]s]
 }
-`, globalProviderBlock, globalOrgId, resourceName, dsName, username, email, perPage)
+`, globalProviderBlock, globalOrgId, resourceName, dsName, username, email, perPageLine)
 }
 
 // maxUserLookupPages caps how many pages testAccUserListContains will scan
@@ -118,7 +132,7 @@ const maxUserLookupPages = 100
 // the only way to assert "our user is in the org" without relying on
 // server-side email/name filtering on the /users endpoint (filed as a
 // follow-up against AV-131648).
-func testAccUserListContains(t *testing.T, resourceReference string) resource.TestCheckFunc {
+func testAccUserListContains(resourceReference string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceReference]
 		if !ok {

--- a/acceptance_tests/users_datasource_test.go
+++ b/acceptance_tests/users_datasource_test.go
@@ -25,11 +25,9 @@ func TestAccDatasourceUsers(t *testing.T) {
 	resourceReference := "couchbase-capella_user." + resourceName
 	dsReference := "data.couchbase-capella_users." + dsName
 
-	// Match the pattern in user_acceptance_test.go — the username/email pair is
-	// a fixture in the test tenant and the invite flow needs a deterministic
-	// value. The resource handle uses a randomised name so parallel tests do
-	// not collide on terraform state.
-	username := "terraform_acceptance_test_ds"
+	// Random per-run email — avoids 422 (code 8010) "email already registered"
+	// when a previous panicked run leaves the invited user undeleted in the org.
+	username := resourceName
 	email := username + "@couchbase.com"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/datasources/users.go
+++ b/internal/datasources/users.go
@@ -61,13 +61,9 @@ func (d *Users) Read(ctx context.Context, req datasource.ReadRequest, resp *data
 	}
 
 	organizationId := state.OrganizationId.ValueString()
-
-	// Make request to list Users
 	baseURL := fmt.Sprintf("%s/v4/organizations/%s/users", d.HostURL, organizationId)
 
-	// If the caller set any of page / per_page / sort_by / sort_direction, fetch
-	// a single page with those query params. Otherwise walk all pages — this
-	// preserves the original behaviour for callers that don't opt in.
+	// Any opt-in knob → single page; otherwise walk all pages.
 	queryParam := buildUsersQueryParams(&state)
 	var response []api.GetUserResponse
 	if len(queryParam) > 0 {
@@ -123,10 +119,8 @@ func (d *Users) Read(ctx context.Context, req datasource.ReadRequest, resp *data
 
 }
 
-// buildUsersQueryParams converts the optional pagination/sort schema attributes
-// into URL query parameters for GET /v4/organizations/{org}/users. Returns an
-// empty map when none of the knobs are set; the caller then falls back to
-// walking all pages via api.GetPaginated.
+// buildUsersQueryParams returns the GET /users query params for the set knobs,
+// or an empty map if none are set.
 func buildUsersQueryParams(state *providerschema.Users) map[string][]string {
 	queryParam := make(map[string][]string)
 	if !state.Page.IsNull() && !state.Page.IsUnknown() {

--- a/internal/datasources/users.go
+++ b/internal/datasources/users.go
@@ -2,8 +2,10 @@ package datasources
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
@@ -61,16 +63,45 @@ func (d *Users) Read(ctx context.Context, req datasource.ReadRequest, resp *data
 	organizationId := state.OrganizationId.ValueString()
 
 	// Make request to list Users
-	url := fmt.Sprintf("%s/v4/organizations/%s/users", d.HostURL, organizationId)
-	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	baseURL := fmt.Sprintf("%s/v4/organizations/%s/users", d.HostURL, organizationId)
 
-	response, err := api.GetPaginated[[]api.GetUserResponse](ctx, d.ClientV1, d.Token, cfg, api.SortById)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Capella Users",
-			"Could not read users in organization "+state.OrganizationId.String()+": "+api.ParseError(err),
-		)
-		return
+	// If the caller set any of page / per_page / sort_by / sort_direction, fetch
+	// a single page with those query params. Otherwise walk all pages — this
+	// preserves the original behaviour for callers that don't opt in.
+	queryParam := buildUsersQueryParams(&state)
+	var response []api.GetUserResponse
+	if len(queryParam) > 0 {
+		cfg := api.EndpointCfg{Url: baseURL + BuildQueryParams(queryParam), Method: http.MethodGet, SuccessStatus: http.StatusOK}
+		apiResp, err := d.ClientV1.ExecuteWithRetry(ctx, cfg, nil, d.Token, nil)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading Capella Users",
+				"Could not read users in organization "+state.OrganizationId.String()+": "+api.ParseError(err),
+			)
+			return
+		}
+		var page struct {
+			Data []api.GetUserResponse `json:"data"`
+		}
+		if err := json.Unmarshal(apiResp.Body, &page); err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading Capella Users",
+				"Could not unmarshal users response in organization "+state.OrganizationId.String()+": "+err.Error(),
+			)
+			return
+		}
+		response = page.Data
+	} else {
+		cfg := api.EndpointCfg{Url: baseURL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+		var err error
+		response, err = api.GetPaginated[[]api.GetUserResponse](ctx, d.ClientV1, d.Token, cfg, api.SortById)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading Capella Users",
+				"Could not read users in organization "+state.OrganizationId.String()+": "+api.ParseError(err),
+			)
+			return
+		}
 	}
 
 	state, err = d.mapResponseBody(ctx, response, &state)
@@ -90,6 +121,27 @@ func (d *Users) Read(ctx context.Context, req datasource.ReadRequest, resp *data
 		return
 	}
 
+}
+
+// buildUsersQueryParams converts the optional pagination/sort schema attributes
+// into URL query parameters for GET /v4/organizations/{org}/users. Returns an
+// empty map when none of the knobs are set; the caller then falls back to
+// walking all pages via api.GetPaginated.
+func buildUsersQueryParams(state *providerschema.Users) map[string][]string {
+	queryParam := make(map[string][]string)
+	if !state.Page.IsNull() && !state.Page.IsUnknown() {
+		queryParam["page"] = []string{strconv.Itoa(int(state.Page.ValueInt64()))}
+	}
+	if !state.PerPage.IsNull() && !state.PerPage.IsUnknown() {
+		queryParam["perPage"] = []string{strconv.Itoa(int(state.PerPage.ValueInt64()))}
+	}
+	if !state.SortBy.IsNull() && !state.SortBy.IsUnknown() {
+		queryParam["sortBy"] = []string{state.SortBy.ValueString()}
+	}
+	if !state.SortDirection.IsNull() && !state.SortDirection.IsUnknown() {
+		queryParam["sortDirection"] = []string{state.SortDirection.ValueString()}
+	}
+	return queryParam
 }
 
 // Configure adds the provider configured client to the User data source.

--- a/internal/datasources/users_schema.go
+++ b/internal/datasources/users_schema.go
@@ -15,9 +15,6 @@ func UsersSchema() schema.Schema {
 
 	capellaschema.AddAttr(attrs, "organization_id", usersBuilder, requiredString())
 
-	// Pagination / sort knobs. Map to GET /v4/organizations/{org}/users query
-	// params when any of them is set; otherwise the datasource walks all pages
-	// (preserving original behaviour for callers that don't opt in).
 	capellaschema.AddAttr(attrs, "page", usersBuilder, optionalInt64())
 	capellaschema.AddAttr(attrs, "per_page", usersBuilder, optionalInt64())
 	capellaschema.AddAttr(attrs, "sort_by", usersBuilder, optionalString())

--- a/internal/datasources/users_schema.go
+++ b/internal/datasources/users_schema.go
@@ -15,6 +15,14 @@ func UsersSchema() schema.Schema {
 
 	capellaschema.AddAttr(attrs, "organization_id", usersBuilder, requiredString())
 
+	// Pagination / sort knobs. Map to GET /v4/organizations/{org}/users query
+	// params when any of them is set; otherwise the datasource walks all pages
+	// (preserving original behaviour for callers that don't opt in).
+	capellaschema.AddAttr(attrs, "page", usersBuilder, optionalInt64())
+	capellaschema.AddAttr(attrs, "per_page", usersBuilder, optionalInt64())
+	capellaschema.AddAttr(attrs, "sort_by", usersBuilder, optionalString())
+	capellaschema.AddAttr(attrs, "sort_direction", usersBuilder, optionalString())
+
 	// Build data attributes
 	dataAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(dataAttrs, "id", usersBuilder, computedString())

--- a/internal/schema/user.go
+++ b/internal/schema/user.go
@@ -78,9 +78,29 @@ type Resource struct {
 }
 
 // Users defines the attributes for a list of users in Capella.
+//
+// Page / PerPage / SortBy / SortDirection are optional pagination knobs
+// that map to the underlying GET /v4/organizations/{org}/users query
+// parameters. When any of them is set the datasource fetches a single
+// page (matching the pattern used by the cloud_project_snapshot_backups
+// datasource); when none are set the datasource walks all pages, which
+// preserves the original behaviour for callers that didn't opt in.
 type Users struct {
 	// OrganizationId is the organizationId of the capella.
 	OrganizationId types.String `tfsdk:"organization_id"`
+
+	// Page selects a specific page of the paginated results
+	// (1-indexed). Optional.
+	Page types.Int64 `tfsdk:"page"`
+
+	// PerPage caps the number of users returned per page. Optional.
+	PerPage types.Int64 `tfsdk:"per_page"`
+
+	// SortBy is the field name to sort the results by. Optional.
+	SortBy types.String `tfsdk:"sort_by"`
+
+	// SortDirection is "asc" or "desc". Optional.
+	SortDirection types.String `tfsdk:"sort_direction"`
 
 	// Data contains the list of resources.
 	Data []User `tfsdk:"data"`

--- a/internal/schema/user.go
+++ b/internal/schema/user.go
@@ -78,32 +78,15 @@ type Resource struct {
 }
 
 // Users defines the attributes for a list of users in Capella.
-//
-// Page / PerPage / SortBy / SortDirection are optional pagination knobs
-// that map to the underlying GET /v4/organizations/{org}/users query
-// parameters. When any of them is set the datasource fetches a single
-// page (matching the pattern used by the cloud_project_snapshot_backups
-// datasource); when none are set the datasource walks all pages, which
-// preserves the original behaviour for callers that didn't opt in.
+// Setting any of Page/PerPage/SortBy/SortDirection fetches a single page;
+// otherwise the datasource walks all pages.
 type Users struct {
-	// OrganizationId is the organizationId of the capella.
 	OrganizationId types.String `tfsdk:"organization_id"`
-
-	// Page selects a specific page of the paginated results
-	// (1-indexed). Optional.
-	Page types.Int64 `tfsdk:"page"`
-
-	// PerPage caps the number of users returned per page. Optional.
-	PerPage types.Int64 `tfsdk:"per_page"`
-
-	// SortBy is the field name to sort the results by. Optional.
-	SortBy types.String `tfsdk:"sort_by"`
-
-	// SortDirection is "asc" or "desc". Optional.
-	SortDirection types.String `tfsdk:"sort_direction"`
-
-	// Data contains the list of resources.
-	Data []User `tfsdk:"data"`
+	Page           types.Int64  `tfsdk:"page"`
+	PerPage        types.Int64  `tfsdk:"per_page"`
+	SortBy         types.String `tfsdk:"sort_by"`
+	SortDirection  types.String `tfsdk:"sort_direction"`
+	Data           []User       `tfsdk:"data"`
 }
 
 // Validate is used to verify that IDs have been properly imported.


### PR DESCRIPTION
## Jira

[AV-131648](https://jira.issues.couchbase.com/browse/AV-131648)

## Description

Add `page`, `per_page`, `sort_by`, `sort_direction` knobs to the `couchbase-capella_users` datasource so callers can fetch a bounded slice instead of walking every page. When none of the knobs are set the original walk-all-pages behaviour is preserved.

Also restores `TestAccDatasourceUsers` (scoped out of PR #601) — the new `per_page` knob makes it feasible to bound the test to one HTTP call, and a separate paginated lookup verifies the created user is in the org regardless of where it lands.

Stacked on PR #601 (base branch `AV-128950-access-management-datasource-tests`). After #601 merges, switch base to `main`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

`TestAccDatasourceUsers` and `TestAccDatasourceUsersInvalidOrganization` pass against the test tenant.

[AV-131648]: https://couchbasecloud.atlassian.net/browse/AV-131648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ