### PR TITLE
[AV-132908] Serialize cloud_snapshot_restore acceptance tests

### DIFF
--- a/acceptance_tests/cloud_snapshot_restore_datasource_test.go
+++ b/acceptance_tests/cloud_snapshot_restore_datasource_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestAccDatasourceCloudSnapshotRestores(t *testing.T) {
+	t.Parallel()
+	cloudSnapshotRestoreMu.Lock()
+	defer cloudSnapshotRestoreMu.Unlock()
+
 	clusterID, err := ensureSnapshotCluster()
 	if err != nil {
 		t.Fatalf("ensureSnapshotCluster: %v", err)
@@ -17,7 +21,7 @@ func TestAccDatasourceCloudSnapshotRestores(t *testing.T) {
 	dsName := randomStringWithPrefix("tf_acc_cloud_snapshot_restores_ds_")
 	dsReference := "data.couchbase-capella_cloud_snapshot_restores." + dsName
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			// Step 1: create snapshot backup (no restore yet).
@@ -41,6 +45,10 @@ func TestAccDatasourceCloudSnapshotRestores(t *testing.T) {
 }
 
 func TestAccDatasourceCloudSnapshotRestore(t *testing.T) {
+	t.Parallel()
+	cloudSnapshotRestoreMu.Lock()
+	defer cloudSnapshotRestoreMu.Unlock()
+
 	clusterID, err := ensureSnapshotCluster()
 	if err != nil {
 		t.Fatalf("ensureSnapshotCluster: %v", err)
@@ -50,7 +58,7 @@ func TestAccDatasourceCloudSnapshotRestore(t *testing.T) {
 	singleDsName := randomStringWithPrefix("tf_acc_cloud_snapshot_restore_ds_")
 	singleDsReference := "data.couchbase-capella_cloud_snapshot_restore." + singleDsName
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{

--- a/acceptance_tests/snapshot_setup.go
+++ b/acceptance_tests/snapshot_setup.go
@@ -21,6 +21,9 @@ var (
 	snapshotClusterID      string
 	snapshotClusterCreated bool
 	snapshotClusterErr     error
+
+	// Serializes tests that trigger snapshot restores; Capella allows only one restore per cluster.
+	cloudSnapshotRestoreMu sync.Mutex
 )
 
 // ensureSnapshotCluster lazily provisions a dedicated cluster used by the


### PR DESCRIPTION
## Jira

* [AV-132908](https://jira.issues.couchbase.com/browse/AV-132908)

## Description

`TestAccDatasourceCloudSnapshotRestore` and `TestAccDatasourceCloudSnapshotRestores` run in parallel against the shared snapshot test cluster. Capella enforces a one-restore-in-progress-per-cluster lock ([AV-83856](https://jira.issues.couchbase.com/browse/AV-83856)), so the two tests intermittently fail with 409s:

- `Unable to delete the backup as it is currently being restored` (on destroy)
- `Unable to trigger a restore as another restore job is already in progress` (on apply)

The provider already retries 409 for ~30 min on each side (`waitForRestoresComplete`, `restoreSnapshotBackup`), but parallel runs exceed that window.

This change serializes just those two tests with a package-level mutex. The other tests in the file (`InvalidID`, `InvalidCluster`, `InvalidFilter`) stay parallel since they never trigger a restore.

Note: `t.Parallel()` is called before `Lock()` so the test runner can release us as parallel before we block; using `resource.Test` (not `ParallelTest`) avoids a double `t.Parallel()` call.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Acceptance tested (relies on CI run)

### Testing

Local build + go vet pass. Behavior is verified by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AV-132908]: https://couchbasecloud.atlassian.net/browse/AV-132908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-83856]: https://couchbasecloud.atlassian.net/browse/AV-83856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ