### PR TITLE
[AV-132988] Fix flaky private endpoint service acceptance test

### DIFF
--- a/acceptance_tests/private_endpoint_acceptance_test.go
+++ b/acceptance_tests/private_endpoint_acceptance_test.go
@@ -2,7 +2,6 @@ package acceptance_tests
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -28,7 +27,7 @@ func TestAccPrivateEndpointServiceEnableDisable(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(dataSourceReference, "project_id", globalProjectId),
 					resource.TestCheckResourceAttr(dataSourceReference, "cluster_id", globalClusterId),
-					resource.TestMatchResourceAttr(dataSourceReference, "private_endpoint_dns", regexp.MustCompile(`^private-endpoint\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$`)),
+					resource.TestCheckResourceAttrSet(dataSourceReference, "private_endpoint_dns"),
 					resource.TestCheckResourceAttr(dataSourceReference, "data.#", "0"),
 				),
 			},


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-132988](https://jira.issues.couchbase.com/browse/AV-132988)

## Description

Fixes `TestAccPrivateEndpointServiceEnableDisable` failing in sandbox when Capella returns a valid private endpoint DNS value that does not start with `private-endpoint.`

Error: 
`private_endpoint_acceptance_test.go:18: Step 1/2 error: Check failed: Check 8/9 error: data.couchbase-capella_private_endpoints.tf_acc_private_endpoints_ds_yimvdreglx: Attribute 'private_endpoint_dns' didn't match "^private-endpoint\\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$", got "kv43bk4doox63eak.pl.sandbox.nonprod-project-avengers.com" `

The test now asserts that `private_endpoint_dns` is set instead of matching an environment-specific DNS prefix.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments

[AV-132988]: https://couchbasecloud.atlassian.net/browse/AV-132988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ