### PR TITLE
[AV-132439] Add deletion protection acceptance coverage

### DIFF
--- a/acceptance_tests/cluster_deletion_protection_acceptance_test.go
+++ b/acceptance_tests/cluster_deletion_protection_acceptance_test.go
@@ -91,6 +91,7 @@ func TestAccClusterDeletionProtectionProtectedDestroyFails(t *testing.T) {
 			{
 				Config: testAccClusterDeletionProtectionProtectedClusterConfig(clusterResourceName, deletionProtectionResourceName, cidr, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					registerDeletionProtectionCleanupForClusterResource(t, clusterReference),
 					testAccExistsClusterResource(t, clusterReference),
 					resource.TestCheckResourceAttr(clusterReference, "name", clusterResourceName),
 					resource.TestCheckResourceAttrSet(clusterReference, "id"),
@@ -136,6 +137,7 @@ func TestAccClusterDeletionProtectionProtectedBucketDeleteFails(t *testing.T) {
 			{
 				Config: testAccClusterDeletionProtectionProtectedBucketConfig(clusterResourceName, bucketResourceName, deletionProtectionResourceName, cidr, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					registerDeletionProtectionCleanupForClusterResource(t, clusterReference),
 					testAccExistsClusterResource(t, clusterReference),
 					resource.TestCheckResourceAttr(clusterReference, "name", clusterResourceName),
 					resource.TestCheckResourceAttr(bucketReference, "name", bucketResourceName),
@@ -183,6 +185,7 @@ func TestAccClusterDeletionProtectionProtectedBucketFlushFails(t *testing.T) {
 			{
 				Config: testAccClusterDeletionProtectionProtectedBucketFlushConfig(clusterResourceName, bucketResourceName, flushResourceName, deletionProtectionResourceName, cidr, true, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					registerDeletionProtectionCleanupForClusterResource(t, clusterReference),
 					testAccExistsClusterResource(t, clusterReference),
 					resource.TestCheckResourceAttr(clusterReference, "name", clusterResourceName),
 					resource.TestCheckResourceAttr(bucketReference, "name", bucketResourceName),
@@ -443,25 +446,61 @@ func generateDeletionProtectionImportId(resourceReference string) resource.Impor
 	}
 }
 
+func registerDeletionProtectionCleanupForClusterResource(t *testing.T, clusterReference string) resource.TestCheckFunc {
+	t.Helper()
+	registered := false
+
+	return func(state *terraform.State) error {
+		if registered {
+			return nil
+		}
+
+		clusterResource, ok := state.RootModule().Resources[clusterReference]
+		if !ok || clusterResource.Primary == nil {
+			return fmt.Errorf("resource %s not found in state", clusterReference)
+		}
+
+		clusterID := clusterResource.Primary.ID
+		if clusterID == "" {
+			clusterID = clusterResource.Primary.Attributes["id"]
+		}
+		if clusterID == "" {
+			return fmt.Errorf("resource %s has no cluster id in state", clusterReference)
+		}
+
+		registered = true
+		t.Cleanup(func() {
+			disableDeletionProtection(t, clusterID)
+		})
+
+		return nil
+	}
+}
+
 // disableDeletionProtectionOnCleanup registers a t.Cleanup hook that
 // unconditionally disables deletion protection on globalClusterId so that
 // TestMain teardown can delete the cluster even if the test fails mid-run.
 func disableDeletionProtectionOnCleanup(t *testing.T) {
 	t.Helper()
 	t.Cleanup(func() {
-		ctx := context.Background()
-		url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/deletionProtection",
-			globalHost, globalOrgId, globalProjectId, globalClusterId)
-		cfg := api.EndpointCfg{Url: url, Method: http.MethodPut, SuccessStatus: http.StatusNoContent}
-		_, err := globalClient.ExecuteWithRetry(
-			ctx,
-			cfg,
-			clusterapi.UpdateDeletionProtectionRequest{DeletionProtection: false},
-			globalToken,
-			nil,
-		)
-		if err != nil {
-			t.Logf("WARNING: failed to disable deletion protection on cleanup: %v", err)
-		}
+		disableDeletionProtection(t, globalClusterId)
 	})
+}
+
+func disableDeletionProtection(t *testing.T, clusterID string) {
+	t.Helper()
+	ctx := context.Background()
+	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/deletionProtection",
+		globalHost, globalOrgId, globalProjectId, clusterID)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodPut, SuccessStatus: http.StatusNoContent}
+	_, err := globalClient.ExecuteWithRetry(
+		ctx,
+		cfg,
+		clusterapi.UpdateDeletionProtectionRequest{DeletionProtection: false},
+		globalToken,
+		nil,
+	)
+	if err != nil {
+		t.Logf("WARNING: failed to disable deletion protection on cleanup for cluster %s: %v", clusterID, err)
+	}
 }

--- a/acceptance_tests/cluster_deletion_protection_acceptance_test.go
+++ b/acceptance_tests/cluster_deletion_protection_acceptance_test.go
@@ -78,6 +78,143 @@ func TestAccClusterDeletionProtectionInvalidCluster(t *testing.T) {
 	})
 }
 
+func TestAccClusterDeletionProtectionProtectedDestroyFails(t *testing.T) {
+	clusterResourceName := randomStringWithPrefix("tf_acc_cluster_del_prot_")
+	deletionProtectionResourceName := randomStringWithPrefix("tf_acc_del_prot_destroy_")
+	clusterReference := "couchbase-capella_cluster." + clusterResourceName
+	deletionProtectionReference := "couchbase-capella_cluster_deletion_protection." + deletionProtectionResourceName
+	cidr := generateRandomCIDR()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDeletionProtectionProtectedClusterConfig(clusterResourceName, deletionProtectionResourceName, cidr, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(t, clusterReference),
+					resource.TestCheckResourceAttr(clusterReference, "name", clusterResourceName),
+					resource.TestCheckResourceAttrSet(clusterReference, "id"),
+					resource.TestCheckResourceAttr(deletionProtectionReference, "deletion_protection", "true"),
+				),
+			},
+			{
+				Config:      testAccClusterDeletionProtectionProtectedClusterConfig(clusterResourceName, deletionProtectionResourceName, cidr, true),
+				Destroy:     true,
+				ExpectError: regexp.MustCompile("Cluster deletion protection is enabled"),
+			},
+			{
+				Config: testAccClusterDeletionProtectionProtectedClusterConfig(clusterResourceName, deletionProtectionResourceName, cidr, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(t, clusterReference),
+					resource.TestCheckResourceAttr(deletionProtectionReference, "deletion_protection", "false"),
+				),
+			},
+			{
+				Config: testAccClusterDeletionProtectionProtectedClusterConfig(clusterResourceName, deletionProtectionResourceName, cidr, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(t, clusterReference),
+					resource.TestCheckResourceAttr(clusterReference, "deletion_protection", "false"),
+					resource.TestCheckResourceAttr(deletionProtectionReference, "deletion_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterDeletionProtectionProtectedBucketDeleteFails(t *testing.T) {
+	clusterResourceName := randomStringWithPrefix("tf_acc_cluster_del_prot_bucket_")
+	bucketResourceName := randomStringWithPrefix("tf_acc_bucket_del_prot_")
+	deletionProtectionResourceName := randomStringWithPrefix("tf_acc_del_prot_bucket_")
+	clusterReference := "couchbase-capella_cluster." + clusterResourceName
+	bucketReference := "couchbase-capella_bucket." + bucketResourceName
+	deletionProtectionReference := "couchbase-capella_cluster_deletion_protection." + deletionProtectionResourceName
+	cidr := generateRandomCIDR()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDeletionProtectionProtectedBucketConfig(clusterResourceName, bucketResourceName, deletionProtectionResourceName, cidr, true, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(t, clusterReference),
+					resource.TestCheckResourceAttr(clusterReference, "name", clusterResourceName),
+					resource.TestCheckResourceAttr(bucketReference, "name", bucketResourceName),
+					resource.TestCheckResourceAttrSet(bucketReference, "id"),
+					resource.TestCheckResourceAttr(deletionProtectionReference, "deletion_protection", "true"),
+				),
+			},
+			{
+				Config:      testAccClusterDeletionProtectionProtectedBucketConfig(clusterResourceName, bucketResourceName, deletionProtectionResourceName, cidr, true, false),
+				ExpectError: regexp.MustCompile(`(?s)Unable to delete bucket.*disable cluster\s+deletion protection`),
+			},
+			{
+				Config: testAccClusterDeletionProtectionProtectedBucketConfig(clusterResourceName, bucketResourceName, deletionProtectionResourceName, cidr, false, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(t, clusterReference),
+					resource.TestCheckResourceAttr(bucketReference, "name", bucketResourceName),
+					resource.TestCheckResourceAttr(deletionProtectionReference, "deletion_protection", "false"),
+				),
+			},
+			{
+				Config: testAccClusterDeletionProtectionProtectedBucketConfig(clusterResourceName, bucketResourceName, deletionProtectionResourceName, cidr, false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(t, clusterReference),
+					resource.TestCheckResourceAttr(clusterReference, "deletion_protection", "false"),
+					resource.TestCheckResourceAttr(deletionProtectionReference, "deletion_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterDeletionProtectionProtectedBucketFlushFails(t *testing.T) {
+	clusterResourceName := randomStringWithPrefix("tf_acc_cluster_del_prot_flush_")
+	bucketResourceName := randomStringWithPrefix("tf_acc_bucket_flush_prot_")
+	flushResourceName := randomStringWithPrefix("tf_acc_flush_del_prot_")
+	deletionProtectionResourceName := randomStringWithPrefix("tf_acc_del_prot_flush_")
+	clusterReference := "couchbase-capella_cluster." + clusterResourceName
+	bucketReference := "couchbase-capella_bucket." + bucketResourceName
+	deletionProtectionReference := "couchbase-capella_cluster_deletion_protection." + deletionProtectionResourceName
+	cidr := generateRandomCIDR()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDeletionProtectionProtectedBucketFlushConfig(clusterResourceName, bucketResourceName, flushResourceName, deletionProtectionResourceName, cidr, true, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(t, clusterReference),
+					resource.TestCheckResourceAttr(clusterReference, "name", clusterResourceName),
+					resource.TestCheckResourceAttr(bucketReference, "name", bucketResourceName),
+					resource.TestCheckResourceAttr(bucketReference, "flush", "true"),
+					resource.TestCheckResourceAttrSet(bucketReference, "id"),
+					resource.TestCheckResourceAttr(deletionProtectionReference, "deletion_protection", "true"),
+				),
+			},
+			{
+				Config:      testAccClusterDeletionProtectionProtectedBucketFlushConfig(clusterResourceName, bucketResourceName, flushResourceName, deletionProtectionResourceName, cidr, true, true),
+				ExpectError: regexp.MustCompile(`(?is)Error flushing the bucket.*deletion.*protection`),
+			},
+			{
+				Config: testAccClusterDeletionProtectionProtectedBucketFlushConfig(clusterResourceName, bucketResourceName, flushResourceName, deletionProtectionResourceName, cidr, false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(t, clusterReference),
+					resource.TestCheckResourceAttr(bucketReference, "name", bucketResourceName),
+					resource.TestCheckResourceAttr(deletionProtectionReference, "deletion_protection", "false"),
+				),
+			},
+			{
+				Config: testAccClusterDeletionProtectionProtectedBucketFlushConfig(clusterResourceName, bucketResourceName, flushResourceName, deletionProtectionResourceName, cidr, false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsClusterResource(t, clusterReference),
+					resource.TestCheckResourceAttr(clusterReference, "deletion_protection", "false"),
+					resource.TestCheckResourceAttr(deletionProtectionReference, "deletion_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
 // --- Config builders ---
 
 func testAccClusterDeletionProtectionConfig(resourceName, clusterID string, enabled bool) string {
@@ -91,6 +228,197 @@ resource "couchbase-capella_cluster_deletion_protection" "%[2]s" {
   deletion_protection = %[6]t
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, clusterID, enabled)
+}
+
+func testAccClusterDeletionProtectionProtectedClusterConfig(clusterResourceName, deletionProtectionResourceName, cidr string, enabled bool) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster" "%[4]s" {
+	organization_id = "%[2]s"
+	project_id      = "%[3]s"
+	name            = "%[4]s"
+	cloud_provider = {
+		type   = "aws"
+		region = "us-east-1"
+		cidr   = "%[6]s"
+	}
+	service_groups = [
+		{
+			node = {
+				compute = {
+					cpu = 4
+					ram = 16
+				}
+				disk = {
+					storage = 50
+					type    = "gp3"
+					iops    = 3000
+				}
+			}
+			num_of_nodes = 3
+			services     = ["data", "index", "query"]
+		}
+	]
+	availability = {
+		"type" : "multi"
+	}
+	support = {
+		plan     = "developer pro"
+		timezone = "PT"
+	}
+}
+
+resource "couchbase-capella_cluster_deletion_protection" "%[5]s" {
+	organization_id     = "%[2]s"
+	project_id          = "%[3]s"
+	cluster_id          = couchbase-capella_cluster.%[4]s.id
+	deletion_protection = %[7]t
+
+	depends_on = [couchbase-capella_cluster.%[4]s]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, clusterResourceName, deletionProtectionResourceName, cidr, enabled)
+}
+
+func testAccClusterDeletionProtectionProtectedBucketConfig(clusterResourceName, bucketResourceName, deletionProtectionResourceName, cidr string, enabled, includeBucket bool) string {
+	bucketConfig := ""
+	if includeBucket {
+		bucketConfig = fmt.Sprintf(`
+resource "couchbase-capella_bucket" %[1]q {
+	organization_id = %[2]q
+	project_id      = %[3]q
+	cluster_id      = couchbase-capella_cluster.%[4]s.id
+	name            = %[1]q
+
+	depends_on = [couchbase-capella_cluster.%[4]s]
+}
+`, bucketResourceName, globalOrgId, globalProjectId, clusterResourceName)
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster" "%[4]s" {
+	organization_id = "%[2]s"
+	project_id      = "%[3]s"
+	name            = "%[4]s"
+	cloud_provider = {
+		type   = "aws"
+		region = "us-east-1"
+		cidr   = "%[7]s"
+	}
+	service_groups = [
+		{
+			node = {
+				compute = {
+					cpu = 4
+					ram = 16
+				}
+				disk = {
+					storage = 50
+					type    = "gp3"
+					iops    = 3000
+				}
+			}
+			num_of_nodes = 3
+			services     = ["data", "index", "query"]
+		}
+	]
+	availability = {
+		"type" : "multi"
+	}
+	support = {
+		plan     = "developer pro"
+		timezone = "PT"
+	}
+}
+
+%[8]s
+resource "couchbase-capella_cluster_deletion_protection" "%[6]s" {
+	organization_id     = "%[2]s"
+	project_id          = "%[3]s"
+	cluster_id          = couchbase-capella_cluster.%[4]s.id
+	deletion_protection = %[5]t
+
+	depends_on = [couchbase-capella_cluster.%[4]s]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, clusterResourceName, enabled, deletionProtectionResourceName, cidr, bucketConfig)
+}
+
+func testAccClusterDeletionProtectionProtectedBucketFlushConfig(clusterResourceName, bucketResourceName, flushResourceName, deletionProtectionResourceName, cidr string, enabled, includeFlush bool) string {
+	flushConfig := ""
+	if includeFlush {
+		flushConfig = fmt.Sprintf(`
+resource "couchbase-capella_flush" %[1]q {
+	organization_id = %[2]q
+	project_id      = %[3]q
+	cluster_id      = couchbase-capella_cluster.%[4]s.id
+	bucket_id       = couchbase-capella_bucket.%[5]s.id
+
+	depends_on = [couchbase-capella_cluster_deletion_protection.%[6]s]
+}
+`, flushResourceName, globalOrgId, globalProjectId, clusterResourceName, bucketResourceName, deletionProtectionResourceName)
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster" "%[4]s" {
+	organization_id = "%[2]s"
+	project_id      = "%[3]s"
+	name            = "%[4]s"
+	cloud_provider = {
+		type   = "aws"
+		region = "us-east-1"
+		cidr   = "%[8]s"
+	}
+	service_groups = [
+		{
+			node = {
+				compute = {
+					cpu = 4
+					ram = 16
+				}
+				disk = {
+					storage = 50
+					type    = "gp3"
+					iops    = 3000
+				}
+			}
+			num_of_nodes = 3
+			services     = ["data", "index", "query"]
+		}
+	]
+	availability = {
+		"type" : "multi"
+	}
+	support = {
+		plan     = "developer pro"
+		timezone = "PT"
+	}
+}
+
+resource "couchbase-capella_bucket" "%[5]s" {
+	organization_id = "%[2]s"
+	project_id      = "%[3]s"
+	cluster_id      = couchbase-capella_cluster.%[4]s.id
+	name            = "%[5]s"
+	flush           = true
+
+	depends_on = [couchbase-capella_cluster.%[4]s]
+}
+
+resource "couchbase-capella_cluster_deletion_protection" "%[7]s" {
+	organization_id     = "%[2]s"
+	project_id          = "%[3]s"
+	cluster_id          = couchbase-capella_cluster.%[4]s.id
+	deletion_protection = %[6]t
+
+	depends_on = [couchbase-capella_bucket.%[5]s]
+}
+
+%[9]s
+`, globalProviderBlock, globalOrgId, globalProjectId, clusterResourceName, bucketResourceName, enabled, deletionProtectionResourceName, cidr, flushConfig)
 }
 
 // --- Import ID ---


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-132439](https://jira.issues.couchbase.com/browse/AV-132439)

## Description

Add deletion protection QE acceptance coverage for protected cluster destroy, protected bucket delete, and protected bucket flush workflows.

This PR expands cluster_deletion_protection acceptance coverage with end-to-end Terraform scenarios that validate deletion protection behavior against real Capella APIs.

Changes include:

- Added TestAccClusterDeletionProtectionProtectedDestroyFails
   - Creates a managed cluster.
   - Enables deletion protection.
   - Verifies Terraform destroy fails with the provider deletion-protection guard.
   - Disables protection before cleanup.
   

- Added TestAccClusterDeletionProtectionProtectedBucketDeleteFails
   - Creates a managed cluster and bucket.
   - Enables deletion protection.
   - Verifies bucket deletion fails with the Capella API deletion-protection error.
   - Disables protection and removes the bucket cleanly.

- Added TestAccClusterDeletionProtectionProtectedBucketFlushFails
    - Creates a managed cluster and flush-enabled bucket.
    - Enables deletion protection.
    - Verifies couchbase-capella_flush fails while protection is enabled.
    - Disables protection before cleanup.

- Added registerDeletionProtectionCleanupForClusterResource(...), which reads the test-created cluster ID from Terraform state during the first successful check.
- Registered that cleanup in all three protected-cluster tests:
   - TestAccClusterDeletionProtectionProtectedDestroyFails
   - TestAccClusterDeletionProtectionProtectedBucketDeleteFails
   - TestAccClusterDeletionProtectionProtectedBucketFlushFails
   
- Refactored the existing global-cluster cleanup to reuse a shared [disableDeletionProtection(...) helper.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments

[AV-132439]: https://couchbasecloud.atlassian.net/browse/AV-132439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ