### PR TITLE
[AV-132227] Add config validation for cluster on/off schedule days

### DIFF
--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -213,10 +213,9 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
-// TestAccClusterOnOffScheduleOutOfOrderDays_AV_132227 verifies that a schedule
-// whose days are not in Monday-to-Sunday order is rejected by local config
-// validation (https://jira.issues.couchbase.com/browse/AV-132227).
-func TestAccClusterOnOffScheduleOutOfOrderDays_AV_132227(t *testing.T) {
+// TestAccClusterOnOffScheduleOutOfOrderDays verifies that a schedule
+// whose days are not in Monday-to-Sunday order is rejected by local config validation.
+func TestAccClusterOnOffScheduleOutOfOrderDays(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_out_of_order_")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -206,7 +206,9 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
   ]
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
-				ExpectError: regexp.MustCompile(`off\s+for\s+the\s+entire\s+day\s+for\s+every\s+day\s+of\s+the\s+week`),
+				// Subset from the start of the message so Terraform's diagnostic
+				// word-wrapping cannot split the match.
+				ExpectError: regexp.MustCompile(`Clusters cannot be scheduled`),
 			},
 		},
 	})
@@ -240,7 +242,9 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
   ]
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
-				ExpectError: regexp.MustCompile(`sequence\s+starting\s+from\s+Monday\s+and\s+ending\s+with\s+Sunday`),
+				// Subset from the start of the message so Terraform's diagnostic
+				// word-wrapping cannot split the match.
+				ExpectError: regexp.MustCompile(`must be in sequence`),
 			},
 		},
 	})

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -178,6 +178,76 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
+// TestAccClusterOnOffSchedule_AV_132227 verifies that a schedule with every day
+// set to "off" is rejected by local config validation instead of being sent to
+// the API (https://jira.issues.couchbase.com/browse/AV-132227).
+func TestAccClusterOnOffSchedule_AV_132227(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_all_off_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  timezone        = "US/Pacific"
+  days = [
+    { day = "monday",    state = "off" },
+    { day = "tuesday",   state = "off" },
+    { day = "wednesday", state = "off" },
+    { day = "thursday",  state = "off" },
+    { day = "friday",    state = "off" },
+    { day = "saturday",  state = "off" },
+    { day = "sunday",    state = "off" },
+  ]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
+				ExpectError: regexp.MustCompile(`(?s)off for the entire day for every day of the week`),
+			},
+		},
+	})
+}
+
+// TestAccClusterOnOffScheduleOutOfOrderDays_AV_132227 verifies that a schedule
+// whose days are not in Monday-to-Sunday order is rejected by local config
+// validation (https://jira.issues.couchbase.com/browse/AV-132227).
+func TestAccClusterOnOffScheduleOutOfOrderDays_AV_132227(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_out_of_order_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  timezone        = "US/Pacific"
+  days = [
+    { day = "sunday",    state = "on" },
+    { day = "monday",    state = "on" },
+    { day = "tuesday",   state = "on" },
+    { day = "wednesday", state = "on" },
+    { day = "thursday",  state = "on" },
+    { day = "friday",    state = "on" },
+    { day = "saturday",  state = "on" },
+  ]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
+				ExpectError: regexp.MustCompile(`(?s)sequence starting from Monday and ending\s+with Sunday`),
+			},
+		},
+	})
+}
+
 func testAccClusterOnOffScheduleResourceConfig(resourceName, timezone string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -204,4 +274,3 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, timezone)
 }
-

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -178,10 +178,9 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
-// TestAccClusterOnOffSchedule_AV_132227 verifies that a schedule with every day
-// set to "off" is rejected by local config validation instead of being sent to
-// the API (https://jira.issues.couchbase.com/browse/AV-132227).
-func TestAccClusterOnOffSchedule_AV_132227(t *testing.T) {
+// TestAccClusterOnOffScheduleAllDaysOff verifies that a schedule with every day
+// set to "off" is rejected by local config validation instead of being sent to the API
+func TestAccClusterOnOffScheduleAllDaysOff(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_all_off_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -207,7 +206,7 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
   ]
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
-				ExpectError: regexp.MustCompile(`(?s)off for the entire day for every day of the week`),
+				ExpectError: regexp.MustCompile(`off\s+for\s+the\s+entire\s+day\s+for\s+every\s+day\s+of\s+the\s+week`),
 			},
 		},
 	})
@@ -241,7 +240,7 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
   ]
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
-				ExpectError: regexp.MustCompile(`(?s)sequence starting from Monday and ending\s+with Sunday`),
+				ExpectError: regexp.MustCompile(`sequence\s+starting\s+from\s+Monday\s+and\s+ending\s+with\s+Sunday`),
 			},
 		},
 	})

--- a/internal/resources/cluster_onoff_schedule.go
+++ b/internal/resources/cluster_onoff_schedule.go
@@ -21,10 +21,15 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &ClusterOnOffSchedule{}
-	_ resource.ResourceWithConfigure   = &ClusterOnOffSchedule{}
-	_ resource.ResourceWithImportState = &ClusterOnOffSchedule{}
+	_ resource.Resource                   = &ClusterOnOffSchedule{}
+	_ resource.ResourceWithConfigure      = &ClusterOnOffSchedule{}
+	_ resource.ResourceWithImportState    = &ClusterOnOffSchedule{}
+	_ resource.ResourceWithValidateConfig = &ClusterOnOffSchedule{}
 )
+
+// weekdays is the order the V4 API requires for the on/off schedule days list:
+// exactly one entry per day of the week, starting from Monday and ending with Sunday.
+var weekdays = [...]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
 
 const errorMessageAfterOnOffScheduleCreation = "Cluster On/Off Schedule creation is successful, but encountered an error while checking the current" +
 	" state of the cluster on/off schedule. Please run `terraform plan` after 1-2 minutes to know the" +
@@ -53,6 +58,63 @@ func (c *ClusterOnOffSchedule) Metadata(_ context.Context, req resource.Metadata
 // Schema defines the schema for the OnOffSchedule resource.
 func (c *ClusterOnOffSchedule) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = OnOffScheduleSchema()
+}
+
+// ValidateConfig enforces the cross-item constraints on the days list that the
+// V4 API documents but the attribute-level validators cannot express: the
+// schedule must contain exactly one entry per day of the week in Monday-to-Sunday
+// order, and the cluster cannot be scheduled to be off for every day of the week.
+func (c *ClusterOnOffSchedule) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var days types.List
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("days"), &days)...)
+	if resp.Diagnostics.HasError() || days.IsNull() || days.IsUnknown() {
+		return
+	}
+
+	var dayItems []providerschema.DayItem
+	// Entries may still be unknown (e.g. computed from other resources); defer
+	// validation to apply time in that case.
+	if diags := days.ElementsAs(ctx, &dayItems, false); diags.HasError() {
+		return
+	}
+
+	if len(dayItems) != len(weekdays) {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("days"),
+			"Invalid Cluster On/Off Schedule",
+			fmt.Sprintf("The schedule requires exactly %d days, one for each day of the week starting"+
+				" from Monday and ending with Sunday, got %d.", len(weekdays), len(dayItems)),
+		)
+		return
+	}
+
+	allOff := true
+	for i, d := range dayItems {
+		if d.Day.IsNull() || d.Day.IsUnknown() || d.State.IsNull() || d.State.IsUnknown() {
+			return
+		}
+		if d.Day.ValueString() != weekdays[i] {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("days").AtListIndex(i).AtName("day"),
+				"Invalid Cluster On/Off Schedule",
+				fmt.Sprintf("The days of the week must be in sequence starting from Monday and ending"+
+					" with Sunday: expected %q at position %d, got %q.", weekdays[i], i, d.Day.ValueString()),
+			)
+			return
+		}
+		if d.State.ValueString() != "off" {
+			allOff = false
+		}
+	}
+
+	if allOff {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("days"),
+			"Invalid Cluster On/Off Schedule",
+			"Clusters cannot be scheduled to be off for the entire day for every day of the week."+
+				" At least one day must have state \"on\" or \"custom\".",
+		)
+	}
 }
 
 // Create creates a new OnOffSchedule.

--- a/internal/resources/cluster_onoff_schedule.go
+++ b/internal/resources/cluster_onoff_schedule.go
@@ -72,9 +72,12 @@ func (c *ClusterOnOffSchedule) ValidateConfig(ctx context.Context, req resource.
 	}
 
 	var dayItems []providerschema.DayItem
-	// Entries may still be unknown (e.g. computed from other resources); defer
-	// validation to apply time in that case.
-	if diags := days.ElementsAs(ctx, &dayItems, false); diags.HasError() {
+	// Entries may still be wholly unknown (e.g. computed from other resources),
+	// which cannot be decoded into DayItem; allow them to decode as zero values
+	// so the per-item null/unknown checks below defer validation to apply time,
+	// while genuine decoding errors still surface.
+	resp.Diagnostics.Append(days.ElementsAs(ctx, &dayItems, true)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/resources/cluster_onoff_schedule.go
+++ b/internal/resources/cluster_onoff_schedule.go
@@ -29,7 +29,8 @@ var (
 
 // weekdays is the order the V4 API requires for the on/off schedule days list:
 // exactly one entry per day of the week, starting from Monday and ending with Sunday.
-var weekdays = [...]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
+// The explicit length guards at compile time against entries being added or removed.
+var weekdays = [7]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
 
 const errorMessageAfterOnOffScheduleCreation = "Cluster On/Off Schedule creation is successful, but encountered an error while checking the current" +
 	" state of the cluster on/off schedule. Please run `terraform plan` after 1-2 minutes to know the" +

--- a/internal/resources/cluster_onoff_schedule_schema.go
+++ b/internal/resources/cluster_onoff_schedule_schema.go
@@ -23,7 +23,8 @@ func OnOffScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(timeBoundaryAttrs, "minute", onOffScheduleBuilder, int64DefaultAttribute(0, optional, computed))
 
 	dayAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(dayAttrs, "state", onOffScheduleBuilder, stringAttribute([]string{required}))
+	capellaschema.AddAttr(dayAttrs, "state", onOffScheduleBuilder, stringAttribute([]string{required},
+		validator.String(stringvalidator.OneOf("on", "off", "custom"))))
 	capellaschema.AddAttr(dayAttrs, "day", onOffScheduleBuilder, stringAttribute([]string{required},
 		validator.String(stringvalidator.OneOf("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"))))
 


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-132227

## Description

<!-- What does this change do? Why is it needed? -->

Fixes [AV-132227](https://jira.issues.couchbase.com/browse/AV-132227): `couchbase-capella_cluster_onoff_schedule` accepted a schedule where every day is set to `off`, even though the Capella API forbids clusters being off for the entire day for every day of the week. `terraform validate` passed and the invalid config was only rejected by the API at apply time.

## Root Cause

The resource schema only validates each `day` value individually (`stringvalidator.OneOf`). There was no cross-item validation on the full `days` list — count, ordering, and the all-days-off constraint were left entirely to the API.

## Changes

- **`internal/resources/cluster_onoff_schedule.go`**: Implement `resource.ResourceWithValidateConfig` so `terraform validate` fails locally when:
  - the `days` list does not contain exactly 7 entries, one per day of the week
  - the days are not in the API-required Monday-to-Sunday sequence
  - every day's state is `off`

  Unknown/computed day values (e.g. built from other resources' outputs) defer validation to apply time instead of erroring spuriously.

- **`acceptance_tests/cluster_onoff_schedule_acceptance_test.go`**: Add acceptance tests:
  - `TestAccClusterOnOffScheduleAllDaysOff` — all-days-off schedule is rejected with a local validation error
  - `TestAccClusterOnOffScheduleOutOfOrderDays` — out-of-sequence days are rejected

  The existing `TestAccClusterOnOffScheduleResourceInvalidDays` regex still matches the new local 7-day error message.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

Ran the new acceptance tests against a sandbox organization with an existing project and cluster (`TF_VAR_project_id` / `TF_VAR_cluster_id` set). Both tests fail at plan time inside local config validation, so no schedule request ever reaches the Capella API:

```
$ TF_ACC=1 go test ./acceptance_tests/ -run 'TestAccClusterOnOffScheduleAllDaysOff|TestAccClusterOnOffScheduleOutOfOrderDays' -v -timeout 30m

=== RUN   TestAccClusterOnOffScheduleAllDaysOff
=== PAUSE TestAccClusterOnOffScheduleAllDaysOff
=== RUN   TestAccClusterOnOffScheduleOutOfOrderDays
=== PAUSE TestAccClusterOnOffScheduleOutOfOrderDays
=== CONT  TestAccClusterOnOffScheduleAllDaysOff
=== CONT  TestAccClusterOnOffScheduleOutOfOrderDays
--- PASS: TestAccClusterOnOffScheduleOutOfOrderDays (1.97s)
--- PASS: TestAccClusterOnOffScheduleAllDaysOff (1.98s)
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests	791.156s
```

The all-days-off config now fails `terraform plan`/`validate` with:

```
Error: Invalid Cluster On/Off Schedule

Clusters cannot be scheduled to be off for the entire day for every day of
the week. At least one day must have state "on" or "custom".
```

Also verified: `goimports`/`go vet` clean and the provider binary builds with version ldflags.

</details>

## Further comments

[AV-132227]: https://couchbasecloud.atlassian.net/browse/AV-132227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
