### PR TITLE
[AV-132944] Add audit log export and settings validation coverage

### DIFF
--- a/acceptance_tests/audit_log_export_acceptance_test.go
+++ b/acceptance_tests/audit_log_export_acceptance_test.go
@@ -85,20 +85,57 @@ func TestAccAuditLogExportResource(t *testing.T) {
 	})
 }
 
-// TestAccAuditLogExportResourceInvalidStart asserts the provider surfaces a
-// parse error when the start timestamp is not a valid RFC3339 string. The
-// Create implementation uses time.Parse(time.RFC3339, ...) and wraps the
-// parse error in a "Could not parse start time" diagnostic.
 func TestAccAuditLogExportResourceInvalidStart(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_export_bad_start_")
-	_, end := auditLogExportWindow()
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAuditLogExportResourceConfig(resourceName, "not-a-timestamp", end),
-				ExpectError: regexp.MustCompile(`(?s)Could not parse start time`),
+				Config:      testAccAuditLogExportResourceInvalidStartConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)start must be a valid RFC3339 timestamp`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogExportResourceMissingStart(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_export_missing_start_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogExportResourceMissingStartConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)The argument "start" is required`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogExportResourceInvalidEnd(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_export_bad_end_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogExportResourceInvalidEndConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)end must be a valid RFC3339 timestamp`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogExportResourceEndBeforeStart(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_export_bad_window_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogExportResourceEndBeforeStartConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)end must not be earlier than start`),
 			},
 		},
 	})
@@ -131,6 +168,21 @@ resource "couchbase-capella_audit_log_export" "%[2]s" {
 	})
 }
 
+func TestAccAuditLogExportResourceEmptyClusterID(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_export_empty_cluster_")
+	start, end := auditLogExportWindow()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogExportResourceEmptyClusterConfig(resourceName, start, end),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value.*Attribute cluster_id string length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
 func testAccAuditLogExportResourceConfig(resourceName, start, end string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -143,6 +195,75 @@ resource "couchbase-capella_audit_log_export" "%[2]s" {
   end             = "%[7]s"
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, start, end)
+}
+
+func testAccAuditLogExportResourceEmptyClusterConfig(resourceName, start, end string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_export" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = ""
+	start           = "%[3]s"
+	end             = "%[4]s"
+}
+`, globalProviderBlock, resourceName, start, end)
+}
+
+func testAccAuditLogExportResourceInvalidStartConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_export" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = "22222222-2222-2222-2222-222222222222"
+	start           = "not-a-date"
+	end             = "2026-05-02T00:00:00Z"
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogExportResourceMissingStartConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_export" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = "22222222-2222-2222-2222-222222222222"
+	end             = "2026-05-02T00:00:00Z"
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogExportResourceInvalidEndConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_export" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = "22222222-2222-2222-2222-222222222222"
+	start           = "2026-05-01T00:00:00Z"
+	end             = "not-a-date"
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogExportResourceEndBeforeStartConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_export" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = "22222222-2222-2222-2222-222222222222"
+	start           = "2026-05-02T00:00:00Z"
+	end             = "2026-05-01T00:00:00Z"
+}
+`, globalProviderBlock, resourceName)
 }
 
 func generateAuditLogExportImportIdForResource(resourceReference string) resource.ImportStateIdFunc {

--- a/acceptance_tests/audit_log_export_acceptance_test.go
+++ b/acceptance_tests/audit_log_export_acceptance_test.go
@@ -85,6 +85,10 @@ func TestAccAuditLogExportResource(t *testing.T) {
 	})
 }
 
+// TestAccAuditLogExportResourceInvalidStart asserts the provider surfaces a
+// parse error when the start timestamp is not a valid RFC3339 string. The
+// Create implementation uses time.Parse(time.RFC3339, ...) and wraps the
+// parse error in a "Could not parse start time" diagnostic.
 func TestAccAuditLogExportResourceInvalidStart(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_export_bad_start_")
 

--- a/acceptance_tests/audit_log_settings_acceptance_test.go
+++ b/acceptance_tests/audit_log_settings_acceptance_test.go
@@ -21,6 +21,7 @@ import (
 func TestAccAuditLogSettingsResource(t *testing.T) {
 	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_")
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_")
+	databaseCredentialName := randomStringWithPrefix("tf_acc_audit_db_credential_")
 	cidr := generateRandomCIDR()
 	clusterReference := "couchbase-capella_cluster." + clusterResourceName
 	resourceReference := "couchbase-capella_audit_log_settings." + resourceName
@@ -50,7 +51,12 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 				ImportStateVerifyIdentifierAttribute: "cluster_id",
 			},
 			{
-				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, true, []int{20488}),
+				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseClusterDatabaseCredentialAndDisabledUsers(clusterResourceName, resourceName, databaseCredentialName, cidr, true, []int{20488}, `[
+					{
+						domain = "local"
+						name   = "%[1]s"
+					}
+				]`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsAuditLogSettingsResource(t, resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
@@ -59,11 +65,15 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
-					resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "0"),
+					resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceReference, "disabled_users.*", map[string]string{
+						"domain": "local",
+						"name":   databaseCredentialName,
+					}),
 				),
 			},
 			{
-				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, false, []int{20488}),
+				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseClusterDatabaseCredentialAndDisabledUsers(clusterResourceName, resourceName, databaseCredentialName, cidr, false, []int{20488}, "[]"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsAuditLogSettingsResource(t, resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
@@ -103,6 +113,90 @@ resource "couchbase-capella_audit_log_settings" "%[2]s" {
 	})
 }
 
+func TestAccAuditLogSettingsResourceEmptyOrganizationID(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_empty_org_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceEmptyOrganizationIDConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)Attribute organization_id string length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogSettingsResourceEventIDWrongType(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_bad_event_id_type_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceEventIDWrongTypeConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)(Incorrect attribute value type|Invalid value for input variable|Invalid Attribute Value).*enabled_event_ids`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogSettingsResourceNegativeEventID(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_negative_event_id_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceNegativeEventIDConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)enabled_event_ids.*value must be at least 1`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogSettingsResourceDisabledUserEmptyDomain(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_empty_domain_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceDisabledUserEmptyDomainConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)Attribute.*disabled_users.*domain string\s+length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogSettingsResourceDisabledUserEmptyName(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_empty_name_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceDisabledUserEmptyNameConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)Attribute.*disabled_users.*name string\s+length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogSettingsResourceDisabledUserMissingName(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_missing_name_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceDisabledUserMissingNameConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)(Missing required|Incorrect attribute value type|attribute).*disabled_users.*name.*required`),
+			},
+		},
+	})
+}
+
 func TestAccAuditLogSettingsResourcePlanUpgrade(t *testing.T) {
 	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_upgrade_")
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_upgrade_")
@@ -126,6 +220,113 @@ func TestAccAuditLogSettingsResourcePlanUpgrade(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccAuditLogSettingsResourceDisabledUserEmptyDomainConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = "00000000-0000-0000-0000-000000000000"
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = [20488]
+
+	disabled_users = [
+		{
+			domain = ""
+			name   = "audit-exempt-user"
+		}
+	]
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogSettingsResourceDisabledUserEmptyNameConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = "00000000-0000-0000-0000-000000000000"
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = [20488]
+
+	disabled_users = [
+		{
+			domain = "local"
+			name   = ""
+		}
+	]
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogSettingsResourceDisabledUserMissingNameConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = "00000000-0000-0000-0000-000000000000"
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = [20488]
+
+	disabled_users = [
+		{
+			domain = "local"
+		}
+	]
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogSettingsResourceEmptyOrganizationIDConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = ""
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = [20488]
+	disabled_users    = []
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogSettingsResourceEventIDWrongTypeConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = "00000000-0000-0000-0000-000000000000"
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = ["not-a-number"]
+	disabled_users    = []
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogSettingsResourceNegativeEventIDConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = "00000000-0000-0000-0000-000000000000"
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = [-1]
+	disabled_users    = []
+}
+`, globalProviderBlock, resourceName)
 }
 
 func testAccAuditLogSettingsResourceConfigWithSupportPlan(clusterResourceName, auditSettingsResourceName, cidr, plan string, auditEnabled bool, enabledEventIDs []int) string {
@@ -192,6 +393,41 @@ resource "couchbase-capella_audit_log_settings" "%[6]s" {
 }
 
 func testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, auditSettingsResourceName, cidr string, auditEnabled bool, enabledEventIDs []int) string {
+	return testAccAuditLogSettingsResourceConfigWithEnterpriseClusterAndDisabledUsers(clusterResourceName, auditSettingsResourceName, cidr, auditEnabled, enabledEventIDs, "[]", "", "")
+}
+
+func testAccAuditLogSettingsResourceConfigWithEnterpriseClusterDatabaseCredentialAndDisabledUsers(clusterResourceName, auditSettingsResourceName, databaseCredentialName, cidr string, auditEnabled bool, enabledEventIDs []int, disabledUsers string) string {
+	databaseCredentialResource := fmt.Sprintf(`
+resource "couchbase-capella_database_credential" "%[1]s" {
+	name            = "%[1]s"
+	organization_id = "%[2]s"
+	project_id      = "%[3]s"
+	cluster_id      = couchbase-capella_cluster.%[4]s.id
+	access = [
+		{
+			privileges = ["data_writer"]
+		},
+	]
+}
+`, databaseCredentialName, globalOrgId, globalProjectId, clusterResourceName)
+	formattedDisabledUsers := disabledUsers
+	if disabledUsers != "[]" {
+		formattedDisabledUsers = fmt.Sprintf(disabledUsers, databaseCredentialName)
+	}
+
+	return testAccAuditLogSettingsResourceConfigWithEnterpriseClusterAndDisabledUsers(
+		clusterResourceName,
+		auditSettingsResourceName,
+		cidr,
+		auditEnabled,
+		enabledEventIDs,
+		formattedDisabledUsers,
+		databaseCredentialName,
+		databaseCredentialResource,
+	)
+}
+
+func testAccAuditLogSettingsResourceConfigWithEnterpriseClusterAndDisabledUsers(clusterResourceName, auditSettingsResourceName, cidr string, auditEnabled bool, enabledEventIDs []int, disabledUsers, databaseCredentialName, databaseCredentialResource string) string {
 	ids := "["
 	for i, id := range enabledEventIDs {
 		if i > 0 {
@@ -200,6 +436,13 @@ func testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceN
 		ids += fmt.Sprintf("%d", id)
 	}
 	ids += "]"
+
+	dependsOn := ""
+	if databaseCredentialResource != "" {
+		dependsOn = fmt.Sprintf(`
+
+	depends_on = [couchbase-capella_database_credential.%[1]s]`, databaseCredentialName)
+	}
 
 	return fmt.Sprintf(`
 %[1]s
@@ -243,15 +486,18 @@ resource "couchbase-capella_cluster" "%[2]s" {
 	}
 }
 
+%[10]s
+
 resource "couchbase-capella_audit_log_settings" "%[6]s" {
 	organization_id   = "%[3]s"
 	project_id        = "%[4]s"
 	cluster_id        = couchbase-capella_cluster.%[2]s.id
 	audit_enabled     = %[7]t
 	enabled_event_ids = %[8]s
-	disabled_users    = []
+	disabled_users    = %[9]s
+%[11]s
 }
-`, globalProviderBlock, clusterResourceName, globalOrgId, globalProjectId, cidr, auditSettingsResourceName, auditEnabled, ids)
+`, globalProviderBlock, clusterResourceName, globalOrgId, globalProjectId, cidr, auditSettingsResourceName, auditEnabled, ids, disabledUsers, databaseCredentialResource, dependsOn)
 }
 
 func generateAuditLogSettingsImportIdForResource(resourceReference string) resource.ImportStateIdFunc {

--- a/internal/resources/audit_log_export.go
+++ b/internal/resources/audit_log_export.go
@@ -19,9 +19,10 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &AuditLogExport{}
-	_ resource.ResourceWithConfigure   = &AuditLogExport{}
-	_ resource.ResourceWithImportState = &AuditLogExport{}
+	_ resource.Resource                   = &AuditLogExport{}
+	_ resource.ResourceWithConfigure      = &AuditLogExport{}
+	_ resource.ResourceWithImportState    = &AuditLogExport{}
+	_ resource.ResourceWithValidateConfig = &AuditLogExport{}
 )
 
 const errorMessageAfterAuditLogExportCreation = "Audit log export job creating is successful, but encountered an error while checking the current" +
@@ -49,6 +50,36 @@ func (a *AuditLogExport) Metadata(_ context.Context, req resource.MetadataReques
 // Schema defines the schema for the audit log export resource.
 func (a *AuditLogExport) Schema(ctx context.Context, rsc resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = AuditLogExportSchema()
+}
+
+func (a *AuditLogExport) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config providerschema.AuditLogExport
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.Start.IsNull() || config.Start.IsUnknown() || config.End.IsNull() || config.End.IsUnknown() {
+		return
+	}
+
+	start, err := time.Parse(time.RFC3339, config.Start.ValueString())
+	if err != nil {
+		return
+	}
+
+	end, err := time.Parse(time.RFC3339, config.End.ValueString())
+	if err != nil {
+		return
+	}
+
+	if end.Before(start) {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("end"),
+			"Invalid Audit Log Export Window",
+			"end must not be earlier than start",
+		)
+	}
 }
 
 // Configure set provider-defined data, clients, etc. that is passed to data sources or resources in the provider.
@@ -100,6 +131,13 @@ func (a *AuditLogExport) Create(ctx context.Context, req resource.CreateRequest,
 		resp.Diagnostics.AddError(
 			"Error creating audit log export job",
 			"Could not parse end time, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	if end.Before(start) {
+		resp.Diagnostics.AddError(
+			"Error creating audit log export job",
+			"end must not be earlier than start",
 		)
 		return
 	}

--- a/internal/resources/audit_log_export_schema.go
+++ b/internal/resources/audit_log_export_schema.go
@@ -48,8 +48,8 @@ func AuditLogExportSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "cluster_id", auditLogExportBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "audit_log_download_url", auditLogExportBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "expiration", auditLogExportBuilder, stringAttribute([]string{computed}))
-	capellaschema.AddAttr(attrs, "start", auditLogExportBuilder, stringAttribute([]string{required}, rfc3339TimestampValidator{attributeName: "start"}))
-	capellaschema.AddAttr(attrs, "end", auditLogExportBuilder, stringAttribute([]string{required}, rfc3339TimestampValidator{attributeName: "end"}))
+	capellaschema.AddAttr(attrs, "start", auditLogExportBuilder, stringAttribute([]string{required, requiresReplace}, rfc3339TimestampValidator{attributeName: "start"}))
+	capellaschema.AddAttr(attrs, "end", auditLogExportBuilder, stringAttribute([]string{required, requiresReplace}, rfc3339TimestampValidator{attributeName: "end"}))
 	capellaschema.AddAttr(attrs, "created_at", auditLogExportBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "status", auditLogExportBuilder, stringAttribute([]string{computed}))
 

--- a/internal/resources/audit_log_export_schema.go
+++ b/internal/resources/audit_log_export_schema.go
@@ -1,24 +1,55 @@
 package resources
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
 
 var auditLogExportBuilder = capellaschema.NewSchemaBuilder("auditLogExport", "clusterAuditLogExport")
 
+type rfc3339TimestampValidator struct {
+	attributeName string
+}
+
+func (v rfc3339TimestampValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("%s must be a valid RFC3339 timestamp", v.attributeName)
+}
+
+func (v rfc3339TimestampValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v rfc3339TimestampValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if _, err := time.Parse(time.RFC3339, req.ConfigValue.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid RFC3339 Timestamp",
+			fmt.Sprintf("%s must be a valid RFC3339 timestamp", v.attributeName),
+		)
+	}
+}
+
 func AuditLogExportSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
 
 	capellaschema.AddAttr(attrs, "id", auditLogExportBuilder, stringAttribute([]string{computed, useStateForUnknown}))
-	capellaschema.AddAttr(attrs, "organization_id", auditLogExportBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(attrs, "project_id", auditLogExportBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(attrs, "cluster_id", auditLogExportBuilder, stringAttribute([]string{required}))
+	capellaschema.AddAttr(attrs, "organization_id", auditLogExportBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "project_id", auditLogExportBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "cluster_id", auditLogExportBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "audit_log_download_url", auditLogExportBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "expiration", auditLogExportBuilder, stringAttribute([]string{computed}))
-	capellaschema.AddAttr(attrs, "start", auditLogExportBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(attrs, "end", auditLogExportBuilder, stringAttribute([]string{required}))
+	capellaschema.AddAttr(attrs, "start", auditLogExportBuilder, stringAttribute([]string{required}, rfc3339TimestampValidator{attributeName: "start"}))
+	capellaschema.AddAttr(attrs, "end", auditLogExportBuilder, stringAttribute([]string{required}, rfc3339TimestampValidator{attributeName: "end"}))
 	capellaschema.AddAttr(attrs, "created_at", auditLogExportBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "status", auditLogExportBuilder, stringAttribute([]string{computed}))
 

--- a/internal/resources/audit_log_settings_schema.go
+++ b/internal/resources/audit_log_settings_schema.go
@@ -1,7 +1,11 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
@@ -12,19 +16,22 @@ var auditLogSettingsBuilder = capellaschema.NewSchemaBuilder("auditLogSettings",
 func AuditLogSettingsSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
 
-	capellaschema.AddAttr(attrs, "organization_id", auditLogSettingsBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(attrs, "project_id", auditLogSettingsBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(attrs, "cluster_id", auditLogSettingsBuilder, stringAttribute([]string{required}))
+	capellaschema.AddAttr(attrs, "organization_id", auditLogSettingsBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "project_id", auditLogSettingsBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "cluster_id", auditLogSettingsBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "audit_enabled", auditLogSettingsBuilder, boolAttribute(computed, optional))
 	capellaschema.AddAttr(attrs, "enabled_event_ids", auditLogSettingsBuilder, &schema.SetAttribute{
 		Computed:    true,
 		Optional:    true,
 		ElementType: types.Int64Type,
+		Validators: []validator.Set{
+			setvalidator.ValueInt64sAre(int64validator.AtLeast(1)),
+		},
 	})
 
 	disabledUserAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(disabledUserAttrs, "domain", auditLogSettingsBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(disabledUserAttrs, "name", auditLogSettingsBuilder, stringAttribute([]string{required}))
+	capellaschema.AddAttr(disabledUserAttrs, "domain", auditLogSettingsBuilder, stringAttribute([]string{required}, stringvalidator.LengthAtLeast(1)))
+	capellaschema.AddAttr(disabledUserAttrs, "name", auditLogSettingsBuilder, stringAttribute([]string{required}, stringvalidator.LengthAtLeast(1)))
 
 	capellaschema.AddAttr(attrs, "disabled_users", auditLogSettingsBuilder, &schema.SetNestedAttribute{
 		Computed: true,


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-132944](https://jira.issues.couchbase.com/browse/AV-132944)
* [AV-132172](https://jira.issues.couchbase.com/browse/AV-132172)
* [AV-132198](https://jira.issues.couchbase.com/browse/AV-132198)
* [AV-132200](https://jira.issues.couchbase.com/browse/AV-132200)
* [AV-132201](https://jira.issues.couchbase.com/browse/AV-132201)
* [AV-132203](https://jira.issues.couchbase.com/browse/AV-132203)
* [AV-132205](https://jira.issues.couchbase.com/browse/AV-132205)
* [AV-132206](https://jira.issues.couchbase.com/browse/AV-132206)

## Description

Adds local validation coverage for audit log export and audit log settings resources so invalid Terraform configs fail before reaching the Capella API.

Changes

- Added RFC3339 validation for couchbase-capella_audit_log_export start and end.
- Added resource-level validation to reject audit log export windows where end is earlier than start.
- Switched audit log export/settings IDs to the required non-empty UUID string helper.
- Added positive integer validation for couchbase-capella_audit_log_settings.enabled_event_ids.
- Added non-empty validation for disabled_users.domain and disabled_users.name.
- Extended audit log settings acceptance coverage to verify a valid non-empty disabled_users entry using a real database credential.
- Added negative acceptance coverage for missing/invalid audit log export and audit log settings validator cases.

Tests Added

Total new acceptance tests added: 10

1. TestAccAuditLogExportResourceMissingStart
2. TestAccAuditLogExportResourceInvalidEnd
3. TestAccAuditLogExportResourceEndBeforeStart
4. TestAccAuditLogExportResourceEmptyClusterID
5. TestAccAuditLogSettingsResourceEmptyOrganizationID
6. TestAccAuditLogSettingsResourceEventIDWrongType
7. TestAccAuditLogSettingsResourceNegativeEventID
8. TestAccAuditLogSettingsResourceDisabledUserEmptyDomain
9. TestAccAuditLogSettingsResourceDisabledUserEmptyName
10. TestAccAuditLogSettingsResourceDisabledUserMissingName

Also updated existing TestAccAuditLogSettingsResource to cover a valid disabled_users entry

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments

[AV-132944]: https://couchbasecloud.atlassian.net/browse/AV-132944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132172]: https://couchbasecloud.atlassian.net/browse/AV-132172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132198]: https://couchbasecloud.atlassian.net/browse/AV-132198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132200]: https://couchbasecloud.atlassian.net/browse/AV-132200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132201]: https://couchbasecloud.atlassian.net/browse/AV-132201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132203]: https://couchbasecloud.atlassian.net/browse/AV-132203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132205]: https://couchbasecloud.atlassian.net/browse/AV-132205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132206]: https://couchbasecloud.atlassian.net/browse/AV-132206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ