### PR TITLE
[AV-131530] Implemented short-term graceful degradation fix

### DIFF
--- a/acceptance_tests/app_endpoint_environment.go
+++ b/acceptance_tests/app_endpoint_environment.go
@@ -27,12 +27,17 @@ var appEndpointEnvironmentOnce struct {
 func ensureAppEndpointTestEnvironment(t *testing.T) {
 	t.Helper()
 
+	setupRan := false
 	appEndpointEnvironmentOnce.Do(func() {
+		setupRan = true
 		ctx := context.Background()
 		appEndpointEnvironmentOnce.err = setupAppEndpointTestEnvironment(ctx, globalClient)
 	})
 	if appEndpointEnvironmentOnce.err != nil {
-		t.Fatalf("failed to provision app endpoint test environment: %v", appEndpointEnvironmentOnce.err)
+		if setupRan {
+			t.Skipf("skipping app endpoint acceptance tests: failed to provision shared test environment: %v", appEndpointEnvironmentOnce.err)
+		}
+		t.Skip("skipping app endpoint acceptance test: shared test environment provisioning already failed")
 	}
 }
 


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-131530](https://jira.issues.couchbase.com/browse/AV-131530)

## Description

Implemented the short-term graceful degradation fix in [app_endpoint_environment.go:29-42].

What changed: the shared sync.Once setup now tracks whether the current test was the one that actually ran provisioning. If provisioning fails, that first caller is skipped with the full setup error, and every later app-endpoint test skips with a concise “shared setup already failed” message instead of failing instantly with the cached error. That stops the red cascade from ~20 dependent tests.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

https://github.com/couchbasecloud/terraform-provider-couchbase-capella/actions/runs/26238064574/job/77218711652?pr=611

=== RUN   TestAccAppEndpoint
    app_endpoint_acceptance_test.go:13: skipping app endpoint acceptance tests: failed to provision shared test environment: {"code":4025,"hint":"The requested cluster details could not be found or fetched. Please ensure that the correct cluster ID is provided.","httpStatusCode":404,"message":"Unable to fetch the cluster details."}
--- SKIP: TestAccAppEndpoint (241.19s)
=== RUN   TestAccAppEndpointInexistentCollection
    app_endpoint_acceptance_test.go:54: skipping app endpoint acceptance test: shared test environment provisioning already failed
--- SKIP: TestAccAppEndpointInexistentCollection (0.00s)

## Further comments

[AV-131530]: https://couchbasecloud.atlassian.net/browse/AV-131530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ