### PR TITLE
[AV-132258] Add stricter Terraform-side validation for API key and user role configuration

### DIFF
--- a/acceptance_tests/apikey_acceptance_test.go
+++ b/acceptance_tests/apikey_acceptance_test.go
@@ -268,7 +268,7 @@ func TestAccApiKeyResourceInvalidScenarioResourceIdEmpty(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccApiKeyResourceConfigWithResourceId(resourceName, ""),
-				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value.*Attribute resources.*id.*string length must be at least 1, got: 0`),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Length.*Attribute\s+resources.*\.id\s+string length must be at least 1, got: 0`),
 			},
 		},
 	})

--- a/acceptance_tests/apikey_acceptance_test.go
+++ b/acceptance_tests/apikey_acceptance_test.go
@@ -23,12 +23,12 @@ func TestAccApiKeyResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
 					resource.TestCheckResourceAttr(resourceReference, "description", "description"),
 					resource.TestCheckResourceAttr(resourceReference, "expiry", "150"),
-					resource.TestCheckResourceAttr(resourceReference, "allowed_cidrs.0", "10.1.42.0/23"),
-					resource.TestCheckResourceAttr(resourceReference, "allowed_cidrs.1", "10.1.42.1/23"),
-					resource.TestCheckResourceAttr(resourceReference, "organization_roles.0", "organizationMember"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "allowed_cidrs.*", "10.1.42.0/23"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "allowed_cidrs.*", "10.1.42.1/23"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "organization_roles.*", "organizationMember"),
 					resource.TestCheckResourceAttr(resourceReference, "resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceReference, "resources.0.roles.0", "projectDataReader"),
-					resource.TestCheckResourceAttr(resourceReference, "resources.0.roles.1", "projectManager"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "resources.0.roles.*", "projectDataReader"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "resources.0.roles.*", "projectManager"),
 					resource.TestCheckResourceAttr(resourceReference, "resources.0.type", "project"),
 				),
 			},
@@ -57,9 +57,9 @@ func TestAccApiKeyResourceWithOnlyReqField(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
 					resource.TestCheckResourceAttr(resourceReference, "description", ""),
 					resource.TestCheckResourceAttr(resourceReference, "expiry", "180"),
-					resource.TestCheckResourceAttr(resourceReference, "allowed_cidrs.0", "0.0.0.0/0"),
-					resource.TestCheckResourceAttr(resourceReference, "organization_roles.0", "organizationMember"),
-					resource.TestCheckResourceAttr(resourceReference, "organization_roles.1", "organizationOwner"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "allowed_cidrs.*", "0.0.0.0/0"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "organization_roles.*", "organizationMember"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "organization_roles.*", "organizationOwner"),
 				),
 			},
 			// ImportState testing
@@ -76,12 +76,34 @@ func TestAccApiKeyResourceWithOnlyReqField(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
 					resource.TestCheckResourceAttr(resourceReference, "description", ""),
 					resource.TestCheckResourceAttr(resourceReference, "expiry", "180"),
-					resource.TestCheckResourceAttr(resourceReference, "allowed_cidrs.0", "0.0.0.0/0"),
-					resource.TestCheckResourceAttr(resourceReference, "organization_roles.0", "organizationMember"),
-					resource.TestCheckResourceAttr(resourceReference, "organization_roles.1", "organizationOwner"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "allowed_cidrs.*", "0.0.0.0/0"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "organization_roles.*", "organizationMember"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "organization_roles.*", "organizationOwner"),
 					resource.TestCheckResourceAttr(resourceReference, "rotate", "1"),
 					resource.TestCheckResourceAttr(resourceReference, "secret", "abc"),
 					resource.TestCheckResourceAttrSet(resourceReference, "token"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccApiKeyResourceWithDefaults(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_apikey_")
+	resourceReference := "couchbase-capella_apikey." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApiKeyResourceConfigWithDefaults(resourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
+					resource.TestCheckResourceAttr(resourceReference, "description", ""),
+					resource.TestCheckResourceAttr(resourceReference, "expiry", "180"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "allowed_cidrs.*", "0.0.0.0/0"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "organization_roles.*", "organizationMember"),
+					resource.TestCheckResourceAttr(resourceReference, "resources.#", "0"),
 				),
 			},
 		},
@@ -102,11 +124,11 @@ func TestAccApiKeyResourceForOrgOwner(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
 					resource.TestCheckResourceAttr(resourceReference, "description", ""),
 					resource.TestCheckResourceAttr(resourceReference, "expiry", "180"),
-					resource.TestCheckResourceAttr(resourceReference, "allowed_cidrs.0", "0.0.0.0/0"),
-					resource.TestCheckResourceAttr(resourceReference, "organization_roles.0", "organizationMember"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "allowed_cidrs.*", "0.0.0.0/0"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "organization_roles.*", "organizationMember"),
 					resource.TestCheckResourceAttr(resourceReference, "resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceReference, "resources.0.roles.0", "projectDataReader"),
-					resource.TestCheckResourceAttr(resourceReference, "resources.0.roles.1", "projectManager"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "resources.0.roles.*", "projectDataReader"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "resources.0.roles.*", "projectManager"),
 					resource.TestCheckResourceAttr(resourceReference, "resources.0.type", "project"),
 				),
 			},
@@ -129,7 +151,124 @@ func TestAccApiKeyResourceInvalidScenarioRotateShouldNotPassedWhileCreate(t *tes
 			// Create and Read testing
 			{
 				Config:      testAccApiKeyResourceConfigRotateSetConfig(resourceName),
-				ExpectError: regexp.MustCompile("rotate value should not be set"),
+				ExpectError: regexp.MustCompile(`(?s)Invalid API Key Configuration.*rotate value should not be set during create`),
+			},
+		},
+	})
+}
+
+func TestAccApiKeyResourceInvalidScenarioSecretShouldNotPassedWhileCreate(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_apikey_")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApiKeyResourceConfigSecretSetConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)Invalid API Key Configuration.*secret can only be configured together with rotate`),
+			},
+		},
+	})
+}
+
+func TestAccApiKeyResourceInvalidScenarioEmptyAllowedCIDRs(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_apikey_")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApiKeyResourceConfigWithEmptyAllowedCIDRs(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value.*Attribute allowed_cidrs set must contain at least 1 elements, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccApiKeyResourceInvalidScenarioEmptyOrganizationID(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_apikey_")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApiKeyResourceConfigWithOrganizationID(resourceName, ""),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value.*Attribute organization_id string length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccApiKeyResourceInvalidScenarioEmptyOrganizationRoles(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_apikey_")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApiKeyResourceConfigWithOrganizationRoles(resourceName, "[]"),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value.*Attribute organization_roles set must contain at least 1 elements, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccApiKeyResourceInvalidScenarioInvalidOrganizationRole(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_apikey_")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApiKeyResourceConfigWithOrganizationRoles(resourceName, `["organizationWizard"]`),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Match.*organizationWizard.*organizationMember.*organizationOwner.*projectCreator`),
+			},
+		},
+	})
+}
+
+func TestAccApiKeyResourceInvalidScenarioInvalidProjectRole(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_apikey_")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApiKeyResourceConfigWithProjectRole(resourceName, "projectWizard"),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Match.*projectWizard.*projectOwner.*projectManager.*projectViewer.*projectDataReaderWriter.*projectDataReader`),
+			},
+		},
+	})
+}
+
+func TestAccApiKeyResourceInvalidScenarioResourceMissingRoles(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_apikey_")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApiKeyResourceConfigWithResourceMissingRoles(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)Incorrect attribute value type.*attribute "roles".*is required`),
+			},
+		},
+	})
+}
+
+func TestAccApiKeyResourceInvalidScenarioResourceIdNotUUID(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_apikey_")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApiKeyResourceConfigWithResourceId(resourceName, "not-a-uuid"),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Match.*not-a-uuid.*resources.id must be a valid UUID`),
+			},
+		},
+	})
+}
+
+func TestAccApiKeyResourceInvalidScenarioResourceIdEmpty(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_apikey_")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApiKeyResourceConfigWithResourceId(resourceName, ""),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value.*Attribute resources.*id.*string length must be at least 1, got: 0`),
 			},
 		},
 	})
@@ -165,6 +304,18 @@ resource "couchbase-capella_apikey" "%[2]s" {
   organization_id    = "%[3]s"
   name               = "%[2]s"
   organization_roles = ["organizationOwner", "organizationMember"]
+}
+`, globalProviderBlock, resourceName, globalOrgId)
+}
+
+func testAccApiKeyResourceConfigWithDefaults(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_apikey" "%[2]s" {
+	organization_id    = "%[3]s"
+	name               = "%[2]s"
+	organization_roles = ["organizationMember"]
 }
 `, globalProviderBlock, resourceName, globalOrgId)
 }
@@ -210,6 +361,112 @@ resource "couchbase-capella_apikey" "%[2]s" {
   rotate = 1
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId)
+}
+
+func testAccApiKeyResourceConfigSecretSetConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_apikey" "%[2]s" {
+	organization_id    = "%[3]s"
+	name               = "%[2]s"
+	organization_roles = ["organizationMember"]
+	secret             = "abc"
+}
+`, globalProviderBlock, resourceName, globalOrgId)
+}
+
+func testAccApiKeyResourceConfigWithEmptyAllowedCIDRs(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_apikey" "%[2]s" {
+	organization_id    = "%[3]s"
+	name               = "%[2]s"
+	organization_roles = ["organizationMember"]
+	allowed_cidrs      = []
+}
+`, globalProviderBlock, resourceName, globalOrgId)
+}
+
+func testAccApiKeyResourceConfigWithOrganizationID(resourceName, organizationID string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_apikey" "%[2]s" {
+	organization_id    = "%[3]s"
+	name               = "%[2]s"
+	organization_roles = ["organizationMember"]
+}
+`, globalProviderBlock, resourceName, organizationID)
+}
+
+func testAccApiKeyResourceConfigWithOrganizationRoles(resourceName, organizationRoles string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_apikey" "%[2]s" {
+	organization_id    = "%[3]s"
+	name               = "%[2]s"
+	organization_roles = %[4]s
+}
+`, globalProviderBlock, resourceName, globalOrgId, organizationRoles)
+}
+
+func testAccApiKeyResourceConfigWithProjectRole(resourceName, projectRole string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_apikey" "%[2]s" {
+	organization_id    = "%[3]s"
+	name               = "%[2]s"
+	organization_roles = ["organizationMember"]
+	resources = [
+		{
+			id    = "%[4]s"
+			roles = ["%[5]s"]
+			type  = "project"
+		}
+	]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, projectRole)
+}
+
+func testAccApiKeyResourceConfigWithResourceMissingRoles(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_apikey" "%[2]s" {
+	organization_id    = "%[3]s"
+	name               = "%[2]s"
+	organization_roles = ["organizationMember"]
+	resources = [
+		{
+			id   = "%[4]s"
+			type = "project"
+		}
+	]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId)
+}
+
+func testAccApiKeyResourceConfigWithResourceId(resourceName, resourceId string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_apikey" "%[2]s" {
+	organization_id    = "%[3]s"
+	name               = "%[2]s"
+	organization_roles = ["organizationMember"]
+	resources = [
+		{
+			id    = "%[4]s"
+			roles = ["projectViewer"]
+			type  = "project"
+		}
+	]
+}
+`, globalProviderBlock, resourceName, globalOrgId, resourceId)
 }
 
 func testAccApiKeyResourceConfigWithOnlyReqFieldRotateConfig(resourceName string) string {

--- a/acceptance_tests/apikey_acceptance_test.go
+++ b/acceptance_tests/apikey_acceptance_test.go
@@ -80,7 +80,7 @@ func TestAccApiKeyResourceWithOnlyReqField(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceReference, "organization_roles.*", "organizationMember"),
 					resource.TestCheckTypeSetElemAttr(resourceReference, "organization_roles.*", "organizationOwner"),
 					resource.TestCheckResourceAttr(resourceReference, "rotate", "1"),
-					resource.TestCheckResourceAttr(resourceReference, "secret", "abc"),
+					resource.TestCheckResourceAttrSet(resourceReference, "secret"),
 					resource.TestCheckResourceAttrSet(resourceReference, "token"),
 				),
 			},
@@ -478,7 +478,6 @@ resource "couchbase-capella_apikey" "%[2]s" {
   name               = "%[2]s"
   organization_roles = ["organizationOwner", "organizationMember"]
   rotate             = 1
-  secret             = "abc"
 }
 `, globalProviderBlock, resourceName, globalOrgId)
 }

--- a/acceptance_tests/apikeys_datasource_test.go
+++ b/acceptance_tests/apikeys_datasource_test.go
@@ -61,6 +61,26 @@ data "couchbase-capella_apikeys" "%[2]s" {
 	})
 }
 
+func TestAccDatasourceApiKeysEmptyOrganization(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_apikeys_ds_empty_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_apikeys" "%[2]s" {
+  organization_id = ""
+}
+`, globalProviderBlock, dsName),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value.*Attribute organization_id string length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
 func testAccApiKeysDataSourceConfig(resourceName, dsName string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/acceptance_tests/user_acceptance_test.go
+++ b/acceptance_tests/user_acceptance_test.go
@@ -2,6 +2,7 @@ package acceptance_tests
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -47,6 +48,114 @@ func TestAccUserResource(t *testing.T) {
 	})
 }
 
+func TestAccUserResourceWithProjectRoles(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_user_")
+	username := resourceName
+	resourceReference := "couchbase-capella_user." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserResourceConfigWithProjectRoles(resourceName, username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "name", username),
+					resource.TestCheckResourceAttr(resourceReference, "email", username+"@couchbase.com"),
+					resource.TestCheckResourceAttr(resourceReference, "organization_roles.0", "organizationMember"),
+					resource.TestCheckResourceAttr(resourceReference, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "resources.0.id", globalProjectId),
+					resource.TestCheckResourceAttr(resourceReference, "resources.0.type", "project"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "resources.0.roles.*", "projectViewer"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "resources.0.roles.*", "projectDataReaderWriter"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccUserResourceInvalidScenarioEmptyOrganizationRoles(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_user_")
+	username := resourceName
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccUserResourceConfigWithOrganizationRoles(resourceName, username, "[]"),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value.*Attribute organization_roles list must contain at least 1 elements, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccUserResourceInvalidScenarioEmptyOrganizationID(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_user_")
+	username := resourceName
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccUserResourceConfigWithOrganizationID(resourceName, username, ""),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value.*Attribute organization_id string length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccUserResourceInvalidScenarioMissingEmail(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_user_")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccUserResourceConfigMissingEmail(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)Missing required argument.*email`),
+			},
+		},
+	})
+}
+
+func TestAccUserResourceInvalidScenarioInvalidOrganizationRole(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_user_")
+	username := resourceName
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccUserResourceConfigWithOrganizationRoles(resourceName, username, `["organizationWizard"]`),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Match.*organizationWizard.*organizationMember.*organizationOwner.*projectCreator`),
+			},
+		},
+	})
+}
+
+func TestAccUserResourceInvalidScenarioInvalidProjectRole(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_user_")
+	username := resourceName
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccUserResourceConfigWithProjectRole(resourceName, username, "projectWizard"),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Match.*projectWizard.*projectOwner.*projectManager.*projectViewer.*projectDataReaderWriter.*projectDataReader`),
+			},
+		},
+	})
+}
+
+func TestAccUserResourceInvalidScenarioResourceIdEmpty(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_user_")
+	username := resourceName
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccUserResourceConfigWithResourceId(resourceName, username, ""),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Length.*Attribute\s+resources.*\.id\s+string length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
 func testAccUserResourceConfig(resourceName, username string) string {
 	return fmt.Sprintf(`
 	%[1]s
@@ -88,6 +197,108 @@ func testAccUserResourceConfigUpdate(resourceName, username string) string {
 		]
 	  }
 	`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, username, username+"@couchbase.com")
+}
+
+func testAccUserResourceConfigWithProjectRoles(resourceName, username string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_user" "%[2]s" {
+	organization_id = "%[3]s"
+	name            = "%[4]s"
+	email           = "%[5]s"
+
+	organization_roles = ["organizationMember"]
+	resources = [
+		{
+			type  = "project"
+			id    = "%[6]s"
+			roles = ["projectViewer", "projectDataReaderWriter"]
+		}
+	]
+}
+`, globalProviderBlock, resourceName, globalOrgId, username, username+"@couchbase.com", globalProjectId)
+}
+
+func testAccUserResourceConfigWithOrganizationRoles(resourceName, username, organizationRoles string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_user" "%[2]s" {
+	organization_id = "%[3]s"
+	name            = "%[4]s"
+	email           = "%[5]s"
+
+	organization_roles = %[6]s
+}
+`, globalProviderBlock, resourceName, globalOrgId, username, username+"@couchbase.com", organizationRoles)
+}
+
+func testAccUserResourceConfigWithOrganizationID(resourceName, username, organizationID string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_user" "%[2]s" {
+	organization_id = "%[3]s"
+	name            = "%[4]s"
+	email           = "%[5]s"
+
+	organization_roles = ["organizationMember"]
+}
+`, globalProviderBlock, resourceName, organizationID, username, username+"@couchbase.com")
+}
+
+func testAccUserResourceConfigMissingEmail(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_user" "%[2]s" {
+	organization_id    = "%[3]s"
+	organization_roles = ["organizationMember"]
+}
+`, globalProviderBlock, resourceName, globalOrgId)
+}
+
+func testAccUserResourceConfigWithProjectRole(resourceName, username, projectRole string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_user" "%[2]s" {
+	organization_id = "%[3]s"
+	name            = "%[4]s"
+	email           = "%[5]s"
+
+	organization_roles = ["organizationMember"]
+	resources = [
+		{
+			type  = "project"
+			id    = "%[6]s"
+			roles = ["%[7]s"]
+		}
+	]
+}
+`, globalProviderBlock, resourceName, globalOrgId, username, username+"@couchbase.com", globalProjectId, projectRole)
+}
+
+func testAccUserResourceConfigWithResourceId(resourceName, username, resourceId string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_user" "%[2]s" {
+	organization_id = "%[3]s"
+	name            = "%[4]s"
+	email           = "%[5]s"
+
+	organization_roles = ["organizationMember"]
+	resources = [
+		{
+			type  = "project"
+			id    = "%[6]s"
+			roles = ["projectViewer"]
+		}
+	]
+}
+`, globalProviderBlock, resourceName, globalOrgId, username, username+"@couchbase.com", resourceId)
 }
 
 func generateUserImportIdForResource(resourceReference string) resource.ImportStateIdFunc {

--- a/acceptance_tests/users_datasource_test.go
+++ b/acceptance_tests/users_datasource_test.go
@@ -99,6 +99,47 @@ data "couchbase-capella_users" "%[2]s" {
 	})
 }
 
+func TestAccDatasourceUsersEmptyOrganization(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_users_ds_empty_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_users" "%[2]s" {
+  organization_id = ""
+}
+`, globalProviderBlock, dsName),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value.*Attribute organization_id string length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceUsersInvalidSortDirection(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_users_ds_sort_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_users" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+  sort_direction  = "sideways"
+}
+`, globalProviderBlock, dsName),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Match.*sideways.*asc.*desc`),
+			},
+		},
+	})
+}
+
 // perPage <= 0 omits per_page from the datasource (walk all pages).
 func testAccUsersDataSourceConfig(resourceName, dsName, username, email string, perPage int) string {
 	perPageLine := ""

--- a/internal/datasources/apikeys_schema.go
+++ b/internal/datasources/apikeys_schema.go
@@ -13,7 +13,7 @@ var apiKeysBuilder = capellaschema.NewSchemaBuilder("apiKeys")
 func ApiKeysSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
 
-	capellaschema.AddAttr(attrs, "organization_id", apiKeysBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "organization_id", apiKeysBuilder, requiredStringWithValidator())
 
 	// Build data attributes
 	dataAttrs := make(map[string]schema.Attribute)

--- a/internal/datasources/users_schema.go
+++ b/internal/datasources/users_schema.go
@@ -1,7 +1,9 @@
 package datasources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
@@ -13,12 +15,17 @@ var usersBuilder = capellaschema.NewSchemaBuilder("users")
 func UsersSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
 
-	capellaschema.AddAttr(attrs, "organization_id", usersBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "organization_id", usersBuilder, requiredStringWithValidator())
 
 	capellaschema.AddAttr(attrs, "page", usersBuilder, optionalInt64())
 	capellaschema.AddAttr(attrs, "per_page", usersBuilder, optionalInt64())
 	capellaschema.AddAttr(attrs, "sort_by", usersBuilder, optionalString())
-	capellaschema.AddAttr(attrs, "sort_direction", usersBuilder, optionalString())
+	capellaschema.AddAttr(attrs, "sort_direction", usersBuilder, &schema.StringAttribute{
+		Optional: true,
+		Validators: []validator.String{
+			stringvalidator.OneOf("asc", "desc"),
+		},
+	})
 
 	// Build data attributes
 	dataAttrs := make(map[string]schema.Attribute)

--- a/internal/resources/apikey.go
+++ b/internal/resources/apikey.go
@@ -21,9 +21,11 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &ApiKey{}
-	_ resource.ResourceWithConfigure   = &ApiKey{}
-	_ resource.ResourceWithImportState = &ApiKey{}
+	_ resource.Resource                   = &ApiKey{}
+	_ resource.ResourceWithConfigure      = &ApiKey{}
+	_ resource.ResourceWithImportState    = &ApiKey{}
+	_ resource.ResourceWithModifyPlan     = &ApiKey{}
+	_ resource.ResourceWithValidateConfig = &ApiKey{}
 )
 
 const errorMessageAfterApiKeyCreation = "Api Key creation is successful, but encountered an error while checking the current" +
@@ -51,6 +53,54 @@ func (r *ApiKey) Metadata(_ context.Context, req resource.MetadataRequest, resp 
 // Schema defines the schema for the apiKey resource.
 func (r *ApiKey) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = ApiKeySchema()
+}
+
+// ValidateConfig validates API key configuration before plan/apply reaches Create.
+func (a *ApiKey) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config providerschema.ApiKey
+	diags := req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !config.Secret.IsNull() && !config.Secret.IsUnknown() && config.Rotate.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("secret"),
+			"Invalid API Key Configuration",
+			"secret can only be configured together with rotate when rotating an existing API key.",
+		)
+	}
+
+	if !config.Rotate.IsNull() && !config.Rotate.IsUnknown() && config.Secret.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("rotate"),
+			"Invalid API Key Configuration",
+			"rotate value should not be set during create. Configure rotate together with secret when rotating an existing API key.",
+		)
+	}
+}
+
+// ModifyPlan rejects create-time rotation while still allowing rotation updates with existing state.
+func (a *ApiKey) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || !req.State.Raw.IsNull() {
+		return
+	}
+
+	var plan providerschema.ApiKey
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Rotate.IsNull() && !plan.Rotate.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("rotate"),
+			"Invalid API Key Configuration",
+			"rotate value should not be set during create.",
+		)
+	}
 }
 
 // Configure adds the provider configured client to the apiKey resource.
@@ -283,7 +333,7 @@ func (a *ApiKey) Update(ctx context.Context, req resource.UpdateRequest, resp *r
 	}
 
 	var rotateApiRequest api.RotateApiKeyRequest
-	if !plan.Secret.IsNull() || !plan.Secret.IsUnknown() {
+	if !plan.Secret.IsNull() && !plan.Secret.IsUnknown() {
 		rotateApiRequest = api.RotateApiKeyRequest{
 			Secret: plan.Secret.ValueStringPointer(),
 		}

--- a/internal/resources/apikey.go
+++ b/internal/resources/apikey.go
@@ -76,6 +76,7 @@ func (a *ApiKey) ValidateConfig(ctx context.Context, req resource.ValidateConfig
 
 // ModifyPlan rejects create-time rotation while still allowing rotation updates with existing state.
 func (a *ApiKey) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Only validate create plans; updates have prior state and may use rotate to request a new key.
 	if req.Plan.Raw.IsNull() || !req.State.Raw.IsNull() {
 		return
 	}
@@ -554,7 +555,7 @@ func (a *ApiKey) convertAllowedCidrs(ctx context.Context, allowedCidrs types.Set
 func (a *ApiKey) retainResourcesIfOrgOwner(apiKeyReq, apiKeyRes *providerschema.ApiKey) *providerschema.ApiKey {
 	isOrgOwner := false
 	for _, role := range apiKeyRes.OrganizationRoles {
-		if role.ValueString() == "organizationOwner" {
+		if role.ValueString() == organizationRoleOwner {
 			isOrgOwner = true
 		}
 	}

--- a/internal/resources/apikey.go
+++ b/internal/resources/apikey.go
@@ -72,13 +72,6 @@ func (a *ApiKey) ValidateConfig(ctx context.Context, req resource.ValidateConfig
 		)
 	}
 
-	if !config.Rotate.IsNull() && !config.Rotate.IsUnknown() && config.Secret.IsNull() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("rotate"),
-			"Invalid API Key Configuration",
-			"rotate value should not be set during create. Configure rotate together with secret when rotating an existing API key.",
-		)
-	}
 }
 
 // ModifyPlan rejects create-time rotation while still allowing rotation updates with existing state.

--- a/internal/resources/apikey_schema.go
+++ b/internal/resources/apikey_schema.go
@@ -1,12 +1,16 @@
 package resources
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -14,6 +18,8 @@ import (
 )
 
 var apiKeyBuilder = capellaschema.NewSchemaBuilder("apiKey", "APIKey")
+
+var apiKeyResourceIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
 func ApiKeySchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
@@ -44,12 +50,48 @@ func ApiKeySchema() schema.Schema {
 		},
 		Default: setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{types.StringValue("0.0.0.0/0")})),
 	})
-	capellaschema.AddAttr(attrs, "organization_roles", apiKeyBuilder, stringSetAttribute(required, requiresReplace))
+	capellaschema.AddAttr(attrs, "organization_roles", apiKeyBuilder, &schema.SetAttribute{
+		Required:    true,
+		ElementType: types.StringType,
+		PlanModifiers: []planmodifier.Set{
+			setplanmodifier.RequiresReplace(),
+		},
+		Validators: []validator.Set{
+			setvalidator.SizeAtLeast(1),
+			setvalidator.ValueStringsAre(stringvalidator.OneOf(
+				"organizationMember",
+				"organizationOwner",
+				"projectCreator",
+			)),
+		},
+	})
 
 	resourceAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(resourceAttrs, "id", apiKeyBuilder, stringAttribute([]string{required}), "Resource")
-	capellaschema.AddAttr(resourceAttrs, "roles", apiKeyBuilder, stringSetAttribute(required), "Resource")
-	capellaschema.AddAttr(resourceAttrs, "type", apiKeyBuilder, stringDefaultAttribute("project", optional, computed), "Resource")
+	capellaschema.AddAttr(resourceAttrs, "id", apiKeyBuilder, stringAttribute(
+		[]string{required},
+		validator.String(stringvalidator.LengthAtLeast(1)),
+		validator.String(stringvalidator.RegexMatches(apiKeyResourceIDPattern, "resources.id must be a valid UUID")),
+	), "Resource")
+	capellaschema.AddAttr(resourceAttrs, "roles", apiKeyBuilder, &schema.SetAttribute{
+		Required:    true,
+		ElementType: types.StringType,
+		Validators: []validator.Set{
+			setvalidator.SizeAtLeast(1),
+			setvalidator.ValueStringsAre(stringvalidator.OneOf(
+				"projectOwner",
+				"projectManager",
+				"projectViewer",
+				"projectDataReaderWriter",
+				"projectDataReader",
+			)),
+		},
+	}, "Resource")
+	capellaschema.AddAttr(resourceAttrs, "type", apiKeyBuilder, &schema.StringAttribute{
+		Optional:   true,
+		Computed:   true,
+		Default:    stringdefault.StaticString("project"),
+		Validators: []validator.String{stringvalidator.OneOf("project")},
+	}, "Resource")
 
 	capellaschema.AddAttr(attrs, "resources", apiKeyBuilder, &schema.SetNestedAttribute{
 		Optional: true,

--- a/internal/resources/apikey_schema.go
+++ b/internal/resources/apikey_schema.go
@@ -58,11 +58,7 @@ func ApiKeySchema() schema.Schema {
 		},
 		Validators: []validator.Set{
 			setvalidator.SizeAtLeast(1),
-			setvalidator.ValueStringsAre(stringvalidator.OneOf(
-				"organizationMember",
-				"organizationOwner",
-				"projectCreator",
-			)),
+			setvalidator.ValueStringsAre(stringvalidator.OneOf(validOrganizationRoles...)),
 		},
 	})
 
@@ -77,20 +73,14 @@ func ApiKeySchema() schema.Schema {
 		ElementType: types.StringType,
 		Validators: []validator.Set{
 			setvalidator.SizeAtLeast(1),
-			setvalidator.ValueStringsAre(stringvalidator.OneOf(
-				"projectOwner",
-				"projectManager",
-				"projectViewer",
-				"projectDataReaderWriter",
-				"projectDataReader",
-			)),
+			setvalidator.ValueStringsAre(stringvalidator.OneOf(validProjectRoles...)),
 		},
 	}, "Resource")
 	capellaschema.AddAttr(resourceAttrs, "type", apiKeyBuilder, &schema.StringAttribute{
 		Optional:   true,
 		Computed:   true,
-		Default:    stringdefault.StaticString("project"),
-		Validators: []validator.String{stringvalidator.OneOf("project")},
+		Default:    stringdefault.StaticString(resourceTypeProject),
+		Validators: []validator.String{stringvalidator.OneOf(resourceTypeProject)},
 	}, "Resource")
 
 	capellaschema.AddAttr(attrs, "resources", apiKeyBuilder, &schema.SetNestedAttribute{

--- a/internal/resources/roles.go
+++ b/internal/resources/roles.go
@@ -1,0 +1,29 @@
+package resources
+
+const (
+	resourceTypeProject = "project"
+
+	organizationRoleMember  = "organizationMember"
+	organizationRoleOwner   = "organizationOwner"
+	organizationRoleCreator = "projectCreator"
+
+	projectRoleOwner            = "projectOwner"
+	projectRoleManager          = "projectManager"
+	projectRoleViewer           = "projectViewer"
+	projectRoleDataReaderWriter = "projectDataReaderWriter"
+	projectRoleDataReader       = "projectDataReader"
+)
+
+var validOrganizationRoles = []string{
+	organizationRoleMember,
+	organizationRoleOwner,
+	organizationRoleCreator,
+}
+
+var validProjectRoles = []string{
+	projectRoleOwner,
+	projectRoleManager,
+	projectRoleViewer,
+	projectRoleDataReaderWriter,
+	projectRoleDataReader,
+}

--- a/internal/resources/user.go
+++ b/internal/resources/user.go
@@ -470,7 +470,7 @@ func compareResources(existingResources, proposedResources []providerschema.Reso
 // a user includes the role 'organizationOwner'.
 func checkOrganizationOwner(roles []basetypes.StringValue, resources []providerschema.Resource) bool {
 	if resources != nil && slices.Contains(
-		roles, basetypes.NewStringValue("organizationOwner")) {
+		roles, basetypes.NewStringValue(organizationRoleOwner)) {
 		return true
 	}
 	return false

--- a/internal/resources/user_schema.go
+++ b/internal/resources/user_schema.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -27,11 +28,7 @@ func UserSchema() schema.Schema {
 		ElementType: types.StringType,
 		Validators: []validator.List{
 			listvalidator.SizeAtLeast(1),
-			listvalidator.ValueStringsAre(stringvalidator.OneOf(
-				"organizationMember",
-				"organizationOwner",
-				"projectCreator",
-			)),
+			listvalidator.ValueStringsAre(stringvalidator.OneOf(validOrganizationRoles...)),
 		},
 	})
 	capellaschema.AddAttr(attrs, "last_login", userBuilder, stringAttribute([]string{computed}))
@@ -42,7 +39,12 @@ func UserSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "audit", userBuilder, computedAuditAttribute())
 
 	resourceAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(resourceAttrs, "type", userBuilder, stringDefaultAttribute("project", optional, computed), "Resource")
+	capellaschema.AddAttr(resourceAttrs, "type", userBuilder, &schema.StringAttribute{
+		Optional:   true,
+		Computed:   true,
+		Default:    stringdefault.StaticString(resourceTypeProject),
+		Validators: []validator.String{stringvalidator.OneOf(resourceTypeProject)},
+	}, "Resource")
 	capellaschema.AddAttr(resourceAttrs, "id", userBuilder, stringAttribute(
 		[]string{required},
 		validator.String(stringvalidator.LengthAtLeast(1)),
@@ -53,13 +55,7 @@ func UserSchema() schema.Schema {
 		ElementType: types.StringType,
 		Validators: []validator.Set{
 			setvalidator.SizeAtLeast(1),
-			setvalidator.ValueStringsAre(stringvalidator.OneOf(
-				"projectOwner",
-				"projectManager",
-				"projectViewer",
-				"projectDataReaderWriter",
-				"projectDataReader",
-			)),
+			setvalidator.ValueStringsAre(stringvalidator.OneOf(validProjectRoles...)),
 		},
 	}, "Resource")
 

--- a/internal/resources/user_schema.go
+++ b/internal/resources/user_schema.go
@@ -1,7 +1,12 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
@@ -17,7 +22,18 @@ func UserSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "inactive", userBuilder, boolAttribute(computed))
 	capellaschema.AddAttr(attrs, "email", userBuilder, stringAttribute([]string{required, requiresReplace}))
 	capellaschema.AddAttr(attrs, "organization_id", userBuilder, requiredUUIDStringAttribute())
-	capellaschema.AddAttr(attrs, "organization_roles", userBuilder, stringListAttribute(required))
+	capellaschema.AddAttr(attrs, "organization_roles", userBuilder, &schema.ListAttribute{
+		Required:    true,
+		ElementType: types.StringType,
+		Validators: []validator.List{
+			listvalidator.SizeAtLeast(1),
+			listvalidator.ValueStringsAre(stringvalidator.OneOf(
+				"organizationMember",
+				"organizationOwner",
+				"projectCreator",
+			)),
+		},
+	})
 	capellaschema.AddAttr(attrs, "last_login", userBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "region", userBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "time_zone", userBuilder, stringAttribute([]string{computed}))
@@ -27,8 +43,25 @@ func UserSchema() schema.Schema {
 
 	resourceAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(resourceAttrs, "type", userBuilder, stringDefaultAttribute("project", optional, computed), "Resource")
-	capellaschema.AddAttr(resourceAttrs, "id", userBuilder, stringAttribute([]string{required}), "Resource")
-	capellaschema.AddAttr(resourceAttrs, "roles", userBuilder, stringSetAttribute(required), "Resource")
+	capellaschema.AddAttr(resourceAttrs, "id", userBuilder, stringAttribute(
+		[]string{required},
+		validator.String(stringvalidator.LengthAtLeast(1)),
+		validator.String(stringvalidator.RegexMatches(apiKeyResourceIDPattern, "resources.id must be a valid UUID")),
+	), "Resource")
+	capellaschema.AddAttr(resourceAttrs, "roles", userBuilder, &schema.SetAttribute{
+		Required:    true,
+		ElementType: types.StringType,
+		Validators: []validator.Set{
+			setvalidator.SizeAtLeast(1),
+			setvalidator.ValueStringsAre(stringvalidator.OneOf(
+				"projectOwner",
+				"projectManager",
+				"projectViewer",
+				"projectDataReaderWriter",
+				"projectDataReader",
+			)),
+		},
+	}, "Resource")
 
 	capellaschema.AddAttr(attrs, "resources", userBuilder, &schema.SetNestedAttribute{
 		Optional: true,


### PR DESCRIPTION
plus acceptance coverage for valid project role usage and invalid input scenarios.


<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-132258](https://jira.issues.couchbase.com/browse/AV-132258)
* [AV-132225](https://jira.issues.couchbase.com/browse/AV-132225)
* [AV-132224](https://jira.issues.couchbase.com/browse/AV-132224)
* [AV-132223](https://jira.issues.couchbase.com/browse/AV-132223)
* [AV-132222](https://jira.issues.couchbase.com/browse/AV-132222)
* [AV-132220](https://jira.issues.couchbase.com/browse/AV-132220)
* [AV-132219](https://jira.issues.couchbase.com/browse/AV-132219)
* [AV-132217](https://jira.issues.couchbase.com/browse/AV-132217)
* [AV-132216](https://jira.issues.couchbase.com/browse/AV-132216)
* [AV-132215](https://jira.issues.couchbase.com/browse/AV-132215)
* [AV-132214](https://jira.issues.couchbase.com/browse/AV-132214)
* [AV-132212](https://jira.issues.couchbase.com/browse/AV-132212)
* [AV-132210](https://jira.issues.couchbase.com/browse/AV-132210)

## Description

This PR hardens API key and user schemas by validating organization roles, project resource roles, resource IDs, empty role collections, and datasource inputs before requests reach the Capella API. It also adds API key config validation for rotate and secret, preventing create-time rotation and requiring those fields to be used together only during rotation updates.

The API key acceptance checks were also adjusted to use order-insensitive assertions for Terraform sets, avoiding flaky test behavior for allowed_cidrs, organization_roles, and nested resource roles.

Tests Added
Total new tests added: 20

Breakdown:

[apikey_acceptance_test.go]: 10
[apikeys_datasource_test.go] 1
[user_acceptance_test.go]: 7
[users_datasource_test.go]: 2

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments

[AV-132258]: https://couchbasecloud.atlassian.net/browse/AV-132258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132225]: https://couchbasecloud.atlassian.net/browse/AV-132225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132224]: https://couchbasecloud.atlassian.net/browse/AV-132224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132223]: https://couchbasecloud.atlassian.net/browse/AV-132223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132222]: https://couchbasecloud.atlassian.net/browse/AV-132222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132220]: https://couchbasecloud.atlassian.net/browse/AV-132220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132219]: https://couchbasecloud.atlassian.net/browse/AV-132219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132217]: https://couchbasecloud.atlassian.net/browse/AV-132217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132216]: https://couchbasecloud.atlassian.net/browse/AV-132216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132215]: https://couchbasecloud.atlassian.net/browse/AV-132215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132214]: https://couchbasecloud.atlassian.net/browse/AV-132214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ