### PR TITLE
[AV-132344] Fix `id=` alias and add import docs for cluster deletion protection

### DIFF
--- a/acceptance_tests/cluster_deletion_protection_acceptance_test.go
+++ b/acceptance_tests/cluster_deletion_protection_acceptance_test.go
@@ -424,6 +424,35 @@ resource "couchbase-capella_cluster_deletion_protection" "%[7]s" {
 `, globalProviderBlock, globalOrgId, globalProjectId, clusterResourceName, bucketResourceName, enabled, deletionProtectionResourceName, cidr, flushConfig)
 }
 
+// TestAccClusterDeletionProtectionResourceImportWithIdAlias verifies that importing with
+// "id=<cluster_id>" (instead of "cluster_id=<cluster_id>") works correctly.
+func TestAccClusterDeletionProtectionResourceImportWithIdAlias(t *testing.T) {
+	disableDeletionProtectionOnCleanup(t)
+	resourceName := randomStringWithPrefix("tf_acc_del_prot_alias_")
+	resourceReference := "couchbase-capella_cluster_deletion_protection." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDeletionProtectionConfig(resourceName, globalClusterId, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(resourceReference, "deletion_protection", "false"),
+				),
+			},
+			// Import using "id=<cluster_id>" alias instead of "cluster_id=<cluster_id>".
+			{
+				ResourceName:                         resourceReference,
+				ImportStateIdFunc:                    generateDeletionProtectionImportIdWithAlias(resourceReference),
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "cluster_id",
+			},
+		},
+	})
+}
+
 // --- Import ID ---
 
 func generateDeletionProtectionImportId(resourceReference string) resource.ImportStateIdFunc {
@@ -441,6 +470,28 @@ func generateDeletionProtectionImportId(resourceReference string) resource.Impor
 		}
 		return fmt.Sprintf(
 			"cluster_id=%s,project_id=%s,organization_id=%s",
+			rawState["cluster_id"], rawState["project_id"], rawState["organization_id"],
+		), nil
+	}
+}
+
+// generateDeletionProtectionImportIdWithAlias produces an import ID that uses "id=" instead of
+// "cluster_id=" to exercise the alias normalization in the provider's ImportState handler.
+func generateDeletionProtectionImportIdWithAlias(resourceReference string) resource.ImportStateIdFunc {
+	return func(state *terraform.State) (string, error) {
+		var rawState map[string]string
+		for _, m := range state.Modules {
+			if len(m.Resources) > 0 {
+				if v, ok := m.Resources[resourceReference]; ok {
+					rawState = v.Primary.Attributes
+				}
+			}
+		}
+		if rawState == nil {
+			return "", fmt.Errorf("resource %s not found in state", resourceReference)
+		}
+		return fmt.Sprintf(
+			"id=%s,project_id=%s,organization_id=%s",
 			rawState["cluster_id"], rawState["project_id"], rawState["organization_id"],
 		), nil
 	}

--- a/examples/deletion_protection/README.md
+++ b/examples/deletion_protection/README.md
@@ -87,3 +87,29 @@ Destroy complete! Resources: 1 destroyed.
 ```
 
 If you need to delete the cluster afterwards, first set `deletion_protection = false` and apply, then destroy.
+
+## IMPORT
+
+To import an existing `couchbase-capella_cluster_deletion_protection` resource into Terraform state, use the following syntax:
+
+```
+terraform import 'couchbase-capella_cluster_deletion_protection.<resource_name>' \
+  'cluster_id=<cluster_id>,project_id=<project_id>,organization_id=<organization_id>'
+```
+
+**Required keys:**
+
+| Key | Description |
+|---|---|
+| `cluster_id` | UUID of the cluster |
+| `project_id` | UUID of the project |
+| `organization_id` | UUID of the organization |
+
+Sample command:
+
+```
+terraform import 'couchbase-capella_cluster_deletion_protection.cluster' \
+  'cluster_id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000001,organization_id=ffffffff-aaaa-1414-eeee-000000000002'
+```
+
+Note: The key `id=` is also accepted as an alias for `cluster_id=` when importing this resource.

--- a/internal/resources/cluster_deletion_protection.go
+++ b/internal/resources/cluster_deletion_protection.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -157,7 +158,22 @@ func (r *ClusterDeletionProtection) Delete(_ context.Context, _ resource.DeleteR
 }
 
 func (r *ClusterDeletionProtection) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	req.ID = normalizeDeletionProtectionImportID(req.ID)
 	resource.ImportStatePassthroughID(ctx, path.Root("cluster_id"), req, resp)
+}
+
+// normalizeDeletionProtectionImportID replaces an "id=<value>" key-value pair in the
+// import string with "cluster_id=<value>", so both forms are accepted on import.
+// Other keys that happen to contain "id" as a substring (e.g. organization_id) are unaffected.
+func normalizeDeletionProtectionImportID(importID string) string {
+	pairs := strings.Split(importID, ",")
+	for i, pair := range pairs {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) == 2 && kv[0] == "id" {
+			pairs[i] = "cluster_id=" + kv[1]
+		}
+	}
+	return strings.Join(pairs, ",")
 }
 
 func (r *ClusterDeletionProtection) putDeletionProtection(ctx context.Context, organizationId, projectId, clusterId string, enabled bool) error {

--- a/internal/resources/cluster_deletion_protection.go
+++ b/internal/resources/cluster_deletion_protection.go
@@ -165,6 +165,14 @@ func (r *ClusterDeletionProtection) ImportState(ctx context.Context, req resourc
 // normalizeDeletionProtectionImportID replaces an "id=<value>" key-value pair in the
 // import string with "cluster_id=<value>", so both forms are accepted on import.
 // Other keys that happen to contain "id" as a substring (e.g. organization_id) are unaffected.
+//
+// This is necessary because this resource has no generic "id" attribute: it uses "cluster_id"
+// as its primary key. ImportStatePassthroughID stores the raw import string into the
+// "cluster_id" field, and splitImportString then parses each key=value pair via the importIds
+// table (validate.go), which maps "id" to the Id attr -- not ClusterId. Without this
+// rewrite, an import string containing "id=<value>" would fail checkKeysAndValues because
+// ClusterId would be absent from the parsed map. Other resources avoid this by targeting
+// path.Root("id"), whose key is already recognised and matches their schema.
 func normalizeDeletionProtectionImportID(importID string) string {
 	pairs := strings.Split(importID, ",")
 	for i, pair := range pairs {

--- a/internal/resources/cluster_deletion_protection_test.go
+++ b/internal/resources/cluster_deletion_protection_test.go
@@ -1,0 +1,47 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_normalizeDeletionProtectionImportID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "id= key is replaced with cluster_id=",
+			input:    "id=533bc6d6-1628-49f5-9384-2dd1c5d025fe,organization_id=5ae82d34-5da8-4313-af5f-90ea4142a4c6,project_id=b02d46ce-c3b1-4a5e-8f3f-ad49112b1dc6",
+			expected: "cluster_id=533bc6d6-1628-49f5-9384-2dd1c5d025fe,organization_id=5ae82d34-5da8-4313-af5f-90ea4142a4c6,project_id=b02d46ce-c3b1-4a5e-8f3f-ad49112b1dc6",
+		},
+		{
+			name:     "cluster_id= is left unchanged",
+			input:    "cluster_id=533bc6d6-1628-49f5-9384-2dd1c5d025fe,organization_id=5ae82d34-5da8-4313-af5f-90ea4142a4c6,project_id=b02d46ce-c3b1-4a5e-8f3f-ad49112b1dc6",
+			expected: "cluster_id=533bc6d6-1628-49f5-9384-2dd1c5d025fe,organization_id=5ae82d34-5da8-4313-af5f-90ea4142a4c6,project_id=b02d46ce-c3b1-4a5e-8f3f-ad49112b1dc6",
+		},
+		{
+			name:     "id= key in non-leading position is replaced",
+			input:    "organization_id=5ae82d34-5da8-4313-af5f-90ea4142a4c6,id=533bc6d6-1628-49f5-9384-2dd1c5d025fe,project_id=b02d46ce-c3b1-4a5e-8f3f-ad49112b1dc6",
+			expected: "organization_id=5ae82d34-5da8-4313-af5f-90ea4142a4c6,cluster_id=533bc6d6-1628-49f5-9384-2dd1c5d025fe,project_id=b02d46ce-c3b1-4a5e-8f3f-ad49112b1dc6",
+		},
+		{
+			name:     "organization_id and project_id substrings containing 'id' are untouched",
+			input:    "cluster_id=aaa,organization_id=bbb,project_id=ccc",
+			expected: "cluster_id=aaa,organization_id=bbb,project_id=ccc",
+		},
+		{
+			name:     "empty string is returned unchanged",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeDeletionProtectionImportID(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-132344

## Description
### Problem

`couchbase-capella_cluster_deletion_protection` uses `cluster_id` as its Terraform primary key
rather than the conventional `id`. When a user ran:

```
terraform import 'couchbase-capella_cluster_deletion_protection.my_resource' \
  'id=<cluster_id>,project_id=<project_id>,organization_id=<organization_id>'
```

the import failed because `ImportStatePassthroughID` stored the raw string into the `cluster_id`
path, and the downstream `splitImportString` parser looked up `id` in the `importIds` table --
which maps to the generic `Id` attribute, not `ClusterId`. The parsed map therefore lacked
`cluster_id` and `checkKeysAndValues` rejected it.

### Changes

- **`cluster_deletion_protection.go`** -- Added `normalizeDeletionProtectionImportID`, called
  from `ImportState` before delegating to `ImportStatePassthroughID`. It rewrites an exact
  `id=<value>` key to `cluster_id=<value>`, leaving all other keys (including `organization_id`
  and `project_id`, which contain "id" as a substring) untouched.

- **`cluster_deletion_protection_test.go`** -- Unit tests covering the normalization: leading
  `id=`, mid-string `id=`, already-correct `cluster_id=`, substring-safe keys, and empty input.

- **`cluster_deletion_protection_acceptance_test.go`** -- New acceptance test
  `TestAccClusterDeletionProtectionResourceImportWithIdAlias` that performs a full import cycle
  using the `id=` form and verifies state is reconciled correctly.

- **`examples/deletion_protection/README.md`** -- Added an IMPORT section with the correct
  `terraform import` syntax, required key table, a sample command, and a note that `id=` is
  accepted as an alias for `cluster_id=`.

### Testing

- Unit tests: `go test ./internal/resources/ -run Test_normalizeDeletionProtectionImportID`
- Acceptance test: `TestAccClusterDeletionProtectionResourceImportWithIdAlias`


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments