### PR TITLE
[AV-132231] Add clear duplicate/missing-day validation for on/off schedule

### DIFF
--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -440,6 +440,44 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
+// TestAccClusterOnOffSchedule_AV_132231 verifies that a schedule which repeats a
+// weekday and omits another (here monday twice, tuesday missing) is rejected by
+// local config validation with a clear duplicate/missing-day diagnostic instead
+// of passing terraform validate. Reproduces AV-132231.
+func TestAccClusterOnOffSchedule_AV_132231(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_dup_days_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  timezone        = "US/Pacific"
+  days = [
+    { day = "monday",    state = "on" },
+    { day = "monday",    state = "on" },
+    { day = "wednesday", state = "on" },
+    { day = "thursday",  state = "on" },
+    { day = "friday",    state = "on" },
+    { day = "saturday",  state = "on" },
+    { day = "sunday",    state = "on" },
+  ]
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId),
+				// Subset from the start of the message so Terraform's diagnostic
+				// word-wrapping cannot split the match.
+				ExpectError: regexp.MustCompile(`exactly one entry for each weekday`),
+			},
+		},
+	})
+}
+
 func testAccClusterOnOffScheduleResourceConfig(resourceName, timezone string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -440,11 +440,11 @@ resource "couchbase-capella_cluster_onoff_schedule" "%[2]s" {
 	})
 }
 
-// TestAccClusterOnOffSchedule_AV_132231 verifies that a schedule which repeats a
-// weekday and omits another (here monday twice, tuesday missing) is rejected by
+// TestAccClusterOnOffScheduleDuplicateDays verifies that a schedule which repeats
+// a weekday and omits another (here monday twice, tuesday missing) is rejected by
 // local config validation with a clear duplicate/missing-day diagnostic instead
-// of passing terraform validate. Reproduces AV-132231.
-func TestAccClusterOnOffSchedule_AV_132231(t *testing.T) {
+// of passing terraform validate.
+func TestAccClusterOnOffScheduleDuplicateDays(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_dup_days_")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/resources/cluster_onoff_schedule.go
+++ b/internal/resources/cluster_onoff_schedule.go
@@ -94,6 +94,36 @@ func (c *ClusterOnOffSchedule) ValidateConfig(ctx context.Context, req resource.
 		return
 	}
 
+	// Reject duplicate or missing weekdays before the positional ordering check
+	// below, so a repeated or omitted day produces a clear diagnostic instead of
+	// the less obvious "out of sequence" message. Day values are constrained to
+	// the seven valid weekdays by the attribute-level enum validator, so with
+	// exactly seven entries any weekday whose count is not one implies a
+	// duplicate paired with an omission.
+	counts := make(map[string]int, len(weekdays))
+	for _, d := range dayItems {
+		if d.Day.IsNull() || d.Day.IsUnknown() {
+			// Unknown/computed day values cannot be counted here; the loop below
+			// defers validation for such entries to apply time.
+			counts = nil
+			break
+		}
+		counts[d.Day.ValueString()]++
+	}
+	if counts != nil {
+		for _, weekday := range weekdays {
+			if counts[weekday] != 1 {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("days"),
+					"Invalid Cluster On/Off Schedule",
+					"The days list must contain exactly one entry for each weekday from Monday"+
+						" through Sunday, with no duplicate or missing days.",
+				)
+				return
+			}
+		}
+	}
+
 	allOff := true
 	for i, d := range dayItems {
 		if d.Day.IsNull() || d.Day.IsUnknown() || d.State.IsNull() || d.State.IsUnknown() {

--- a/internal/resources/cluster_onoff_schedule.go
+++ b/internal/resources/cluster_onoff_schedule.go
@@ -95,33 +95,10 @@ func (c *ClusterOnOffSchedule) ValidateConfig(ctx context.Context, req resource.
 	}
 
 	// Reject duplicate or missing weekdays before the positional ordering check
-	// below, so a repeated or omitted day produces a clear diagnostic instead of
-	// the less obvious "out of sequence" message. Day values are constrained to
-	// the seven valid weekdays by the attribute-level enum validator, so with
-	// exactly seven entries any weekday whose count is not one implies a
-	// duplicate paired with an omission.
-	counts := make(map[string]int, len(weekdays))
-	for _, d := range dayItems {
-		if d.Day.IsNull() || d.Day.IsUnknown() {
-			// Unknown/computed day values cannot be counted here; the loop below
-			// defers validation for such entries to apply time.
-			counts = nil
-			break
-		}
-		counts[d.Day.ValueString()]++
-	}
-	if counts != nil {
-		for _, weekday := range weekdays {
-			if counts[weekday] != 1 {
-				resp.Diagnostics.AddAttributeError(
-					path.Root("days"),
-					"Invalid Cluster On/Off Schedule",
-					"The days list must contain exactly one entry for each weekday from Monday"+
-						" through Sunday, with no duplicate or missing days.",
-				)
-				return
-			}
-		}
+	// so the diagnostic names the actual mistake.
+	validateWeekdayCoverage(dayItems, resp)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	allOff := true
@@ -154,6 +131,32 @@ func (c *ClusterOnOffSchedule) ValidateConfig(ctx context.Context, req resource.
 			"Clusters cannot be scheduled to be off for the entire day for every day of the week."+
 				" At least one day must have state \"on\" or \"custom\".",
 		)
+	}
+}
+
+// validateWeekdayCoverage rejects a days list that repeats or omits a weekday.
+// Day values are restricted to the seven valid weekdays by the attribute-level
+// enum validator, so with exactly seven entries any weekday counted other than
+// once implies a duplicate paired with an omission. Entries with unknown/computed
+// day values are left to the positional check (and ultimately apply time).
+func validateWeekdayCoverage(dayItems []providerschema.DayItem, resp *resource.ValidateConfigResponse) {
+	counts := make(map[string]int, len(weekdays))
+	for _, d := range dayItems {
+		if d.Day.IsNull() || d.Day.IsUnknown() {
+			return
+		}
+		counts[d.Day.ValueString()]++
+	}
+	for _, weekday := range weekdays {
+		if counts[weekday] != 1 {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("days"),
+				"Invalid Cluster On/Off Schedule",
+				"The days list must contain exactly one entry for each weekday from Monday"+
+					" through Sunday, with no duplicate or missing days.",
+			)
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-132231

## Description

### Problem                                                                                                                                                                                    
  `couchbase-capella_cluster_onoff_schedule.days` requires exactly one entry per weekday (Monday–Sunday). A config that repeats a weekday and omits another — e.g. `monday` twice with `tuesday` missing — should be rejected by `terraform validate`.                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                 
### Change                                                                                                                                                                                     
 
Added a dedicated weekday-coverage check in `ClusterOnOffSchedule.ValidateConfig`, running **before** the positional ordering check. It counts weekday occurrences (after the existing `len == 7` guard; day values are already constrained to the seven valid weekdays by the enum validator) and, when any weekday's count is not exactly one, reports a clear message:                     
                                                                                                                                                                                                 
> The days list must contain exactly one entry for each weekday from Monday through Sunday, with no duplicate or missing days.                                                                                                                                                                                                                                                           
Unknown/computed day values are skipped so validation is still deferred to apply time, matching the existing loop's behavior. 

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [X] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

**Acceptance tests** — full `couchbase-capella_cluster_onoff_schedule` suite run against a live Capella sandbox cluster (`TF_ACC=1`). Includes the new negative test `TestAccClusterOnOffScheduleDuplicateDays`, which asserts a schedule repeating `monday` and omitting `tuesday` is rejected at `terraform validate` with the message `...exactly one entry for each weekday...`.

```
=== RUN   TestAccClusterOnOffScheduleResource
--- PASS: TestAccClusterOnOffScheduleResource (4.51s)
--- PASS: TestAccClusterOnOffScheduleBoundaryOnNonCustomDay (0.29s)
--- PASS: TestAccClusterOnOffScheduleAllDaysOff (0.30s)
--- PASS: TestAccClusterOnOffScheduleInvalidBoundaryHour (0.31s)
--- PASS: TestAccClusterOnOffScheduleDuplicateDays (0.32s)
--- PASS: TestAccClusterOnOffScheduleCustomWithoutFrom (0.32s)
--- PASS: TestAccClusterOnOffScheduleFromAfterTo (0.32s)
--- PASS: TestAccClusterOnOffScheduleOutOfOrderDays (0.34s)
--- PASS: TestAccClusterOnOffScheduleResourceInvalidState (0.35s)
--- PASS: TestAccClusterOnOffScheduleInvalidBoundaryMinute (0.18s)
--- PASS: TestAccClusterOnOffScheduleResourceInvalidDays (0.18s)
--- PASS: TestAccClusterOnOffScheduleResourceInvalidCluster (0.58s)
--- PASS: TestAccClusterOnOffScheduleResourceInvalidTimezone (0.64s)
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests	795.292s
```

All 13 tests pass (1 create/update/import lifecycle test against the live cluster + 12 config-validation tests). The new `TestAccClusterOnOffScheduleDuplicateDays` confirms the duplicate/missing-day case is now rejected locally; `TestAccClusterOnOffScheduleOutOfOrderDays` confirms the all-unique-but-out-of-order case still reports the ordering error, so the new coverage check did not regress the existing sequence validation.

</details>

## Further comments

