### PR TITLE
[AV-132963] Add local validation for backup and snapshot restore inputs

### DIFF
--- a/acceptance_tests/backup_acceptance_test.go
+++ b/acceptance_tests/backup_acceptance_test.go
@@ -134,7 +134,7 @@ resource "couchbase-capella_backup" "%[2]s" {
   restore_times   = 1
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, globalBucketId),
-				ExpectError: regexp.MustCompile("restore times must not be set while create backup"),
+				ExpectError: regexp.MustCompile("restore times must not be set during backup creation"),
 			},
 		},
 	})
@@ -148,7 +148,7 @@ func TestAccBackupResourceRestoreOnCreate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBackupResourceRestoreOnCreateConfig(resourceName),
-				ExpectError: regexp.MustCompile(`restore must not be set while create backup`),
+				ExpectError: regexp.MustCompile(`restore must not be set during backup creation`),
 			},
 		},
 	})

--- a/acceptance_tests/backup_acceptance_test.go
+++ b/acceptance_tests/backup_acceptance_test.go
@@ -134,7 +134,7 @@ resource "couchbase-capella_backup" "%[2]s" {
   restore_times   = 1
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, globalBucketId),
-				ExpectError: regexp.MustCompile("restore times must not be set during backup creation"),
+				ExpectError: regexp.MustCompile("restore times must not be set while create backup"),
 			},
 		},
 	})

--- a/acceptance_tests/backup_acceptance_test.go
+++ b/acceptance_tests/backup_acceptance_test.go
@@ -140,6 +140,62 @@ resource "couchbase-capella_backup" "%[2]s" {
 	})
 }
 
+func TestAccBackupResourceRestoreOnCreate(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_backup_restore_on_create_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBackupResourceRestoreOnCreateConfig(resourceName),
+				ExpectError: regexp.MustCompile(`restore must not be set while create backup`),
+			},
+		},
+	})
+}
+
+func TestAccBackupResourceRestoreInvalidReplaceTTL(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_backup_invalid_replace_ttl_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBackupResourceInvalidRestoreReplaceTTLConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)replace_ttl.*(none|all|expired).*forever|forever.*(none|all|expired)`),
+			},
+		},
+	})
+}
+
+func testAccBackupResourceRestoreOnCreateConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_backup" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = "22222222-2222-2222-2222-222222222222"
+	bucket_id       = "default"
+
+	restore = {
+		target_cluster_id       = "33333333-3333-3333-3333-333333333333"
+		source_cluster_id       = "22222222-2222-2222-2222-222222222222"
+		services                = ["data"]
+		force_updates           = true
+		auto_remove_collections = false
+		replace_ttl             = "none"
+		replace_ttl_with        = "0"
+		include_data            = "bucket.scope.collection"
+		exclude_data            = null
+		filter_keys             = null
+		filter_values           = null
+		map_data                = null
+	}
+}
+`, globalProviderBlock, resourceName)
+}
+
 // testAccBackupResourceConfigWithBucketID is used by the invalid-input tests,
 // which short-circuit before any backup is actually created and therefore have
 // no per-bucket-queue dependency — they continue to point at the shared bucket.
@@ -154,6 +210,34 @@ resource "couchbase-capella_backup" "%[2]s" {
   bucket_id       = "%[6]s"
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, bucketID)
+}
+
+func testAccBackupResourceInvalidRestoreReplaceTTLConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_backup" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = "22222222-2222-2222-2222-222222222222"
+	bucket_id       = "default"
+
+	restore = {
+		target_cluster_id       = "33333333-3333-3333-3333-333333333333"
+		source_cluster_id       = "22222222-2222-2222-2222-222222222222"
+		services                = ["data"]
+		force_updates           = true
+		auto_remove_collections = false
+		replace_ttl             = "forever"
+		replace_ttl_with        = "0"
+		include_data            = "bucket.scope.collection"
+		exclude_data            = null
+		filter_keys             = null
+		filter_values           = null
+		map_data                = null
+	}
+}
+`, globalProviderBlock, resourceName)
 }
 
 // testAccBackupOnIsolatedBucketConfig declares a fresh bucket alongside the

--- a/acceptance_tests/backup_schedule_acceptance_test.go
+++ b/acceptance_tests/backup_schedule_acceptance_test.go
@@ -132,7 +132,7 @@ func TestAccBackupScheduleResourceInvalidStartAt(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "sunday", 99, 4, "30days", false),
-				ExpectError: regexp.MustCompile(`(?s)start_at.*value must be one of|Attribute.*start_at.*one of`),
+				ExpectError: regexp.MustCompile(`(?s)start_at.*value must be between 0 and 23`),
 			},
 		},
 	})

--- a/acceptance_tests/backup_schedule_acceptance_test.go
+++ b/acceptance_tests/backup_schedule_acceptance_test.go
@@ -118,7 +118,7 @@ func TestAccBackupScheduleResourceInvalidStartAt(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "sunday", 99, 4, "30days", false),
-				ExpectError: regexp.MustCompile("start_at value must be one of"),
+				ExpectError: regexp.MustCompile(`start_at value must be between 0 and 23`),
 			},
 		},
 	})

--- a/acceptance_tests/backup_schedule_acceptance_test.go
+++ b/acceptance_tests/backup_schedule_acceptance_test.go
@@ -76,7 +76,7 @@ func TestAccBackupScheduleResourceInvalidDayOfWeek(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "funday", 10, 4, "30days", false),
-				ExpectError: regexp.MustCompile("There is an error during backup schedule creation"),
+				ExpectError: regexp.MustCompile(`(?s)day_of_week.*value must be one of|Attribute.*day_of_week.*one of`),
 			},
 		},
 	})
@@ -89,8 +89,22 @@ func TestAccBackupScheduleResourceInvalidRetention(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "sunday", 10, 4, "9999days", false),
-				ExpectError: regexp.MustCompile("There is an error during backup schedule creation"),
+				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "sunday", 10, 4, "7days", false),
+				ExpectError: regexp.MustCompile(`(?s)retention_time.*value must be one of|Attribute.*retention_time.*one of`),
+			},
+		},
+	})
+}
+
+func TestAccBackupScheduleResourceInvalidIncrementalEvery(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_backup_schedule_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "sunday", 10, 3, "90days", false),
+				ExpectError: regexp.MustCompile(`(?s)incremental_every.*value must be one of|Attribute.*incremental_every.*one of`),
 			},
 		},
 	})
@@ -118,7 +132,7 @@ func TestAccBackupScheduleResourceInvalidStartAt(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "sunday", 99, 4, "30days", false),
-				ExpectError: regexp.MustCompile("There is an error during backup schedule creation"),
+				ExpectError: regexp.MustCompile(`(?s)start_at.*value must be one of|Attribute.*start_at.*one of`),
 			},
 		},
 	})

--- a/acceptance_tests/backup_schedule_acceptance_test.go
+++ b/acceptance_tests/backup_schedule_acceptance_test.go
@@ -77,7 +77,6 @@ func TestAccBackupScheduleResourceInvalidDayOfWeek(t *testing.T) {
 			{
 				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "funday", 10, 4, "30days", false),
 				ExpectError: regexp.MustCompile("day_of_week value must be one of"),
-				ExpectError: regexp.MustCompile(`(?s)day_of_week.*value must be one of|Attribute.*day_of_week.*one of`),
 			},
 		},
 	})

--- a/acceptance_tests/cloud_snapshot_restore_datasource_test.go
+++ b/acceptance_tests/cloud_snapshot_restore_datasource_test.go
@@ -141,6 +141,60 @@ data "couchbase-capella_cloud_snapshot_restores" "%[2]s" {
 	})
 }
 
+func TestAccDatasourceCloudSnapshotRestoresEmptyFilterValues(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_cloud_snapshot_restores_empty_filter_values_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_cloud_snapshot_restores" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  cluster_id      = "22222222-2222-2222-2222-222222222222"
+
+  filter {
+    name   = "status"
+    values = []
+  }
+}
+`, globalProviderBlock, dsName),
+				ExpectError: regexp.MustCompile(`(?s)filter.*values.*(at least 1|minimum|empty)`),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceCloudSnapshotRestoresInvalidFilterName(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_cloud_snapshot_restores_invalid_filter_name_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_cloud_snapshot_restores" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  cluster_id      = "22222222-2222-2222-2222-222222222222"
+
+  filter {
+    name   = "created_at"
+    values = ["complete"]
+  }
+}
+`, globalProviderBlock, dsName),
+				ExpectError: regexp.MustCompile(`(?s)filter.*name.*value must be one of|Attribute.*name.*one of`),
+			},
+		},
+	})
+}
+
 func testAccCloudSnapshotRestoreBackupOnlyConfig(clusterID, backupResourceName string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -186,6 +186,8 @@ var (
 
 	ErrRestoreTimesMustNotBeSetWhileCreateBackup = errors.New("restore times must not be set while create backup")
 
+	ErrRestoreMustNotBeSetWhileCreateBackup = errors.New("restore must not be set while create backup")
+
 	// ErrTFVarHostIsNotSet is returned when TF_VAR_host is not set.
 	ErrTFVarHostIsNotSet = errors.New("TF_VAR_host is not set")
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -184,9 +184,9 @@ var (
 	// ErrBucketIdMissing is returned when an expected Bucket Id was not found after an import.
 	ErrBucketIdMissing = errors.New("bucket ID is missing or was passed incorrectly, please check provider documentation for syntax")
 
-	ErrRestoreTimesMustNotBeSetWhileCreateBackup = errors.New("restore times must not be set while create backup")
+	ErrRestoreTimesMustNotBeSetWhileCreateBackup = errors.New("restore times must not be set during backup creation")
 
-	ErrRestoreMustNotBeSetWhileCreateBackup = errors.New("restore must not be set while create backup")
+	ErrRestoreMustNotBeSetWhileCreateBackup = errors.New("restore must not be set during backup creation")
 
 	// ErrTFVarHostIsNotSet is returned when TF_VAR_host is not set.
 	ErrTFVarHostIsNotSet = errors.New("TF_VAR_host is not set")

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -184,7 +184,7 @@ var (
 	// ErrBucketIdMissing is returned when an expected Bucket Id was not found after an import.
 	ErrBucketIdMissing = errors.New("bucket ID is missing or was passed incorrectly, please check provider documentation for syntax")
 
-	ErrRestoreTimesMustNotBeSetWhileCreateBackup = errors.New("restore times must not be set during backup creation")
+	ErrRestoreTimesMustNotBeSetWhileCreateBackup = errors.New("restore times must not be set while create backup")
 
 	ErrRestoreMustNotBeSetWhileCreateBackup = errors.New("restore must not be set during backup creation")
 

--- a/internal/generated/enums/lookup.go
+++ b/internal/generated/enums/lookup.go
@@ -135,6 +135,7 @@ var acronyms = map[string]string{
 	"oidc": "OIDC",
 	"sso":  "SSO",
 	"tls":  "TLS",
+	"ttl":  "TTL",
 	"uri":  "URI",
 	"url":  "URL",
 	"uuid": "UUID",

--- a/internal/resources/backup.go
+++ b/internal/resources/backup.go
@@ -429,6 +429,9 @@ func (a *Backup) validateCreateBackupRequest(plan providerschema.Backup) error {
 	if !plan.RestoreTimes.IsNull() && !plan.RestoreTimes.IsUnknown() {
 		return internal_errors.ErrRestoreTimesMustNotBeSetWhileCreateBackup
 	}
+	if !plan.Restore.IsNull() && !plan.Restore.IsUnknown() {
+		return internal_errors.ErrRestoreMustNotBeSetWhileCreateBackup
+	}
 	return nil
 }
 

--- a/internal/resources/backup.go
+++ b/internal/resources/backup.go
@@ -24,6 +24,7 @@ var (
 	_ resource.Resource                = &Backup{}
 	_ resource.ResourceWithConfigure   = &Backup{}
 	_ resource.ResourceWithImportState = &Backup{}
+	_ resource.ResourceWithModifyPlan  = &Backup{}
 )
 
 const errorMessageWhileBackupCreation = "There is an error during backup creation. Please check in Capella to see if any hanging resources" +
@@ -47,6 +48,35 @@ func (b *Backup) Metadata(_ context.Context, req resource.MetadataRequest, resp 
 // Schema defines the schema for the Backup resource.
 func (b *Backup) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = BackupSchema()
+}
+
+// ModifyPlan validates backup restore-only fields that are invalid during resource creation.
+func (b *Backup) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || !req.State.Raw.IsNull() {
+		return
+	}
+
+	var plan providerschema.Backup
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.RestoreTimes.IsNull() && !plan.RestoreTimes.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("restore_times"),
+			"Invalid Backup Restore Configuration",
+			internal_errors.ErrRestoreTimesMustNotBeSetWhileCreateBackup.Error(),
+		)
+	}
+
+	if !plan.Restore.IsNull() && !plan.Restore.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("restore"),
+			"Invalid Backup Restore Configuration",
+			internal_errors.ErrRestoreMustNotBeSetWhileCreateBackup.Error(),
+		)
+	}
 }
 
 // Create creates a new Backup.

--- a/internal/resources/backup.go
+++ b/internal/resources/backup.go
@@ -50,7 +50,10 @@ func (b *Backup) Schema(_ context.Context, _ resource.SchemaRequest, resp *resou
 	resp.Schema = BackupSchema()
 }
 
-// ModifyPlan validates backup restore-only fields that are invalid during resource creation.
+// ModifyPlan validates restore-related fields at plan time. On create (no prior
+// state) it rejects restore and restore_times, which are only valid when restoring
+// an existing backup. On update (prior state present) it enforces that restore and
+// restore_times are configured together, since one without the other is invalid.
 func (b *Backup) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		return

--- a/internal/resources/backup.go
+++ b/internal/resources/backup.go
@@ -52,13 +52,36 @@ func (b *Backup) Schema(_ context.Context, _ resource.SchemaRequest, resp *resou
 
 // ModifyPlan validates backup restore-only fields that are invalid during resource creation.
 func (b *Backup) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() || !req.State.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() {
 		return
 	}
 
 	var plan providerschema.Backup
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	restoreTimesConfigured := !plan.RestoreTimes.IsNull() && !plan.RestoreTimes.IsUnknown()
+	restoreConfigured := !plan.Restore.IsNull() && !plan.Restore.IsUnknown()
+
+	if !req.State.Raw.IsNull() {
+		if restoreTimesConfigured && !restoreConfigured {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("restore"),
+				"Invalid Backup Restore Configuration",
+				"restore must be configured when restore_times is set.",
+			)
+		}
+
+		if restoreConfigured && !restoreTimesConfigured {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("restore_times"),
+				"Invalid Backup Restore Configuration",
+				"restore_times must be configured when restore is set.",
+			)
+		}
+
 		return
 	}
 

--- a/internal/resources/backup_schedule_schema.go
+++ b/internal/resources/backup_schedule_schema.go
@@ -1,7 +1,10 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
@@ -18,10 +21,20 @@ func BackupScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "type", backupScheduleBuilder, stringAttribute([]string{required, requiresReplace}))
 
 	weeklyScheduleAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(weeklyScheduleAttrs, "day_of_week", backupScheduleBuilder, stringAttribute([]string{required}), "WeeklySchedule")
-	capellaschema.AddAttr(weeklyScheduleAttrs, "start_at", backupScheduleBuilder, int64Attribute(required), "WeeklySchedule")
-	capellaschema.AddAttr(weeklyScheduleAttrs, "incremental_every", backupScheduleBuilder, int64Attribute(required), "WeeklySchedule")
-	capellaschema.AddAttr(weeklyScheduleAttrs, "retention_time", backupScheduleBuilder, stringAttribute([]string{required}), "WeeklySchedule")
+	capellaschema.AddAttr(weeklyScheduleAttrs, "day_of_week", backupScheduleBuilder, stringAttribute([]string{required}, stringvalidator.OneOf("sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday")), "WeeklySchedule")
+	capellaschema.AddAttr(weeklyScheduleAttrs, "start_at", backupScheduleBuilder, &schema.Int64Attribute{
+		Required: true,
+		Validators: []validator.Int64{
+			int64validator.OneOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23),
+		},
+	}, "WeeklySchedule")
+	capellaschema.AddAttr(weeklyScheduleAttrs, "incremental_every", backupScheduleBuilder, &schema.Int64Attribute{
+		Required: true,
+		Validators: []validator.Int64{
+			int64validator.OneOf(1, 2, 4, 6, 8, 12, 24),
+		},
+	}, "WeeklySchedule")
+	capellaschema.AddAttr(weeklyScheduleAttrs, "retention_time", backupScheduleBuilder, stringAttribute([]string{required}, stringvalidator.OneOf("30days", "60days", "90days", "180days", "1year", "2years", "3years", "4years", "5years")), "WeeklySchedule")
 	capellaschema.AddAttr(weeklyScheduleAttrs, "cost_optimized_retention", backupScheduleBuilder, boolAttribute(required), "WeeklySchedule")
 
 	capellaschema.AddAttr(attrs, "weekly_schedule", backupScheduleBuilder, &schema.SingleNestedAttribute{

--- a/internal/resources/backup_schedule_schema.go
+++ b/internal/resources/backup_schedule_schema.go
@@ -25,7 +25,7 @@ func BackupScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(weeklyScheduleAttrs, "start_at", backupScheduleBuilder, &schema.Int64Attribute{
 		Required: true,
 		Validators: []validator.Int64{
-			int64validator.OneOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23),
+			int64validator.Between(0, 23),
 		},
 	}, "WeeklySchedule")
 	capellaschema.AddAttr(weeklyScheduleAttrs, "incremental_every", backupScheduleBuilder, &schema.Int64Attribute{

--- a/internal/resources/backup_schedule_schema.go
+++ b/internal/resources/backup_schedule_schema.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
@@ -21,20 +20,19 @@ func BackupScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "type", backupScheduleBuilder, stringAttribute([]string{required, requiresReplace}))
 
 	weeklyScheduleAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(weeklyScheduleAttrs, "day_of_week", backupScheduleBuilder, stringAttribute([]string{required}, stringvalidator.OneOf("sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday")), "WeeklySchedule")
+	// day_of_week, incremental_every, and retention_time get their OneOf enum
+	// validators auto-attached from the OpenAPI spec via AddAttr (see AV-132154).
+	// start_at is the exception: the spec models it as an enum of 0..23, but a
+	// Between range validator gives a clearer message, so override it here.
+	capellaschema.AddAttr(weeklyScheduleAttrs, "day_of_week", backupScheduleBuilder, stringAttribute([]string{required}), "WeeklySchedule")
 	capellaschema.AddAttr(weeklyScheduleAttrs, "start_at", backupScheduleBuilder, &schema.Int64Attribute{
 		Required: true,
 		Validators: []validator.Int64{
 			int64validator.Between(0, 23),
 		},
 	}, "WeeklySchedule")
-	capellaschema.AddAttr(weeklyScheduleAttrs, "incremental_every", backupScheduleBuilder, &schema.Int64Attribute{
-		Required: true,
-		Validators: []validator.Int64{
-			int64validator.OneOf(1, 2, 4, 6, 8, 12, 24),
-		},
-	}, "WeeklySchedule")
-	capellaschema.AddAttr(weeklyScheduleAttrs, "retention_time", backupScheduleBuilder, stringAttribute([]string{required}, stringvalidator.OneOf("30days", "60days", "90days", "180days", "1year", "2years", "3years", "4years", "5years")), "WeeklySchedule")
+	capellaschema.AddAttr(weeklyScheduleAttrs, "incremental_every", backupScheduleBuilder, int64Attribute(required), "WeeklySchedule")
+	capellaschema.AddAttr(weeklyScheduleAttrs, "retention_time", backupScheduleBuilder, stringAttribute([]string{required}), "WeeklySchedule")
 	capellaschema.AddAttr(weeklyScheduleAttrs, "cost_optimized_retention", backupScheduleBuilder, boolAttribute(required), "WeeklySchedule")
 
 	capellaschema.AddAttr(attrs, "weekly_schedule", backupScheduleBuilder, &schema.SingleNestedAttribute{

--- a/internal/resources/backup_schema.go
+++ b/internal/resources/backup_schema.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -73,7 +72,7 @@ func BackupSchema() schema.Schema {
 	capellaschema.AddAttr(restoreAttrs, "include_data", backupBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(restoreAttrs, "exclude_data", backupBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(restoreAttrs, "map_data", backupBuilder, stringAttribute([]string{optional}))
-	capellaschema.AddAttr(restoreAttrs, "replace_ttl", backupBuilder, stringAttribute([]string{optional}, stringvalidator.OneOf("none", "all", "expired")))
+	capellaschema.AddAttr(restoreAttrs, "replace_ttl", backupBuilder, stringAttribute([]string{optional}), "CreateOnDemandRestoreRequest")
 	capellaschema.AddAttr(restoreAttrs, "replace_ttl_with", backupBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(restoreAttrs, "status", backupBuilder, stringAttribute([]string{computed}))
 

--- a/internal/resources/backup_schema.go
+++ b/internal/resources/backup_schema.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -72,7 +73,7 @@ func BackupSchema() schema.Schema {
 	capellaschema.AddAttr(restoreAttrs, "include_data", backupBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(restoreAttrs, "exclude_data", backupBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(restoreAttrs, "map_data", backupBuilder, stringAttribute([]string{optional}))
-	capellaschema.AddAttr(restoreAttrs, "replace_ttl", backupBuilder, stringAttribute([]string{optional}))
+	capellaschema.AddAttr(restoreAttrs, "replace_ttl", backupBuilder, stringAttribute([]string{optional}, stringvalidator.OneOf("none", "all", "expired")))
 	capellaschema.AddAttr(restoreAttrs, "replace_ttl_with", backupBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(restoreAttrs, "status", backupBuilder, stringAttribute([]string{computed}))
 


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-132963](https://jira.issues.couchbase.com/browse/AV-132963)
* [AV-132149](https://jira.issues.couchbase.com/browse/AV-132149)
* [AV-132150](https://jira.issues.couchbase.com/browse/AV-132150)
* [AV-132153](https://jira.issues.couchbase.com/browse/AV-132153)
* [AV-132154](https://jira.issues.couchbase.com/browse/AV-132154)

## Description

Summary

This PR adds local Terraform validation coverage for backup, backup schedule, and cloud snapshot restore configuration edge cases that were previously accepted by terraform validate and only failed later during provider/API execution.

Changes include:

- Reject couchbase-capella_backup.restore during backup creation using resource-level plan validation.
- Reject couchbase-capella_backup.restore_times during backup creation at plan time.
- Validate backup.restore.replace_ttl locally with allowed values: none, all, expired.
- Validate nested backup_schedule.weekly_schedule enum fields locally:
    - day_of_week
    - start_at
    - incremental_every
    - retention_time
- Add explicit validation coverage for cloud_snapshot_restores.filter:
    - invalid filter name
    - empty filter values

Tests Added

Total new acceptance tests added: 5

New tests:

1. TestAccBackupResourceRestoreOnCreate
2. TestAccBackupResourceRestoreInvalidReplaceTTL
3. TestAccBackupScheduleResourceInvalidIncrementalEvery
4. TestAccDatasourceCloudSnapshotRestoresEmptyFilterValues
5. TestAccDatasourceCloudSnapshotRestoresInvalidFilterName

Also updated existing backup schedule negative tests to expect local validation errors instead of API/create-time failures:

- invalid day_of_week
- invalid retention_time
- invalid start_at

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments

[AV-132963]: https://couchbasecloud.atlassian.net/browse/AV-132963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132149]: https://couchbasecloud.atlassian.net/browse/AV-132149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132150]: https://couchbasecloud.atlassian.net/browse/AV-132150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132153]: https://couchbasecloud.atlassian.net/browse/AV-132153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132154]: https://couchbasecloud.atlassian.net/browse/AV-132154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ