### PR TITLE
[AV-132230] Add UUID validation for cluster on/off schedule data source IDs

### DIFF
--- a/acceptance_tests/cluster_onoff_schedule_datasource_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_datasource_test.go
@@ -54,6 +54,56 @@ data "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
+// TestAccDatasourceClusterOnOffScheduleEmptyClusterId verifies that an empty
+// cluster_id is rejected by local schema validation instead of being sent to
+// the API (https://jira.issues.couchbase.com/browse/AV-132230).
+func TestAccDatasourceClusterOnOffScheduleEmptyClusterId(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_empty_id_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = ""
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId),
+				ExpectError: regexp.MustCompile(`must be a valid UUID|at least 1`),
+			},
+		},
+	})
+}
+
+// TestAccDatasourceClusterOnOffScheduleNonUUIDIds verifies that IDs that are
+// not valid UUIDs are rejected by local schema validation
+// (https://jira.issues.couchbase.com/browse/AV-132230).
+func TestAccDatasourceClusterOnOffScheduleNonUUIDIds(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_non_uuid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "not-a-uuid"
+  project_id      = "also-not-a-uuid"
+  cluster_id      = "definitely-not-a-uuid"
+}
+`, globalProviderBlock, dsName),
+				ExpectError: regexp.MustCompile(`must be a valid UUID`),
+			},
+		},
+	})
+}
+
 func testAccClusterOnOffScheduleResourceAndDatasourceConfig(resName, dsName string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/acceptance_tests/cluster_onoff_schedule_datasource_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_datasource_test.go
@@ -56,7 +56,7 @@ data "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 
 // TestAccDatasourceClusterOnOffScheduleEmptyClusterId verifies that an empty
 // cluster_id is rejected by local schema validation instead of being sent to
-// the API (https://jira.issues.couchbase.com/browse/AV-132230).
+// the API.
 func TestAccDatasourceClusterOnOffScheduleEmptyClusterId(t *testing.T) {
 	dsName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_empty_id_")
 
@@ -64,44 +64,73 @@ func TestAccDatasourceClusterOnOffScheduleEmptyClusterId(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(`
+				Config: testAccClusterOnOffScheduleDatasourceIDsConfig(dsName, globalOrgId, globalProjectId, ""),
+				ExpectError: regexp.MustCompile(
+					`(?s)Invalid Attribute Value Length.*cluster_id.*string length must be at least 1`),
+			},
+		},
+	})
+}
+
+// TestAccDatasourceClusterOnOffScheduleInvalidUUIDs verifies that each ID
+// attribute rejects non-UUID values via local schema validation, one attribute
+// per subtest.
+func TestAccDatasourceClusterOnOffScheduleInvalidUUIDs(t *testing.T) {
+	tests := []struct {
+		name           string
+		organizationID string
+		projectID      string
+		clusterID      string
+	}{
+		{
+			name:           "organization_id",
+			organizationID: "not-a-uuid",
+			projectID:      "11111111-1111-1111-1111-111111111111",
+			clusterID:      "22222222-2222-2222-2222-222222222222",
+		},
+		{
+			name:           "project_id",
+			organizationID: "00000000-0000-0000-0000-000000000000",
+			projectID:      "not-a-uuid",
+			clusterID:      "22222222-2222-2222-2222-222222222222",
+		},
+		{
+			name:           "cluster_id",
+			organizationID: "00000000-0000-0000-0000-000000000000",
+			projectID:      "11111111-1111-1111-1111-111111111111",
+			clusterID:      "not-a-uuid",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dsName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_non_uuid_")
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccClusterOnOffScheduleDatasourceIDsConfig(
+							dsName, test.organizationID, test.projectID, test.clusterID),
+						ExpectError: regexp.MustCompile(
+							`(?s)Invalid Attribute Value Match.*` + test.name + `.*must be a valid UUID`),
+					},
+				},
+			})
+		})
+	}
+}
+
+func testAccClusterOnOffScheduleDatasourceIDsConfig(dsName, organizationID, projectID, clusterID string) string {
+	return fmt.Sprintf(`
 %[1]s
 
 data "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
   organization_id = "%[3]s"
   project_id      = "%[4]s"
-  cluster_id      = ""
+  cluster_id      = "%[5]s"
 }
-`, globalProviderBlock, dsName, globalOrgId, globalProjectId),
-				ExpectError: regexp.MustCompile(`must be a valid UUID|at least 1`),
-			},
-		},
-	})
-}
-
-// TestAccDatasourceClusterOnOffScheduleNonUUIDIds verifies that IDs that are
-// not valid UUIDs are rejected by local schema validation
-// (https://jira.issues.couchbase.com/browse/AV-132230).
-func TestAccDatasourceClusterOnOffScheduleNonUUIDIds(t *testing.T) {
-	dsName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_non_uuid_")
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-%[1]s
-
-data "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
-  organization_id = "not-a-uuid"
-  project_id      = "also-not-a-uuid"
-  cluster_id      = "definitely-not-a-uuid"
-}
-`, globalProviderBlock, dsName),
-				ExpectError: regexp.MustCompile(`must be a valid UUID`),
-			},
-		},
-	})
+`, globalProviderBlock, dsName, organizationID, projectID, clusterID)
 }
 
 func testAccClusterOnOffScheduleResourceAndDatasourceConfig(resName, dsName string) string {

--- a/internal/datasources/cluster_onoff_schedule_schema.go
+++ b/internal/datasources/cluster_onoff_schedule_schema.go
@@ -12,9 +12,9 @@ var clusterOnOffScheduleBuilder = capellaschema.NewSchemaBuilder("clusterOnOffSc
 func ClusterOnOffScheduleSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
 
-	capellaschema.AddAttr(attrs, "organization_id", clusterOnOffScheduleBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "project_id", clusterOnOffScheduleBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "cluster_id", clusterOnOffScheduleBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "organization_id", clusterOnOffScheduleBuilder, requiredUUIDString())
+	capellaschema.AddAttr(attrs, "project_id", clusterOnOffScheduleBuilder, requiredUUIDString())
+	capellaschema.AddAttr(attrs, "cluster_id", clusterOnOffScheduleBuilder, requiredUUIDString())
 	capellaschema.AddAttr(attrs, "timezone", clusterOnOffScheduleBuilder, computedString())
 
 	// Build time attributes (for 'from' and 'to')


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-132230

## Description

Bug: the `couchbase-capella_cluster_onoff_schedule` data source accepted an empty (or non-UUID) `organization_id`, `project_id`, or `cluster_id` — `terraform validate` passed and the config only failed at the API during read/refresh.

Root cause: the data source schema used plain `requiredString()` for all three IDs, which only enforces presence, so `""` was accepted.

Fix: switched the three ID attributes to the existing `requiredUUIDString()` helper (`LengthAtLeast(1)` + UUID regex), matching the resource side which already uses `requiredUUIDStringAttribute()`. This covers both the minimum ask (non-empty) and the preferred UUID-format validation from the ticket.

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

**Acceptance tests** — ran the regression tests against a sandbox organization with an existing project and cluster. All fail at plan time inside local schema validation, so no request ever reaches the Capella API. Per review feedback, each ID attribute is validated in its own subtest with an attribute-specific error assertion:

```
$ TF_ACC=1 go test ./acceptance_tests/ -run 'TestAccDatasourceClusterOnOffSchedule(EmptyClusterId|InvalidUUIDs)' -v -timeout 30m

--- PASS: TestAccDatasourceClusterOnOffScheduleInvalidUUIDs (0.00s)
    --- PASS: TestAccDatasourceClusterOnOffScheduleInvalidUUIDs/organization_id (2.12s)
    --- PASS: TestAccDatasourceClusterOnOffScheduleInvalidUUIDs/project_id (2.12s)
    --- PASS: TestAccDatasourceClusterOnOffScheduleInvalidUUIDs/cluster_id (2.12s)
--- PASS: TestAccDatasourceClusterOnOffScheduleEmptyClusterId (0.16s)
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests	792.019s
```

**Manual verification** — built the provider locally and ran `terraform plan` (dev_overrides, no credentials needed). Each validator was confirmed to fire independently, producing exactly one attribute-specific error per case:

- Empty `cluster_id` (ticket repro):

```
Error: Invalid Attribute Value Length
Attribute cluster_id string length must be at least 1, got: 0

Error: Invalid Attribute Value Match
Attribute cluster_id must be a valid UUID, got:
```

- `organization_id = "not-a-uuid"` (others valid) -> `Attribute organization_id must be a valid UUID, got: not-a-uuid` (1 error only)
- `project_id = "not-a-uuid"` (others valid) -> `Attribute project_id must be a valid UUID, got: not-a-uuid`
- `cluster_id = "not-a-uuid"` (others valid) -> `Attribute cluster_id must be a valid UUID, got: not-a-uuid`

Also verified: `goimports`/`go vet` clean and the provider binary builds with version ldflags.

</details>

## Further comments
