### PR TITLE
[AV-128951] Use per-test enterprise cluster in audit_log_settings tests

### DIFF
--- a/acceptance_tests/audit_log_settings_acceptance_test.go
+++ b/acceptance_tests/audit_log_settings_acceptance_test.go
@@ -15,12 +15,8 @@ import (
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
 
-// audit_log_settings is a per-cluster singleton: there's no real
-// create/destroy lifecycle on the server side. The provider's Create
-// method PUTs the settings, Update PUTs the new settings, and Delete is a
-// no-op. The Terraform test framework still runs a Destroy at the end,
-// which only removes the resource from state — the server-side singleton
-// is unchanged. We exercise: Create -> Read -> Import -> Update.
+// audit_log_settings is a per-cluster singleton — Create/Update both PUT,
+// Delete is a no-op. We exercise: Create -> Read -> Import -> Update.
 
 func TestAccAuditLogSettingsResource(t *testing.T) {
 	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_")
@@ -29,10 +25,9 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 	clusterReference := "couchbase-capella_cluster." + clusterResourceName
 	resourceReference := "couchbase-capella_audit_log_settings." + resourceName
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
-			// Create and Read testing.
 			{
 				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, true, []int{20488, 20490, 20491}),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -42,22 +37,18 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceReference, "cluster_id", clusterReference, "id"),
 					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20490"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20491"),
 					resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "0"),
 				),
 			},
-			// ImportState testing. The resource has no `id` attribute; the
-			// natural primary key is cluster_id (one settings record per
-			// cluster). The import string keys map through importIds, so
-			// `id` here is matched to ClusterId via the schema's Validate.
 			{
 				ResourceName:                         resourceReference,
 				ImportState:                          true,
 				ImportStateIdFunc:                    generateAuditLogSettingsImportIdForResource(resourceReference),
 				ImportStateVerifyIdentifierAttribute: "cluster_id",
 			},
-			// Update: shrink the enabled event id list and assert ALL
-			// fields to catch reset-to-default regressions per the
-			// acceptance test skill guidance.
 			{
 				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, true, []int{20488}),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -67,10 +58,10 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceReference, "cluster_id", clusterReference, "id"),
 					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
 					resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "0"),
 				),
 			},
-			// Update audit_enabled to false. Assert ALL fields again.
 			{
 				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, false, []int{20488}),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -80,14 +71,13 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceReference, "cluster_id", clusterReference, "id"),
 					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
 				),
 			},
 		},
 	})
 }
 
-// TestAccAuditLogSettingsResourceInvalidCluster asserts that pointing at a
-// non-existent cluster yields the expected create-time error.
 func TestAccAuditLogSettingsResourceInvalidCluster(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_bad_cluster_")
 
@@ -113,15 +103,13 @@ resource "couchbase-capella_audit_log_settings" "%[2]s" {
 	})
 }
 
-// TestAccAuditLogSettingsResourcePlanUpgrade verifies that audit log settings
-// are rejected on a developer pro cluster and succeed after upgrading to enterprise.
 func TestAccAuditLogSettingsResourcePlanUpgrade(t *testing.T) {
 	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_upgrade_")
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_upgrade_")
 	cidr := generateRandomCIDR()
 	resourceReference := "couchbase-capella_audit_log_settings." + resourceName
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
@@ -133,6 +121,7 @@ func TestAccAuditLogSettingsResourcePlanUpgrade(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
 				),
 			},
 		},
@@ -265,30 +254,6 @@ resource "couchbase-capella_audit_log_settings" "%[6]s" {
 `, globalProviderBlock, clusterResourceName, globalOrgId, globalProjectId, cidr, auditSettingsResourceName, auditEnabled, ids)
 }
 
-func testAccAuditLogSettingsResourceConfig(resourceName string, auditEnabled bool, enabledEventIDs []int) string {
-	ids := "["
-	for i, id := range enabledEventIDs {
-		if i > 0 {
-			ids += ", "
-		}
-		ids += fmt.Sprintf("%d", id)
-	}
-	ids += "]"
-
-	return fmt.Sprintf(`
-%[1]s
-
-resource "couchbase-capella_audit_log_settings" "%[2]s" {
-  organization_id   = "%[3]s"
-  project_id        = "%[4]s"
-  cluster_id        = "%[5]s"
-  audit_enabled     = %[6]t
-  enabled_event_ids = %[7]s
-  disabled_users    = []
-}
-`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, auditEnabled, ids)
-}
-
 func generateAuditLogSettingsImportIdForResource(resourceReference string) resource.ImportStateIdFunc {
 	return func(state *terraform.State) (string, error) {
 		var rawState map[string]string
@@ -299,10 +264,6 @@ func generateAuditLogSettingsImportIdForResource(resourceReference string) resou
 				}
 			}
 		}
-		// The resource's schema Validate maps cluster_id to the Id key; the
-		// import string parser uses the importIds lookup table where
-		// "id" -> Id. The provider's ImportState passes the import string
-		// through to the cluster_id attribute, then Validate splits it.
 		return fmt.Sprintf(
 			"id=%s,project_id=%s,organization_id=%s",
 			rawState["cluster_id"], rawState["project_id"], rawState["organization_id"],

--- a/acceptance_tests/audit_log_settings_acceptance_test.go
+++ b/acceptance_tests/audit_log_settings_acceptance_test.go
@@ -23,7 +23,10 @@ import (
 // is unchanged. We exercise: Create -> Read -> Import -> Update.
 
 func TestAccAuditLogSettingsResource(t *testing.T) {
+	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_")
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_")
+	cidr := generateRandomCIDR()
+	clusterReference := "couchbase-capella_cluster." + clusterResourceName
 	resourceReference := "couchbase-capella_audit_log_settings." + resourceName
 
 	resource.Test(t, resource.TestCase{
@@ -31,12 +34,12 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing.
 			{
-				Config: testAccAuditLogSettingsResourceConfig(resourceName, true, []int{20488, 20490, 20491}),
+				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, true, []int{20488, 20490, 20491}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsAuditLogSettingsResource(t, resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
-					resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttrPair(resourceReference, "cluster_id", clusterReference, "id"),
 					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "3"),
 					resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "0"),
@@ -56,12 +59,12 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 			// fields to catch reset-to-default regressions per the
 			// acceptance test skill guidance.
 			{
-				Config: testAccAuditLogSettingsResourceConfig(resourceName, true, []int{20488}),
+				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, true, []int{20488}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsAuditLogSettingsResource(t, resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
-					resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttrPair(resourceReference, "cluster_id", clusterReference, "id"),
 					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "0"),
@@ -69,12 +72,12 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 			},
 			// Update audit_enabled to false. Assert ALL fields again.
 			{
-				Config: testAccAuditLogSettingsResourceConfig(resourceName, false, []int{20488}),
+				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, false, []int{20488}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsAuditLogSettingsResource(t, resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
-					resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttrPair(resourceReference, "cluster_id", clusterReference, "id"),
 					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
 				),
@@ -108,6 +111,158 @@ resource "couchbase-capella_audit_log_settings" "%[2]s" {
 			},
 		},
 	})
+}
+
+// TestAccAuditLogSettingsResourcePlanUpgrade verifies that audit log settings
+// are rejected on a developer pro cluster and succeed after upgrading to enterprise.
+func TestAccAuditLogSettingsResourcePlanUpgrade(t *testing.T) {
+	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_upgrade_")
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_upgrade_")
+	cidr := generateRandomCIDR()
+	resourceReference := "couchbase-capella_audit_log_settings." + resourceName
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceConfigWithSupportPlan(clusterResourceName, resourceName, cidr, "developer pro", true, []int{20488}),
+				ExpectError: regexp.MustCompile(`(?s)error during audit log settings creation|support package`),
+			},
+			{
+				Config: testAccAuditLogSettingsResourceConfigWithSupportPlan(clusterResourceName, resourceName, cidr, "enterprise", true, []int{20488}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAuditLogSettingsResourceConfigWithSupportPlan(clusterResourceName, auditSettingsResourceName, cidr, plan string, auditEnabled bool, enabledEventIDs []int) string {
+	ids := "["
+	for i, id := range enabledEventIDs {
+		if i > 0 {
+			ids += ", "
+		}
+		ids += fmt.Sprintf("%d", id)
+	}
+	ids += "]"
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster" "%[2]s" {
+	organization_id = "%[3]s"
+	project_id      = "%[4]s"
+	name            = "%[2]s"
+
+	cloud_provider = {
+		type   = "aws"
+		region = "us-east-1"
+		cidr   = "%[5]s"
+	}
+
+	service_groups = [
+		{
+			node = {
+				compute = {
+					cpu = 4
+					ram = 16
+				}
+				disk = {
+					storage = 50
+					type    = "io2"
+					iops    = 3000
+				}
+			}
+			num_of_nodes = 3
+			services     = ["data", "index", "query"]
+		}
+	]
+
+	availability = {
+		type = "multi"
+	}
+
+	support = {
+		plan     = "%[8]s"
+		timezone = "PT"
+	}
+}
+
+resource "couchbase-capella_audit_log_settings" "%[6]s" {
+	organization_id   = "%[3]s"
+	project_id        = "%[4]s"
+	cluster_id        = couchbase-capella_cluster.%[2]s.id
+	audit_enabled     = %[7]t
+	enabled_event_ids = %[9]s
+	disabled_users    = []
+}
+`, globalProviderBlock, clusterResourceName, globalOrgId, globalProjectId, cidr, auditSettingsResourceName, auditEnabled, plan, ids)
+}
+
+func testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, auditSettingsResourceName, cidr string, auditEnabled bool, enabledEventIDs []int) string {
+	ids := "["
+	for i, id := range enabledEventIDs {
+		if i > 0 {
+			ids += ", "
+		}
+		ids += fmt.Sprintf("%d", id)
+	}
+	ids += "]"
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster" "%[2]s" {
+	organization_id = "%[3]s"
+	project_id      = "%[4]s"
+	name            = "%[2]s"
+
+	cloud_provider = {
+		type   = "aws"
+		region = "us-east-1"
+		cidr   = "%[5]s"
+	}
+
+	service_groups = [
+		{
+			node = {
+				compute = {
+					cpu = 4
+					ram = 16
+				}
+				disk = {
+					storage = 50
+					type    = "io2"
+					iops    = 3000
+				}
+			}
+			num_of_nodes = 3
+			services     = ["data", "index", "query"]
+		}
+	]
+
+	availability = {
+		type = "multi"
+	}
+
+	support = {
+		plan     = "enterprise"
+		timezone = "PT"
+	}
+}
+
+resource "couchbase-capella_audit_log_settings" "%[6]s" {
+	organization_id   = "%[3]s"
+	project_id        = "%[4]s"
+	cluster_id        = couchbase-capella_cluster.%[2]s.id
+	audit_enabled     = %[7]t
+	enabled_event_ids = %[8]s
+	disabled_users    = []
+}
+`, globalProviderBlock, clusterResourceName, globalOrgId, globalProjectId, cidr, auditSettingsResourceName, auditEnabled, ids)
 }
 
 func testAccAuditLogSettingsResourceConfig(resourceName string, auditEnabled bool, enabledEventIDs []int) string {

--- a/acceptance_tests/audit_log_settings_datasource_test.go
+++ b/acceptance_tests/audit_log_settings_datasource_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// TestAccDatasourceAuditLogSettings provisions an audit_log_settings
-// resource and reads it back through the datasource in the same plan.
-// audit_log_settings is a per-cluster singleton, so the datasource is
-// guaranteed to return the values we just wrote.
 func TestAccDatasourceAuditLogSettings(t *testing.T) {
 	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_for_ds_")
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_for_ds_")
@@ -20,7 +16,7 @@ func TestAccDatasourceAuditLogSettings(t *testing.T) {
 	clusterReference := "couchbase-capella_cluster." + clusterResourceName
 	dsReference := "data.couchbase-capella_audit_log_settings." + dsName
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
@@ -31,6 +27,8 @@ func TestAccDatasourceAuditLogSettings(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dsReference, "cluster_id", clusterReference, "id"),
 					resource.TestCheckResourceAttr(dsReference, "audit_enabled", "true"),
 					resource.TestCheckResourceAttr(dsReference, "enabled_event_ids.#", "2"),
+					resource.TestCheckTypeSetElemAttr(dsReference, "enabled_event_ids.*", "20488"),
+					resource.TestCheckTypeSetElemAttr(dsReference, "enabled_event_ids.*", "20489"),
 					resource.TestCheckResourceAttr(dsReference, "disabled_users.#", "0"),
 				),
 			},

--- a/acceptance_tests/audit_log_settings_datasource_test.go
+++ b/acceptance_tests/audit_log_settings_datasource_test.go
@@ -13,19 +13,22 @@ import (
 // audit_log_settings is a per-cluster singleton, so the datasource is
 // guaranteed to return the values we just wrote.
 func TestAccDatasourceAuditLogSettings(t *testing.T) {
+	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_for_ds_")
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_for_ds_")
 	dsName := randomStringWithPrefix("tf_acc_audit_log_settings_ds_")
+	cidr := generateRandomCIDR()
+	clusterReference := "couchbase-capella_cluster." + clusterResourceName
 	dsReference := "data.couchbase-capella_audit_log_settings." + dsName
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAuditLogSettingsResourceAndDatasourceConfig(resourceName, dsName, true, []int{20488, 20489}),
+				Config: testAccAuditLogSettingsResourceAndDatasourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, dsName, cidr, true, []int{20488, 20489}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
-					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttrPair(dsReference, "cluster_id", clusterReference, "id"),
 					resource.TestCheckResourceAttr(dsReference, "audit_enabled", "true"),
 					resource.TestCheckResourceAttr(dsReference, "enabled_event_ids.#", "2"),
 					resource.TestCheckResourceAttr(dsReference, "disabled_users.#", "0"),
@@ -78,7 +81,7 @@ data "couchbase-capella_audit_log_settings" "%[2]s" {
 	})
 }
 
-func testAccAuditLogSettingsResourceAndDatasourceConfig(resourceName, dsName string, auditEnabled bool, enabledEventIDs []int) string {
+func testAccAuditLogSettingsResourceAndDatasourceConfigWithEnterpriseCluster(clusterResourceName, auditSettingsResourceName, dsName, cidr string, auditEnabled bool, enabledEventIDs []int) string {
 	ids := "["
 	for i, id := range enabledEventIDs {
 		if i > 0 {
@@ -91,21 +94,60 @@ func testAccAuditLogSettingsResourceAndDatasourceConfig(resourceName, dsName str
 	return fmt.Sprintf(`
 %[1]s
 
-resource "couchbase-capella_audit_log_settings" "%[2]s" {
-  organization_id   = "%[4]s"
-  project_id        = "%[5]s"
-  cluster_id        = "%[6]s"
-  audit_enabled     = %[7]t
-  enabled_event_ids = %[8]s
+resource "couchbase-capella_cluster" "%[2]s" {
+	organization_id = "%[5]s"
+	project_id      = "%[6]s"
+	name            = "%[2]s"
+
+	cloud_provider = {
+		type   = "aws"
+		region = "us-east-1"
+		cidr   = "%[4]s"
+	}
+
+	service_groups = [
+		{
+			node = {
+				compute = {
+					cpu = 4
+					ram = 16
+				}
+				disk = {
+					storage = 50
+					type    = "io2"
+					iops    = 3000
+				}
+			}
+			num_of_nodes = 3
+			services     = ["data", "index", "query"]
+		}
+	]
+
+	availability = {
+		type = "multi"
+	}
+
+	support = {
+		plan     = "enterprise"
+		timezone = "PT"
+	}
+}
+
+resource "couchbase-capella_audit_log_settings" "%[3]s" {
+	organization_id   = "%[5]s"
+	project_id        = "%[6]s"
+	cluster_id        = couchbase-capella_cluster.%[2]s.id
+	audit_enabled     = %[7]t
+	enabled_event_ids = %[8]s
   disabled_users    = []
 }
 
-data "couchbase-capella_audit_log_settings" "%[3]s" {
-  organization_id = "%[4]s"
-  project_id      = "%[5]s"
-  cluster_id      = "%[6]s"
+data "couchbase-capella_audit_log_settings" "%[9]s" {
+	organization_id = "%[5]s"
+	project_id      = "%[6]s"
+	cluster_id      = couchbase-capella_cluster.%[2]s.id
 
-  depends_on = [couchbase-capella_audit_log_settings.%[2]s]
+	depends_on = [couchbase-capella_audit_log_settings.%[3]s]
 }
-`, globalProviderBlock, resourceName, dsName, globalOrgId, globalProjectId, globalClusterId, auditEnabled, ids)
+`, globalProviderBlock, clusterResourceName, auditSettingsResourceName, cidr, globalOrgId, globalProjectId, auditEnabled, ids, dsName)
 }


### PR DESCRIPTION
## Jira

[AV-128951](https://jira.issues.couchbase.com/browse/AV-128951)

## Description

Follow-up to PR #602. The audit_log_settings resource and datasource tests were using `globalClusterId` which may be a developer-pro cluster — audit log settings are only supported on enterprise. This replaces the global cluster with a per-test enterprise multi-AZ cluster so the tests are self-contained and reliably succeed.

Also adds `TestAccAuditLogSettingsResourcePlanUpgrade` which verifies that applying audit log settings to a developer-pro cluster is rejected by the API, and succeeds after upgrading to enterprise.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

`TestAccAuditLogSettingsResource` and `TestAccDatasourceAuditLogSettings` pass against the test tenant with a dedicated enterprise cluster. `TestAccAuditLogSettingsResourcePlanUpgrade` verifies the plan-upgrade flow.

[AV-128951]: https://couchbasecloud.atlassian.net/browse/AV-128951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ