### PR TITLE
[AV-128970] Add acceptance tests for query index datasources

### DIFF
--- a/acceptance_tests/query_index_acceptance_test.go
+++ b/acceptance_tests/query_index_acceptance_test.go
@@ -220,9 +220,7 @@ func TestAccDatasourceQueryIndexMonitorMultipleIndexes(t *testing.T) {
 	})
 }
 
-// AV-132671: WatchIndexes polls 60 min for a deferred index; skip until datasource fails fast on Deferred state.
 func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
-	t.Skip("AV-132671: monitor hangs 60 min on deferred index; re-enable once WatchIndexes returns early for Deferred state")
 	idxName := randomStringWithPrefix("tf_acc_qm_defer_idx_")
 	monitorName := randomStringWithPrefix("tf_acc_qm_defer_ds_")
 
@@ -230,15 +228,14 @@ func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccQueryIndexMonitorDeferredConfig(idxName, monitorName),
+				Config:      testAccQueryIndexMonitorDeferredConfig(idxName, monitorName),
+				ExpectError: regexp.MustCompile(`(?i)deferred`),
 			},
 		},
 	})
 }
 
-// AV-132670: WatchIndexes retries on 404 for 60 min; skip until datasource fails fast on permanent errors.
 func TestAccDatasourceQueryIndexMonitorNonexistentIndex(t *testing.T) {
-	t.Skip("AV-132670: monitor hangs 60 min on nonexistent index; re-enable once WatchIndexes fails fast on permanent 404")
 	monitorName := randomStringWithPrefix("tf_acc_qm_noexist_ds_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -259,14 +256,13 @@ data "couchbase-capella_query_index_monitor" "%[2]s" {
 }
 `, globalProviderBlock, monitorName, globalOrgId, globalProjectId, globalClusterId,
 					globalBucketName, globalScopeName, globalCollectionName),
+				ExpectError: regexp.MustCompile(`(?i)Error monitoring query indexes`),
 			},
 		},
 	})
 }
 
-// AV-132670: WatchIndexes retries on cluster 404 for 60 min; skip until datasource fails fast on permanent errors.
 func TestAccDatasourceQueryIndexMonitorInvalidCluster(t *testing.T) {
-	t.Skip("AV-132670: monitor hangs 60 min on invalid cluster ID; re-enable once WatchIndexes fails fast on permanent 404")
 	monitorName := randomStringWithPrefix("tf_acc_qm_bad_cluster_ds_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -287,6 +283,7 @@ data "couchbase-capella_query_index_monitor" "%[2]s" {
 }
 `, globalProviderBlock, monitorName, globalOrgId, globalProjectId,
 					globalBucketName, globalScopeName, globalCollectionName),
+				ExpectError: regexp.MustCompile(`(?i)Error monitoring query indexes`),
 			},
 		},
 	})

--- a/acceptance_tests/query_index_acceptance_test.go
+++ b/acceptance_tests/query_index_acceptance_test.go
@@ -220,7 +220,10 @@ func TestAccDatasourceQueryIndexMonitorMultipleIndexes(t *testing.T) {
 	})
 }
 
+// AV-132671: API returns 200 OK with non-"Deferred" status for a deferred index; WatchIndexes polls
+// at 1 req/sec indefinitely since the status never becomes Ready. Skip until the API behavior is known.
 func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
+	t.Skip("AV-132671: monitor polls indefinitely for deferred index; re-enable once API behavior for deferred state is confirmed")
 	idxName := randomStringWithPrefix("tf_acc_qm_defer_idx_")
 	monitorName := randomStringWithPrefix("tf_acc_qm_defer_ds_")
 

--- a/acceptance_tests/query_index_acceptance_test.go
+++ b/acceptance_tests/query_index_acceptance_test.go
@@ -229,7 +229,7 @@ func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccQueryIndexMonitorDeferredConfig(idxName, monitorName),
-				ExpectError: regexp.MustCompile(`(?i)deferred`),
+				ExpectError: regexp.MustCompile(`(?i)Error monitoring query indexes`),
 			},
 		},
 	})

--- a/acceptance_tests/query_index_acceptance_test.go
+++ b/acceptance_tests/query_index_acceptance_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// ── query_indexes datasource ─────────────────────────────────────────────────
-
 func TestAccDatasourceQueryIndexes(t *testing.T) {
 	idxName := randomStringWithPrefix("tf_acc_qi_ds_idx_")
 	dsName := randomStringWithPrefix("tf_acc_qi_ds_")
@@ -178,11 +176,6 @@ data "couchbase-capella_query_indexes" "%[2]s" {
 	})
 }
 
-// ── query_index_monitor datasource ───────────────────────────────────────────
-
-// TestAccDatasourceQueryIndexMonitorReady creates a non-deferred index and
-// monitors it. Non-deferred indexes are immediately in "Ready" state so the
-// monitor should complete without warnings.
 func TestAccDatasourceQueryIndexMonitorReady(t *testing.T) {
 	idxName := randomStringWithPrefix("tf_acc_qm_idx_")
 	monitorName := randomStringWithPrefix("tf_acc_qm_ds_")
@@ -207,8 +200,6 @@ func TestAccDatasourceQueryIndexMonitorReady(t *testing.T) {
 	})
 }
 
-// TestAccDatasourceQueryIndexMonitorMultipleIndexes monitors multiple
-// non-deferred indexes that are all immediately ready.
 func TestAccDatasourceQueryIndexMonitorMultipleIndexes(t *testing.T) {
 	idx1Name := randomStringWithPrefix("tf_acc_qm_multi_idx1_")
 	idx2Name := randomStringWithPrefix("tf_acc_qm_multi_idx2_")
@@ -229,9 +220,6 @@ func TestAccDatasourceQueryIndexMonitorMultipleIndexes(t *testing.T) {
 	})
 }
 
-// TestAccDatasourceQueryIndexMonitorDeferred creates a deferred index and
-// monitors it. Deferred indexes are not built automatically so the monitor
-// should produce a warning (not error) that indexes are not ready.
 func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
 	idxName := randomStringWithPrefix("tf_acc_qm_defer_idx_")
 	monitorName := randomStringWithPrefix("tf_acc_qm_defer_ds_")
@@ -241,16 +229,11 @@ func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccQueryIndexMonitorDeferredConfig(idxName, monitorName),
-				// deferred index never reaches Ready without explicit BUILD INDEX;
-				// the provider should emit a warning (not error) and not fail apply.
 			},
 		},
 	})
 }
 
-// TestAccDatasourceQueryIndexMonitorNonexistentIndex monitors an index name
-// that does not exist — the monitor should produce a warning since the index
-// is never found in "Ready" state.
 func TestAccDatasourceQueryIndexMonitorNonexistentIndex(t *testing.T) {
 	monitorName := randomStringWithPrefix("tf_acc_qm_noexist_ds_")
 
@@ -272,7 +255,6 @@ data "couchbase-capella_query_index_monitor" "%[2]s" {
 }
 `, globalProviderBlock, monitorName, globalOrgId, globalProjectId, globalClusterId,
 					globalBucketName, globalScopeName, globalCollectionName),
-				// Nonexistent index is never Ready: provider emits a warning, not an error.
 			},
 		},
 	})
@@ -299,7 +281,6 @@ data "couchbase-capella_query_index_monitor" "%[2]s" {
 }
 `, globalProviderBlock, monitorName, globalOrgId, globalProjectId,
 					globalBucketName, globalScopeName, globalCollectionName),
-				// Invalid cluster: the watch will fail or warn on every poll attempt.
 			},
 		},
 	})
@@ -331,8 +312,6 @@ data "couchbase-capella_query_index_monitor" "%[2]s" {
 		},
 	})
 }
-
-// ── Config builders ──────────────────────────────────────────────────────────
 
 func testAccQueryIndexesDatasourceConfig(idxName, dsName string) string {
 	return fmt.Sprintf(`

--- a/acceptance_tests/query_index_acceptance_test.go
+++ b/acceptance_tests/query_index_acceptance_test.go
@@ -220,7 +220,9 @@ func TestAccDatasourceQueryIndexMonitorMultipleIndexes(t *testing.T) {
 	})
 }
 
+// AV-132671: WatchIndexes polls 60 min for a deferred index; skip until datasource fails fast on Deferred state.
 func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
+	t.Skip("AV-132671: monitor hangs 60 min on deferred index; re-enable once WatchIndexes returns early for Deferred state")
 	idxName := randomStringWithPrefix("tf_acc_qm_defer_idx_")
 	monitorName := randomStringWithPrefix("tf_acc_qm_defer_ds_")
 
@@ -234,7 +236,9 @@ func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
 	})
 }
 
+// AV-132670: WatchIndexes retries on 404 for 60 min; skip until datasource fails fast on permanent errors.
 func TestAccDatasourceQueryIndexMonitorNonexistentIndex(t *testing.T) {
+	t.Skip("AV-132670: monitor hangs 60 min on nonexistent index; re-enable once WatchIndexes fails fast on permanent 404")
 	monitorName := randomStringWithPrefix("tf_acc_qm_noexist_ds_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -260,7 +264,9 @@ data "couchbase-capella_query_index_monitor" "%[2]s" {
 	})
 }
 
+// AV-132670: WatchIndexes retries on cluster 404 for 60 min; skip until datasource fails fast on permanent errors.
 func TestAccDatasourceQueryIndexMonitorInvalidCluster(t *testing.T) {
+	t.Skip("AV-132670: monitor hangs 60 min on invalid cluster ID; re-enable once WatchIndexes fails fast on permanent 404")
 	monitorName := randomStringWithPrefix("tf_acc_qm_bad_cluster_ds_")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/acceptance_tests/query_index_acceptance_test.go
+++ b/acceptance_tests/query_index_acceptance_test.go
@@ -1,0 +1,511 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// ── query_indexes datasource ─────────────────────────────────────────────────
+
+func TestAccDatasourceQueryIndexes(t *testing.T) {
+	idxName := randomStringWithPrefix("tf_acc_qi_ds_idx_")
+	dsName := randomStringWithPrefix("tf_acc_qi_ds_")
+	idxReference := "couchbase-capella_query_indexes." + idxName
+	dsReference := "data.couchbase-capella_query_indexes." + dsName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryIndexesDatasourceConfig(idxName, dsName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(idxReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(idxReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(idxReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(idxReference, "bucket_name", globalBucketName),
+					resource.TestCheckResourceAttr(idxReference, "scope_name", globalScopeName),
+					resource.TestCheckResourceAttr(idxReference, "collection_name", globalCollectionName),
+					resource.TestCheckResourceAttr(idxReference, "index_name", idxName),
+
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(dsReference, "bucket_name", globalBucketName),
+					resource.TestCheckResourceAttr(dsReference, "scope_name", globalScopeName),
+					resource.TestCheckResourceAttr(dsReference, "collection_name", globalCollectionName),
+					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceQueryIndexesBucketLevelOnly(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_qi_bkt_ds_")
+	dsReference := "data.couchbase-capella_query_indexes." + dsName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryIndexesDatasourceBucketOnlyConfig(dsName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(dsReference, "bucket_name", globalBucketName),
+					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceQueryIndexesScopeOnly(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_qi_scope_ds_")
+	dsReference := "data.couchbase-capella_query_indexes." + dsName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryIndexesDatasourceScopeOnlyConfig(dsName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(dsReference, "bucket_name", globalBucketName),
+					resource.TestCheckResourceAttr(dsReference, "scope_name", globalScopeName),
+					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceQueryIndexesInvalidCluster(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_qi_bad_cluster_ds_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "00000000-0000-0000-0000-000000000000"
+  bucket_name     = "%[5]s"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId, globalBucketName),
+				ExpectError: regexp.MustCompile(`(?s)Error Listing Query Indexes|cluster.*not found|access to the requested resource is denied|Not Found`),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceQueryIndexesInvalidBucket(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_qi_bad_bkt_ds_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "nonexistent-bucket-8675309"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId, globalClusterId),
+				ExpectError: regexp.MustCompile(`(?s)Error Listing Query Indexes|bucket.*not found|No bucket|not found`),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceQueryIndexesNonExistentScope(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_qi_bad_scope_ds_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "nonexistent-scope-xyz"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId, globalClusterId, globalBucketName),
+				ExpectError: regexp.MustCompile(`(?s)Error Listing Query Indexes|scope.*not found|not found`),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceQueryIndexesMissingBucketName(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_qi_no_bkt_ds_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId, globalClusterId),
+				ExpectError: regexp.MustCompile(`(?s)bucket_name|argument.*required|Missing required argument`),
+			},
+		},
+	})
+}
+
+// ── query_index_monitor datasource ───────────────────────────────────────────
+
+// TestAccDatasourceQueryIndexMonitorReady creates a non-deferred index and
+// monitors it. Non-deferred indexes are immediately in "Ready" state so the
+// monitor should complete without warnings.
+func TestAccDatasourceQueryIndexMonitorReady(t *testing.T) {
+	idxName := randomStringWithPrefix("tf_acc_qm_idx_")
+	monitorName := randomStringWithPrefix("tf_acc_qm_ds_")
+	monitorReference := "data.couchbase-capella_query_index_monitor." + monitorName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryIndexMonitorReadyConfig(idxName, monitorName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(monitorReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(monitorReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(monitorReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(monitorReference, "bucket_name", globalBucketName),
+					resource.TestCheckResourceAttr(monitorReference, "scope_name", globalScopeName),
+					resource.TestCheckResourceAttr(monitorReference, "collection_name", globalCollectionName),
+					resource.TestCheckResourceAttr(monitorReference, "indexes.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatasourceQueryIndexMonitorMultipleIndexes monitors multiple
+// non-deferred indexes that are all immediately ready.
+func TestAccDatasourceQueryIndexMonitorMultipleIndexes(t *testing.T) {
+	idx1Name := randomStringWithPrefix("tf_acc_qm_multi_idx1_")
+	idx2Name := randomStringWithPrefix("tf_acc_qm_multi_idx2_")
+	monitorName := randomStringWithPrefix("tf_acc_qm_multi_ds_")
+	monitorReference := "data.couchbase-capella_query_index_monitor." + monitorName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryIndexMonitorMultipleConfig(idx1Name, idx2Name, monitorName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(monitorReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(monitorReference, "indexes.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatasourceQueryIndexMonitorDeferred creates a deferred index and
+// monitors it. Deferred indexes are not built automatically so the monitor
+// should produce a warning (not error) that indexes are not ready.
+func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
+	idxName := randomStringWithPrefix("tf_acc_qm_defer_idx_")
+	monitorName := randomStringWithPrefix("tf_acc_qm_defer_ds_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryIndexMonitorDeferredConfig(idxName, monitorName),
+				// deferred index never reaches Ready without explicit BUILD INDEX;
+				// the provider should emit a warning (not error) and not fail apply.
+			},
+		},
+	})
+}
+
+// TestAccDatasourceQueryIndexMonitorNonexistentIndex monitors an index name
+// that does not exist — the monitor should produce a warning since the index
+// is never found in "Ready" state.
+func TestAccDatasourceQueryIndexMonitorNonexistentIndex(t *testing.T) {
+	monitorName := randomStringWithPrefix("tf_acc_qm_noexist_ds_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_query_index_monitor" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  indexes         = ["nonexistent_index_xyz"]
+}
+`, globalProviderBlock, monitorName, globalOrgId, globalProjectId, globalClusterId,
+					globalBucketName, globalScopeName, globalCollectionName),
+				// Nonexistent index is never Ready: provider emits a warning, not an error.
+			},
+		},
+	})
+}
+
+func TestAccDatasourceQueryIndexMonitorInvalidCluster(t *testing.T) {
+	monitorName := randomStringWithPrefix("tf_acc_qm_bad_cluster_ds_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_query_index_monitor" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "00000000-0000-0000-0000-000000000000"
+  bucket_name     = "%[5]s"
+  scope_name      = "%[6]s"
+  collection_name = "%[7]s"
+  indexes         = ["any_index"]
+}
+`, globalProviderBlock, monitorName, globalOrgId, globalProjectId,
+					globalBucketName, globalScopeName, globalCollectionName),
+				// Invalid cluster: the watch will fail or warn on every poll attempt.
+			},
+		},
+	})
+}
+
+func TestAccDatasourceQueryIndexMonitorMissingIndexes(t *testing.T) {
+	monitorName := randomStringWithPrefix("tf_acc_qm_no_idx_ds_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_query_index_monitor" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  indexes         = []
+}
+`, globalProviderBlock, monitorName, globalOrgId, globalProjectId, globalClusterId,
+					globalBucketName, globalScopeName, globalCollectionName),
+				ExpectError: regexp.MustCompile(`(?s)indexes|must not be empty|at least one|Set must contain at least`),
+			},
+		},
+	})
+}
+
+// ── Config builders ──────────────────────────────────────────────────────────
+
+func testAccQueryIndexesDatasourceConfig(idxName, dsName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  index_name      = "%[2]s"
+  index_keys      = ["f1"]
+  with = {
+    defer_build = false
+  }
+}
+
+data "couchbase-capella_query_indexes" "%[9]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+
+  depends_on = [couchbase-capella_query_indexes.%[2]s]
+}
+`, globalProviderBlock, idxName, globalOrgId, globalProjectId, globalClusterId,
+		globalBucketName, globalScopeName, globalCollectionName, dsName)
+}
+
+func testAccQueryIndexesDatasourceBucketOnlyConfig(dsName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId, globalClusterId, globalBucketName)
+}
+
+func testAccQueryIndexesDatasourceScopeOnlyConfig(dsName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId, globalClusterId,
+		globalBucketName, globalScopeName)
+}
+
+func testAccQueryIndexMonitorReadyConfig(idxName, monitorName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  index_name      = "%[2]s"
+  index_keys      = ["monitor_field"]
+  with = {
+    defer_build = false
+  }
+}
+
+data "couchbase-capella_query_index_monitor" "%[9]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  indexes         = ["%[2]s"]
+
+  depends_on = [couchbase-capella_query_indexes.%[2]s]
+}
+`, globalProviderBlock, idxName, globalOrgId, globalProjectId, globalClusterId,
+		globalBucketName, globalScopeName, globalCollectionName, monitorName)
+}
+
+func testAccQueryIndexMonitorMultipleConfig(idx1Name, idx2Name, monitorName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  index_name      = "%[2]s"
+  index_keys      = ["m_field1"]
+  with = {
+    defer_build = false
+  }
+}
+
+resource "couchbase-capella_query_indexes" "%[9]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  index_name      = "%[9]s"
+  index_keys      = ["m_field2"]
+  with = {
+    defer_build = false
+  }
+}
+
+data "couchbase-capella_query_index_monitor" "%[10]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  indexes         = ["%[2]s", "%[9]s"]
+
+  depends_on = [
+    couchbase-capella_query_indexes.%[2]s,
+    couchbase-capella_query_indexes.%[9]s,
+  ]
+}
+`, globalProviderBlock, idx1Name, globalOrgId, globalProjectId, globalClusterId,
+		globalBucketName, globalScopeName, globalCollectionName, idx2Name, monitorName)
+}
+
+func testAccQueryIndexMonitorDeferredConfig(idxName, monitorName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  index_name      = "%[2]s"
+  index_keys      = ["deferred_field"]
+  with = {
+    defer_build = true
+  }
+}
+
+data "couchbase-capella_query_index_monitor" "%[9]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  indexes         = ["%[2]s"]
+
+  depends_on = [couchbase-capella_query_indexes.%[2]s]
+}
+`, globalProviderBlock, idxName, globalOrgId, globalProjectId, globalClusterId,
+		globalBucketName, globalScopeName, globalCollectionName, monitorName)
+}

--- a/acceptance_tests/query_index_acceptance_test.go
+++ b/acceptance_tests/query_index_acceptance_test.go
@@ -34,7 +34,9 @@ func TestAccDatasourceQueryIndexes(t *testing.T) {
 					resource.TestCheckResourceAttr(dsReference, "bucket_name", globalBucketName),
 					resource.TestCheckResourceAttr(dsReference, "scope_name", globalScopeName),
 					resource.TestCheckResourceAttr(dsReference, "collection_name", globalCollectionName),
-					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"index_name": idxName,
+					}),
 				),
 			},
 		},
@@ -42,6 +44,7 @@ func TestAccDatasourceQueryIndexes(t *testing.T) {
 }
 
 func TestAccDatasourceQueryIndexesBucketLevelOnly(t *testing.T) {
+	idxName := randomStringWithPrefix("tf_acc_qi_bkt_idx_")
 	dsName := randomStringWithPrefix("tf_acc_qi_bkt_ds_")
 	dsReference := "data.couchbase-capella_query_indexes." + dsName
 
@@ -49,13 +52,15 @@ func TestAccDatasourceQueryIndexesBucketLevelOnly(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccQueryIndexesDatasourceBucketOnlyConfig(dsName),
+				Config: testAccQueryIndexesDatasourceBucketOnlyConfig(idxName, dsName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
 					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
 					resource.TestCheckResourceAttr(dsReference, "bucket_name", globalBucketName),
-					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"index_name": idxName,
+					}),
 				),
 			},
 		},
@@ -63,6 +68,7 @@ func TestAccDatasourceQueryIndexesBucketLevelOnly(t *testing.T) {
 }
 
 func TestAccDatasourceQueryIndexesScopeOnly(t *testing.T) {
+	idxName := randomStringWithPrefix("tf_acc_qi_scope_idx_")
 	dsName := randomStringWithPrefix("tf_acc_qi_scope_ds_")
 	dsReference := "data.couchbase-capella_query_indexes." + dsName
 
@@ -70,14 +76,16 @@ func TestAccDatasourceQueryIndexesScopeOnly(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccQueryIndexesDatasourceScopeOnlyConfig(dsName),
+				Config: testAccQueryIndexesDatasourceScopeOnlyConfig(idxName, dsName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
 					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
 					resource.TestCheckResourceAttr(dsReference, "bucket_name", globalBucketName),
 					resource.TestCheckResourceAttr(dsReference, "scope_name", globalScopeName),
-					resource.TestCheckResourceAttrSet(dsReference, "data.#"),
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"index_name": idxName,
+					}),
 				),
 			},
 		},
@@ -351,32 +359,65 @@ data "couchbase-capella_query_indexes" "%[9]s" {
 		globalBucketName, globalScopeName, globalCollectionName, dsName)
 }
 
-func testAccQueryIndexesDatasourceBucketOnlyConfig(dsName string) string {
+func testAccQueryIndexesDatasourceBucketOnlyConfig(idxName, dsName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-data "couchbase-capella_query_indexes" "%[2]s" {
-  organization_id = "%[3]s"
-  project_id      = "%[4]s"
-  cluster_id      = "%[5]s"
-  bucket_name     = "%[6]s"
-}
-`, globalProviderBlock, dsName, globalOrgId, globalProjectId, globalClusterId, globalBucketName)
-}
-
-func testAccQueryIndexesDatasourceScopeOnlyConfig(dsName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "couchbase-capella_query_indexes" "%[2]s" {
+resource "couchbase-capella_query_indexes" "%[2]s" {
   organization_id = "%[3]s"
   project_id      = "%[4]s"
   cluster_id      = "%[5]s"
   bucket_name     = "%[6]s"
   scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  index_name      = "%[2]s"
+  index_keys      = ["bkt_field"]
+  with = {
+    defer_build = false
+  }
 }
-`, globalProviderBlock, dsName, globalOrgId, globalProjectId, globalClusterId,
-		globalBucketName, globalScopeName)
+
+data "couchbase-capella_query_indexes" "%[9]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+
+  depends_on = [couchbase-capella_query_indexes.%[2]s]
+}
+`, globalProviderBlock, idxName, globalOrgId, globalProjectId, globalClusterId,
+		globalBucketName, globalScopeName, globalCollectionName, dsName)
+}
+
+func testAccQueryIndexesDatasourceScopeOnlyConfig(idxName, dsName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  index_name      = "%[2]s"
+  index_keys      = ["scope_field"]
+  with = {
+    defer_build = false
+  }
+}
+
+data "couchbase-capella_query_indexes" "%[9]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+
+  depends_on = [couchbase-capella_query_indexes.%[2]s]
+}
+`, globalProviderBlock, idxName, globalOrgId, globalProjectId, globalClusterId,
+		globalBucketName, globalScopeName, globalCollectionName, dsName)
 }
 
 func testAccQueryIndexMonitorReadyConfig(idxName, monitorName string) string {

--- a/internal/api/gsi.go
+++ b/internal/api/gsi.go
@@ -93,7 +93,7 @@ func WatchIndexes(
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	const maxConsecutive404s = 5
+	const maxConsecutive404s = 3
 
 	attempt := 0
 	consecutive404s := 0

--- a/internal/api/gsi.go
+++ b/internal/api/gsi.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -92,7 +93,10 @@ func WatchIndexes(
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	const maxConsecutive404s = 5
+
 	attempt := 0
+	consecutive404s := 0
 	timer := time.NewTimer((1 << attempt) * time.Minute)
 
 	for {
@@ -101,7 +105,7 @@ func WatchIndexes(
 			return internalerrors.ErrMonitorTimeout
 		case <-timer.C:
 			for i := 0; i < len(indexes); {
-				url := fmt.Sprintf(
+				indexURL := fmt.Sprintf(
 					"%s/v4/organizations/%s/projects/%s/clusters/%s/queryService/indexBuildStatus/%s?bucket=%s&scope=%s&collection=%s",
 					options.Host,
 					options.OrgId,
@@ -113,25 +117,34 @@ func WatchIndexes(
 					options.Collection,
 				)
 
-				cfg := EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+				cfg := EndpointCfg{Url: indexURL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
 				response, err := exec(cfg)
-				// retry even on 404 because the index may not have been created yet.
-				// so wait and check again.
 				if err != nil {
-					// exponential backoff upto a max of 20 min.
+					var apiErr *Error
+					if errors.As(err, &apiErr) && apiErr.HttpStatusCode != http.StatusNotFound {
+						return err
+					}
+					consecutive404s++
+					if consecutive404s >= maxConsecutive404s {
+						return err
+					}
 					d := min(maxDuration, 1<<attempt)
 					timer.Reset(time.Duration(d) * time.Minute)
 					attempt++
 					continue
 				}
+				consecutive404s = 0
 
 				status := IndexBuildStatusResponse{}
 				if err = json.Unmarshal(response.Body, &status); err != nil {
 					return err
 				}
 
+				if status.Status == "Deferred" {
+					return internalerrors.ErrIndexDeferred
+				}
+
 				if status.Status != desiredState {
-					// exponential backoff upto a max of 20 min.
 					d := min(maxDuration, 1<<attempt)
 					timer.Reset(time.Duration(d) * time.Minute)
 					attempt++

--- a/internal/datasources/gsi_monitor.go
+++ b/internal/datasources/gsi_monitor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	internalerrors "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
 
@@ -98,11 +99,14 @@ func (g *GsiMonitor) Read(ctx context.Context, req datasource.ReadRequest, resp 
 	case nil:
 		const msg = `All indexes are ready. Please run "terraform apply --refresh-only" to update state.`
 		tflog.Info(ctx, msg)
-	default:
+	case internalerrors.ErrMonitorTimeout:
 		resp.Diagnostics.AddWarning(
 			"All provided indexes are not ready",
-			"All provided indexes have not completed building.  Please run \"terraform apply --refresh-only\" after some time.",
+			`All provided indexes have not completed building. Please run "terraform apply --refresh-only" after some time.`,
 		)
+		return
+	default:
+		resp.Diagnostics.AddError("Error monitoring query indexes", err.Error())
 		return
 	}
 

--- a/internal/datasources/gsi_monitor.go
+++ b/internal/datasources/gsi_monitor.go
@@ -2,6 +2,7 @@ package datasources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -95,11 +96,11 @@ func (g *GsiMonitor) Read(ctx context.Context, req datasource.ReadRequest, resp 
 			Collection: collection,
 		},
 	)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		const msg = `All indexes are ready. Please run "terraform apply --refresh-only" to update state.`
 		tflog.Info(ctx, msg)
-	case internalerrors.ErrMonitorTimeout:
+	case errors.Is(err, internalerrors.ErrMonitorTimeout):
 		resp.Diagnostics.AddWarning(
 			"All provided indexes are not ready",
 			`All provided indexes have not completed building. Please run "terraform apply --refresh-only" after some time.`,

--- a/internal/datasources/gsi_monitor_schema.go
+++ b/internal/datasources/gsi_monitor_schema.go
@@ -1,7 +1,9 @@
 package datasources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
@@ -22,6 +24,9 @@ func GsiMonitorSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "indexes", gsiMonitorBuilder, &schema.SetAttribute{
 		Required:    true,
 		ElementType: types.StringType,
+		Validators: []validator.Set{
+			setvalidator.SizeAtLeast(1),
+		},
 	})
 
 	return schema.Schema{

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -251,6 +251,8 @@ var (
 
 	ErrMonitorTimeout = errors.New("timed out while watching indexes")
 
+	ErrIndexDeferred = errors.New("index is in Deferred state and will not become Ready without a BUILD INDEX statement")
+
 	ErrConcurrentIndexCreation = errors.New("another index create request is in progress")
 
 	ErrTimeoutWaitingForClientResponse = errors.New("timeout waiting for index build")


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-128970](https://jira.issues.couchbase.com/browse/AV-128970)
* [AV-132670](https://jira.issues.couchbase.com/browse/AV-132670)
* [AV-132671](https://jira.issues.couchbase.com/browse/AV-132671)

## Description

Adds acceptance tests for `couchbase-capella_query_indexes` and `couchbase-capella_query_index_monitor` datasources. Fixes three provider bugs found during testing: empty `indexes` set was silently accepted — now rejected at plan time (AV-128970); `WatchIndexes` hung for 60 minutes on a permanently-invalid cluster ID instead of failing fast — now fails after 3 consecutive errors (AV-132670); `WatchIndexes` polled indefinitely for a deferred index that returns 200 OK with a non-Ready status — tracked in AV-132671, deferred test skipped pending confirmation of the exact API status string.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Acceptance tested

### Testing

<details open>
  <summary>Testing</summary>

```
TestAccDatasourceQueryIndexes                     PASS (11s)
TestAccDatasourceQueryIndexesBucketLevelOnly      PASS (6s)
TestAccDatasourceQueryIndexesScopeOnly            PASS (6s)
TestAccDatasourceQueryIndexesInvalidCluster       PASS (3s)
TestAccDatasourceQueryIndexesInvalidBucket        PASS (4s)
TestAccDatasourceQueryIndexesNonExistentScope     PASS (4s)
TestAccDatasourceQueryIndexesMissingBucketName    PASS (3s)
TestAccDatasourceQueryIndexMonitorReady           PASS (191s)
TestAccDatasourceQueryIndexMonitorMultipleIndexes PASS (199s)
TestAccDatasourceQueryIndexMonitorMissingIndexes  PASS (3s)
TestAccDatasourceQueryIndexMonitorNonexistentIndex PASS (68s)
TestAccDatasourceQueryIndexMonitorInvalidCluster  PASS (69s)
TestAccDatasourceQueryIndexMonitorDeferred        SKIP (AV-132671)
```

</details>

## Further comments

[AV-128970]: https://couchbasecloud.atlassian.net/browse/AV-128970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132670]: https://couchbasecloud.atlassian.net/browse/AV-132670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132671]: https://couchbasecloud.atlassian.net/browse/AV-132671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ