### PR TITLE
[AV-132229] Add config validation for cluster on/off schedule time boundaries

### DIFF
--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -250,11 +250,11 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
-// TestAccClusterOnOffScheduleCustomWithoutFrom_AV_132229 verifies that a custom
+// TestAccClusterOnOffScheduleCustomWithoutFrom verifies that a custom
 // day without the required from time boundary is rejected by local config
 // validation instead of being sent to the API
 // (https://jira.issues.couchbase.com/browse/AV-132229).
-func TestAccClusterOnOffScheduleCustomWithoutFrom_AV_132229(t *testing.T) {
+func TestAccClusterOnOffScheduleCustomWithoutFrom(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_custom_no_from_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -290,10 +290,10 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
-// TestAccClusterOnOffScheduleBoundaryOnNonCustomDay_AV_132229 verifies that a
+// TestAccClusterOnOffScheduleBoundaryOnNonCustomDay verifies that a
 // day with state "on" or "off" cannot contain from/to time boundaries
 // (https://jira.issues.couchbase.com/browse/AV-132229).
-func TestAccClusterOnOffScheduleBoundaryOnNonCustomDay_AV_132229(t *testing.T) {
+func TestAccClusterOnOffScheduleBoundaryOnNonCustomDay(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_boundary_on_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -325,10 +325,10 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
-// TestAccClusterOnOffScheduleFromAfterTo_AV_132229 verifies that a custom day
+// TestAccClusterOnOffScheduleFromAfterTo verifies that a custom day
 // whose from time boundary is later than its to time boundary is rejected by
 // local config validation (https://jira.issues.couchbase.com/browse/AV-132229).
-func TestAccClusterOnOffScheduleFromAfterTo_AV_132229(t *testing.T) {
+func TestAccClusterOnOffScheduleFromAfterTo(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_from_after_to_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -365,10 +365,10 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
-// TestAccClusterOnOffScheduleInvalidBoundaryHour_AV_132229 verifies that a time
+// TestAccClusterOnOffScheduleInvalidBoundaryHour verifies that a time
 // boundary hour outside the valid 0-23 range is rejected by schema validation
 // (https://jira.issues.couchbase.com/browse/AV-132229).
-func TestAccClusterOnOffScheduleInvalidBoundaryHour_AV_132229(t *testing.T) {
+func TestAccClusterOnOffScheduleInvalidBoundaryHour(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_invalid_hour_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -399,6 +399,45 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
 				ExpectError: regexp.MustCompile(`must be between 0 and 23`),
+			},
+		},
+	})
+}
+
+// TestAccClusterOnOffScheduleInvalidBoundaryMinute verifies that a
+// time boundary minute other than the valid values 0 and 30 is rejected by
+// schema validation (https://jira.issues.couchbase.com/browse/AV-132229).
+func TestAccClusterOnOffScheduleInvalidBoundaryMinute(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_invalid_minute_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  timezone        = "US/Pacific"
+  days = [
+    {
+      day   = "monday"
+      state = "custom"
+      from  = { hour = 8, minute = 15 }
+    },
+    { day = "tuesday",   state = "on" },
+    { day = "wednesday", state = "on" },
+    { day = "thursday",  state = "on" },
+    { day = "friday",    state = "on" },
+    { day = "saturday",  state = "on" },
+    { day = "sunday",    state = "on" },
+  ]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
+				ExpectError: regexp.MustCompile(`must be one of`),
 			},
 		},
 	})

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -213,10 +213,9 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
-// TestAccClusterOnOffScheduleOutOfOrderDays_AV_132227 verifies that a schedule
-// whose days are not in Monday-to-Sunday order is rejected by local config
-// validation (https://jira.issues.couchbase.com/browse/AV-132227).
-func TestAccClusterOnOffScheduleOutOfOrderDays_AV_132227(t *testing.T) {
+// TestAccClusterOnOffScheduleOutOfOrderDays verifies that a schedule
+// whose days are not in Monday-to-Sunday order is rejected by local config validation.
+func TestAccClusterOnOffScheduleOutOfOrderDays(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_out_of_order_")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -206,7 +206,9 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
   ]
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
-				ExpectError: regexp.MustCompile(`off\s+for\s+the\s+entire\s+day\s+for\s+every\s+day\s+of\s+the\s+week`),
+				// Subset from the start of the message so Terraform's diagnostic
+				// word-wrapping cannot split the match.
+				ExpectError: regexp.MustCompile(`Clusters cannot be scheduled`),
 			},
 		},
 	})
@@ -240,7 +242,9 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
   ]
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
-				ExpectError: regexp.MustCompile(`sequence\s+starting\s+from\s+Monday\s+and\s+ending\s+with\s+Sunday`),
+				// Subset from the start of the message so Terraform's diagnostic
+				// word-wrapping cannot split the match.
+				ExpectError: regexp.MustCompile(`must be in sequence`),
 			},
 		},
 	})

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -178,6 +178,76 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
+// TestAccClusterOnOffSchedule_AV_132227 verifies that a schedule with every day
+// set to "off" is rejected by local config validation instead of being sent to
+// the API (https://jira.issues.couchbase.com/browse/AV-132227).
+func TestAccClusterOnOffSchedule_AV_132227(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_all_off_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  timezone        = "US/Pacific"
+  days = [
+    { day = "monday",    state = "off" },
+    { day = "tuesday",   state = "off" },
+    { day = "wednesday", state = "off" },
+    { day = "thursday",  state = "off" },
+    { day = "friday",    state = "off" },
+    { day = "saturday",  state = "off" },
+    { day = "sunday",    state = "off" },
+  ]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
+				ExpectError: regexp.MustCompile(`(?s)off for the entire day for every day of the week`),
+			},
+		},
+	})
+}
+
+// TestAccClusterOnOffScheduleOutOfOrderDays_AV_132227 verifies that a schedule
+// whose days are not in Monday-to-Sunday order is rejected by local config
+// validation (https://jira.issues.couchbase.com/browse/AV-132227).
+func TestAccClusterOnOffScheduleOutOfOrderDays_AV_132227(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_out_of_order_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  timezone        = "US/Pacific"
+  days = [
+    { day = "sunday",    state = "on" },
+    { day = "monday",    state = "on" },
+    { day = "tuesday",   state = "on" },
+    { day = "wednesday", state = "on" },
+    { day = "thursday",  state = "on" },
+    { day = "friday",    state = "on" },
+    { day = "saturday",  state = "on" },
+  ]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
+				ExpectError: regexp.MustCompile(`(?s)sequence starting from Monday and ending\s+with Sunday`),
+			},
+		},
+	})
+}
+
 func testAccClusterOnOffScheduleResourceConfig(resourceName, timezone string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -204,4 +274,3 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, timezone)
 }
-

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -178,10 +178,9 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
-// TestAccClusterOnOffSchedule_AV_132227 verifies that a schedule with every day
-// set to "off" is rejected by local config validation instead of being sent to
-// the API (https://jira.issues.couchbase.com/browse/AV-132227).
-func TestAccClusterOnOffSchedule_AV_132227(t *testing.T) {
+// TestAccClusterOnOffScheduleAllDaysOff verifies that a schedule with every day
+// set to "off" is rejected by local config validation instead of being sent to the API
+func TestAccClusterOnOffScheduleAllDaysOff(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_all_off_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -207,7 +206,7 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
   ]
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
-				ExpectError: regexp.MustCompile(`(?s)off for the entire day for every day of the week`),
+				ExpectError: regexp.MustCompile(`off\s+for\s+the\s+entire\s+day\s+for\s+every\s+day\s+of\s+the\s+week`),
 			},
 		},
 	})
@@ -241,7 +240,7 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
   ]
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
-				ExpectError: regexp.MustCompile(`(?s)sequence starting from Monday and ending\s+with Sunday`),
+				ExpectError: regexp.MustCompile(`sequence\s+starting\s+from\s+Monday\s+and\s+ending\s+with\s+Sunday`),
 			},
 		},
 	})

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -250,6 +250,160 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
+// TestAccClusterOnOffScheduleCustomWithoutFrom_AV_132229 verifies that a custom
+// day without the required from time boundary is rejected by local config
+// validation instead of being sent to the API
+// (https://jira.issues.couchbase.com/browse/AV-132229).
+func TestAccClusterOnOffScheduleCustomWithoutFrom_AV_132229(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_custom_no_from_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  timezone        = "US/Pacific"
+  days = [
+    {
+      day   = "monday"
+      state = "custom"
+      to    = { hour = 18, minute = 30 }
+    },
+    { day = "tuesday",   state = "on" },
+    { day = "wednesday", state = "on" },
+    { day = "thursday",  state = "on" },
+    { day = "friday",    state = "on" },
+    { day = "saturday",  state = "on" },
+    { day = "sunday",    state = "on" },
+  ]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
+				ExpectError: regexp.MustCompile(`from time boundary is required`),
+			},
+		},
+	})
+}
+
+// TestAccClusterOnOffScheduleBoundaryOnNonCustomDay_AV_132229 verifies that a
+// day with state "on" or "off" cannot contain from/to time boundaries
+// (https://jira.issues.couchbase.com/browse/AV-132229).
+func TestAccClusterOnOffScheduleBoundaryOnNonCustomDay_AV_132229(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_boundary_on_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  timezone        = "US/Pacific"
+  days = [
+    { day = "monday",    state = "on", from = { hour = 8, minute = 0 } },
+    { day = "tuesday",   state = "on" },
+    { day = "wednesday", state = "on" },
+    { day = "thursday",  state = "on" },
+    { day = "friday",    state = "on" },
+    { day = "saturday",  state = "on" },
+    { day = "sunday",    state = "on" },
+  ]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
+				ExpectError: regexp.MustCompile(`cannot contain from/to`),
+			},
+		},
+	})
+}
+
+// TestAccClusterOnOffScheduleFromAfterTo_AV_132229 verifies that a custom day
+// whose from time boundary is later than its to time boundary is rejected by
+// local config validation (https://jira.issues.couchbase.com/browse/AV-132229).
+func TestAccClusterOnOffScheduleFromAfterTo_AV_132229(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_from_after_to_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  timezone        = "US/Pacific"
+  days = [
+    {
+      day   = "monday"
+      state = "custom"
+      from  = { hour = 18, minute = 30 }
+      to    = { hour = 8, minute = 0 }
+    },
+    { day = "tuesday",   state = "on" },
+    { day = "wednesday", state = "on" },
+    { day = "thursday",  state = "on" },
+    { day = "friday",    state = "on" },
+    { day = "saturday",  state = "on" },
+    { day = "sunday",    state = "on" },
+  ]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
+				ExpectError: regexp.MustCompile(`must not be later than`),
+			},
+		},
+	})
+}
+
+// TestAccClusterOnOffScheduleInvalidBoundaryHour_AV_132229 verifies that a time
+// boundary hour outside the valid 0-23 range is rejected by schema validation
+// (https://jira.issues.couchbase.com/browse/AV-132229).
+func TestAccClusterOnOffScheduleInvalidBoundaryHour_AV_132229(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_invalid_hour_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  timezone        = "US/Pacific"
+  days = [
+    {
+      day   = "monday"
+      state = "custom"
+      from  = { hour = 24, minute = 0 }
+    },
+    { day = "tuesday",   state = "on" },
+    { day = "wednesday", state = "on" },
+    { day = "thursday",  state = "on" },
+    { day = "friday",    state = "on" },
+    { day = "saturday",  state = "on" },
+    { day = "sunday",    state = "on" },
+  ]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
+				ExpectError: regexp.MustCompile(`must be between 0 and 23`),
+			},
+		},
+	})
+}
+
 func testAccClusterOnOffScheduleResourceConfig(resourceName, timezone string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/internal/resources/cluster_onoff_schedule.go
+++ b/internal/resources/cluster_onoff_schedule.go
@@ -21,10 +21,15 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &ClusterOnOffSchedule{}
-	_ resource.ResourceWithConfigure   = &ClusterOnOffSchedule{}
-	_ resource.ResourceWithImportState = &ClusterOnOffSchedule{}
+	_ resource.Resource                   = &ClusterOnOffSchedule{}
+	_ resource.ResourceWithConfigure      = &ClusterOnOffSchedule{}
+	_ resource.ResourceWithImportState    = &ClusterOnOffSchedule{}
+	_ resource.ResourceWithValidateConfig = &ClusterOnOffSchedule{}
 )
+
+// weekdays is the order the V4 API requires for the on/off schedule days list:
+// exactly one entry per day of the week, starting from Monday and ending with Sunday.
+var weekdays = [...]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
 
 const errorMessageAfterOnOffScheduleCreation = "Cluster On/Off Schedule creation is successful, but encountered an error while checking the current" +
 	" state of the cluster on/off schedule. Please run `terraform plan` after 1-2 minutes to know the" +
@@ -53,6 +58,63 @@ func (c *ClusterOnOffSchedule) Metadata(_ context.Context, req resource.Metadata
 // Schema defines the schema for the OnOffSchedule resource.
 func (c *ClusterOnOffSchedule) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = OnOffScheduleSchema()
+}
+
+// ValidateConfig enforces the cross-item constraints on the days list that the
+// V4 API documents but the attribute-level validators cannot express: the
+// schedule must contain exactly one entry per day of the week in Monday-to-Sunday
+// order, and the cluster cannot be scheduled to be off for every day of the week.
+func (c *ClusterOnOffSchedule) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var days types.List
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("days"), &days)...)
+	if resp.Diagnostics.HasError() || days.IsNull() || days.IsUnknown() {
+		return
+	}
+
+	var dayItems []providerschema.DayItem
+	// Entries may still be unknown (e.g. computed from other resources); defer
+	// validation to apply time in that case.
+	if diags := days.ElementsAs(ctx, &dayItems, false); diags.HasError() {
+		return
+	}
+
+	if len(dayItems) != len(weekdays) {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("days"),
+			"Invalid Cluster On/Off Schedule",
+			fmt.Sprintf("The schedule requires exactly %d days, one for each day of the week starting"+
+				" from Monday and ending with Sunday, got %d.", len(weekdays), len(dayItems)),
+		)
+		return
+	}
+
+	allOff := true
+	for i, d := range dayItems {
+		if d.Day.IsNull() || d.Day.IsUnknown() || d.State.IsNull() || d.State.IsUnknown() {
+			return
+		}
+		if d.Day.ValueString() != weekdays[i] {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("days").AtListIndex(i).AtName("day"),
+				"Invalid Cluster On/Off Schedule",
+				fmt.Sprintf("The days of the week must be in sequence starting from Monday and ending"+
+					" with Sunday: expected %q at position %d, got %q.", weekdays[i], i, d.Day.ValueString()),
+			)
+			return
+		}
+		if d.State.ValueString() != "off" {
+			allOff = false
+		}
+	}
+
+	if allOff {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("days"),
+			"Invalid Cluster On/Off Schedule",
+			"Clusters cannot be scheduled to be off for the entire day for every day of the week."+
+				" At least one day must have state \"on\" or \"custom\".",
+		)
+	}
 }
 
 // Create creates a new OnOffSchedule.

--- a/internal/resources/cluster_onoff_schedule.go
+++ b/internal/resources/cluster_onoff_schedule.go
@@ -72,9 +72,12 @@ func (c *ClusterOnOffSchedule) ValidateConfig(ctx context.Context, req resource.
 	}
 
 	var dayItems []providerschema.DayItem
-	// Entries may still be unknown (e.g. computed from other resources); defer
-	// validation to apply time in that case.
-	if diags := days.ElementsAs(ctx, &dayItems, false); diags.HasError() {
+	// Entries may still be wholly unknown (e.g. computed from other resources),
+	// which cannot be decoded into DayItem; allow them to decode as zero values
+	// so the per-item null/unknown checks below defer validation to apply time,
+	// while genuine decoding errors still surface.
+	resp.Diagnostics.Append(days.ElementsAs(ctx, &dayItems, true)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/resources/cluster_onoff_schedule.go
+++ b/internal/resources/cluster_onoff_schedule.go
@@ -29,7 +29,8 @@ var (
 
 // weekdays is the order the V4 API requires for the on/off schedule days list:
 // exactly one entry per day of the week, starting from Monday and ending with Sunday.
-var weekdays = [...]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
+// The explicit length guards at compile time against entries being added or removed.
+var weekdays = [7]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
 
 const errorMessageAfterOnOffScheduleCreation = "Cluster On/Off Schedule creation is successful, but encountered an error while checking the current" +
 	" state of the cluster on/off schedule. Please run `terraform plan` after 1-2 minutes to know the" +

--- a/internal/resources/cluster_onoff_schedule.go
+++ b/internal/resources/cluster_onoff_schedule.go
@@ -61,10 +61,12 @@ func (c *ClusterOnOffSchedule) Schema(_ context.Context, _ resource.SchemaReques
 	resp.Schema = OnOffScheduleSchema()
 }
 
-// ValidateConfig enforces the cross-item constraints on the days list that the
-// V4 API documents but the attribute-level validators cannot express: the
-// schedule must contain exactly one entry per day of the week in Monday-to-Sunday
-// order, and the cluster cannot be scheduled to be off for every day of the week.
+// ValidateConfig enforces the constraints on the days list that the V4 API
+// documents but the attribute-level validators cannot express: the schedule
+// must contain exactly one entry per day of the week in Monday-to-Sunday order,
+// the cluster cannot be scheduled to be off for every day of the week, custom
+// days require a from time boundary, non-custom days cannot have time
+// boundaries, and from must not be later than to.
 func (c *ClusterOnOffSchedule) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var days types.List
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("days"), &days)...)
@@ -109,6 +111,10 @@ func (c *ClusterOnOffSchedule) ValidateConfig(ctx context.Context, req resource.
 		if d.State.ValueString() != "off" {
 			allOff = false
 		}
+		validateDayTimeBoundaries(i, d, resp)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if allOff {
@@ -119,6 +125,63 @@ func (c *ClusterOnOffSchedule) ValidateConfig(ctx context.Context, req resource.
 				" At least one day must have state \"on\" or \"custom\".",
 		)
 	}
+}
+
+// validateDayTimeBoundaries enforces the V4 API rules tying a day's state to
+// its from/to time boundaries: custom days must contain the from boundary,
+// on/off days cannot contain any time boundary, and from must not be later
+// than to.
+func validateDayTimeBoundaries(i int, d providerschema.DayItem, resp *resource.ValidateConfigResponse) {
+	day := d.Day.ValueString()
+
+	switch d.State.ValueString() {
+	case "custom":
+		if d.From == nil {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("days").AtListIndex(i).AtName("from"),
+				"Invalid Cluster On/Off Schedule",
+				fmt.Sprintf("The from time boundary is required when state is \"custom\" (day %q).", day),
+			)
+			return
+		}
+		if d.To == nil {
+			return
+		}
+		from, fromKnown := boundaryMinutes(d.From)
+		to, toKnown := boundaryMinutes(d.To)
+		if fromKnown && toKnown && from > to {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("days").AtListIndex(i).AtName("from"),
+				"Invalid Cluster On/Off Schedule",
+				fmt.Sprintf("The from time boundary must not be later than the to time boundary (day %q).", day),
+			)
+		}
+	case "on", "off":
+		if d.From != nil || d.To != nil {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("days").AtListIndex(i),
+				"Invalid Cluster On/Off Schedule",
+				fmt.Sprintf("Days with state \"on\" or \"off\" cannot contain from/to time boundaries (day %q).", day),
+			)
+		}
+	}
+}
+
+// boundaryMinutes converts a time boundary to minutes since midnight. Null
+// hour/minute values default to 0, matching the API default. Returns false
+// when a value is unknown so validation is deferred to apply time.
+func boundaryMinutes(b *providerschema.OnTimeBoundary) (int64, bool) {
+	if b.Hour.IsUnknown() || b.Minute.IsUnknown() {
+		return 0, false
+	}
+	var hour, minute int64
+	if !b.Hour.IsNull() {
+		hour = b.Hour.ValueInt64()
+	}
+	if !b.Minute.IsNull() {
+		minute = b.Minute.ValueInt64()
+	}
+	return hour*60 + minute, true
 }
 
 // Create creates a new OnOffSchedule.

--- a/internal/resources/cluster_onoff_schedule_schema.go
+++ b/internal/resources/cluster_onoff_schedule_schema.go
@@ -23,7 +23,8 @@ func OnOffScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(timeBoundaryAttrs, "minute", onOffScheduleBuilder, int64DefaultAttribute(0, optional, computed))
 
 	dayAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(dayAttrs, "state", onOffScheduleBuilder, stringAttribute([]string{required}))
+	capellaschema.AddAttr(dayAttrs, "state", onOffScheduleBuilder, stringAttribute([]string{required},
+		validator.String(stringvalidator.OneOf("on", "off", "custom"))))
 	capellaschema.AddAttr(dayAttrs, "day", onOffScheduleBuilder, stringAttribute([]string{required},
 		validator.String(stringvalidator.OneOf("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"))))
 

--- a/internal/resources/cluster_onoff_schedule_schema.go
+++ b/internal/resources/cluster_onoff_schedule_schema.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -9,6 +10,22 @@ import (
 )
 
 var onOffScheduleBuilder = capellaschema.NewSchemaBuilder("onOffSchedule", "ClusterOnOffSchedule")
+
+// onOffScheduleHourAttribute returns the hour attribute for an on/off schedule
+// time boundary. The V4 API accepts hour values from 0 to 23 inclusive.
+func onOffScheduleHourAttribute() *schema.Int64Attribute {
+	attribute := int64DefaultAttribute(0, optional, computed)
+	attribute.Validators = []validator.Int64{int64validator.Between(0, 23)}
+	return attribute
+}
+
+// onOffScheduleMinuteAttribute returns the minute attribute for an on/off
+// schedule time boundary. The V4 API only accepts minute values 0 and 30.
+func onOffScheduleMinuteAttribute() *schema.Int64Attribute {
+	attribute := int64DefaultAttribute(0, optional, computed)
+	attribute.Validators = []validator.Int64{int64validator.OneOf(0, 30)}
+	return attribute
+}
 
 func OnOffScheduleSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
@@ -19,8 +36,8 @@ func OnOffScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "timezone", onOffScheduleBuilder, stringAttribute([]string{required, requiresReplace}))
 
 	timeBoundaryAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(timeBoundaryAttrs, "hour", onOffScheduleBuilder, int64DefaultAttribute(0, optional, computed))
-	capellaschema.AddAttr(timeBoundaryAttrs, "minute", onOffScheduleBuilder, int64DefaultAttribute(0, optional, computed))
+	capellaschema.AddAttr(timeBoundaryAttrs, "hour", onOffScheduleBuilder, onOffScheduleHourAttribute())
+	capellaschema.AddAttr(timeBoundaryAttrs, "minute", onOffScheduleBuilder, onOffScheduleMinuteAttribute())
 
 	dayAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(dayAttrs, "state", onOffScheduleBuilder, stringAttribute([]string{required},
@@ -34,8 +51,8 @@ func OnOffScheduleSchema() schema.Schema {
 	})
 
 	toAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(toAttrs, "hour", onOffScheduleBuilder, int64DefaultAttribute(0, optional, computed))
-	capellaschema.AddAttr(toAttrs, "minute", onOffScheduleBuilder, int64DefaultAttribute(0, optional, computed))
+	capellaschema.AddAttr(toAttrs, "hour", onOffScheduleBuilder, onOffScheduleHourAttribute())
+	capellaschema.AddAttr(toAttrs, "minute", onOffScheduleBuilder, onOffScheduleMinuteAttribute())
 
 	capellaschema.AddAttr(dayAttrs, "to", onOffScheduleBuilder, &schema.SingleNestedAttribute{
 		Optional:   true,


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-132229

## Description

Bug: couchbase-capella_cluster_onoff_schedule accepted a day with state = "custom" but no from time boundary (plus other invalid boundary combinations) — terraform validate passed and the config only failed at the API.

Root cause: from/to are plain Optional nested attributes with no validators on hour/minute, and nothing ties boundaries to the day's state.

Fix:

1. cluster_onoff_schedule_schema.go — attribute-level validators for the scalar ranges, applied to both from and to via new helpers:
  - hour: int64validator.Between(0, 23)
  - minute: int64validator.OneOf(0, 30)
2. cluster_onoff_schedule.go — extended the existing ValidateConfig loop with validateDayTimeBoundaries (cluster_onoff_schedule.go:135):
  - custom without from → "The from time boundary is required when state is "custom""
  - on/off with from or to → "Days with state "on" or "off" cannot contain from/to time boundaries"
  - from > to (null hour/minute treated as 0, matching the API default; unknown values defer to apply time) → "The from time boundary must not be later than the to time boundary"

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

**Acceptance tests** — ran the five new tests (run predates dropping the `_AV_132229` suffix from the test names; behavior identical) against a sandbox organization with an existing project and cluster (`TF_VAR_project_id` / `TF_VAR_cluster_id` set). All fail at plan time inside local validation, so no request ever reaches the Capella API:

```
$ TF_ACC=1 go test ./acceptance_tests/ -run 'AV_132229' -v -timeout 30m

=== RUN   TestAccClusterOnOffScheduleCustomWithoutFrom
=== RUN   TestAccClusterOnOffScheduleBoundaryOnNonCustomDay
=== RUN   TestAccClusterOnOffScheduleFromAfterTo
=== RUN   TestAccClusterOnOffScheduleInvalidBoundaryHour
=== RUN   TestAccClusterOnOffScheduleInvalidBoundaryMinute
--- PASS: TestAccClusterOnOffScheduleFromAfterTo (2.18s)
--- PASS: TestAccClusterOnOffScheduleBoundaryOnNonCustomDay (2.18s)
--- PASS: TestAccClusterOnOffScheduleInvalidBoundaryHour (2.18s)
--- PASS: TestAccClusterOnOffScheduleInvalidBoundaryMinute (2.18s)
--- PASS: TestAccClusterOnOffScheduleCustomWithoutFrom (2.18s)
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests	851.450s
```

**Manual verification** — built the provider locally and ran `terraform plan` (dev_overrides, no credentials needed) against the ticket's exact repro config and each invalid variant:

- Custom day without `from` (ticket repro):

```
Error: Invalid Cluster On/Off Schedule

The from time boundary is required when state is "custom" (day "monday").
```

- `on` day with a `from` boundary → `Days with state "on" or "off" cannot contain from/to time boundaries (day "monday").`
- Custom day with `from` 18:30 / `to` 8:00 → `The from time boundary must not be later than the to time boundary (day "monday").`
- `hour = 24` → `Attribute days[0].from.hour value must be between 0 and 23, got: 24`
- `minute = 15` → `Attribute days[0].from.minute value must be one of: ["0" "30"], got: 15`
- Valid config (custom day with `from` + `to`) still plans cleanly: `Plan: 1 to add, 0 to change, 0 to destroy.`

Also verified: `goimports`/`go vet` clean, provider binary builds, and `internal/resources` + `internal/schema` unit tests pass.

</details>

## Further comments
