### PR TITLE
[AV-132232] Reject empty/invalid timezone on cluster on/off schedule

### DIFF
--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -87,6 +87,23 @@ func TestAccClusterOnOffScheduleResourceInvalidTimezone(t *testing.T) {
 	})
 }
 
+// TestAccClusterOnOffScheduleEmptyTimezone verifies that an empty timezone is
+// rejected by local config validation (the enum OneOf validator) at terraform
+// validate instead of being sent to the API.
+func TestAccClusterOnOffScheduleEmptyTimezone(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_empty_tz_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccClusterOnOffScheduleResourceConfig(resourceName, ""),
+				ExpectError: regexp.MustCompile(`(?s)timezone|must be one of|Validation Error`),
+			},
+		},
+	})
+}
+
 func TestAccClusterOnOffScheduleResourceInvalidDays(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_invalid_days_")
 

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -81,7 +81,7 @@ func TestAccClusterOnOffScheduleResourceInvalidTimezone(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccClusterOnOffScheduleResourceConfig(resourceName, "Mars/Olympus"),
-				ExpectError: regexp.MustCompile(`(?s)timezone|invalid value|Validation Error`),
+				ExpectError: regexp.MustCompile(`must be one of`),
 			},
 		},
 	})
@@ -98,7 +98,7 @@ func TestAccClusterOnOffScheduleEmptyTimezone(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccClusterOnOffScheduleResourceConfig(resourceName, ""),
-				ExpectError: regexp.MustCompile(`(?s)timezone|must be one of|Validation Error`),
+				ExpectError: regexp.MustCompile(`must be one of`),
 			},
 		},
 	})

--- a/internal/resources/cluster_onoff_schedule_schema.go
+++ b/internal/resources/cluster_onoff_schedule_schema.go
@@ -11,12 +11,8 @@ import (
 
 var onOffScheduleBuilder = capellaschema.NewSchemaBuilder("onOffSchedule", "ClusterOnOffSchedule")
 
-// onOffScheduleTimezones is the set of timezones the V4 API accepts for a
-// cluster on/off schedule. The generated enum table only carries this enum on
-// the request schema, while the builder resolves "ClusterOnOffSchedule" (the
-// response schema, which has no enum) first, so no OneOf validator is
-// auto-attached. Declaring it here and passing it at the call site enforces the
-// documented values locally and rejects an empty timezone.
+// onOffScheduleTimezones lists the timezones the V4 API accepts. Validated at
+// the call site since the builder's auto-lookup finds no enum for this schema.
 var onOffScheduleTimezones = []string{
 	"Pacific/Midway", "US/Hawaii", "US/Alaska", "US/Pacific", "US/Mountain",
 	"US/Central", "US/Eastern", "America/Puerto_Rico", "Canada/Newfoundland",

--- a/internal/resources/cluster_onoff_schedule_schema.go
+++ b/internal/resources/cluster_onoff_schedule_schema.go
@@ -11,6 +11,22 @@ import (
 
 var onOffScheduleBuilder = capellaschema.NewSchemaBuilder("onOffSchedule", "ClusterOnOffSchedule")
 
+// onOffScheduleTimezones is the set of timezones the V4 API accepts for a
+// cluster on/off schedule. The generated enum table only carries this enum on
+// the request schema, while the builder resolves "ClusterOnOffSchedule" (the
+// response schema, which has no enum) first, so no OneOf validator is
+// auto-attached. Declaring it here and passing it at the call site enforces the
+// documented values locally and rejects an empty timezone.
+var onOffScheduleTimezones = []string{
+	"Pacific/Midway", "US/Hawaii", "US/Alaska", "US/Pacific", "US/Mountain",
+	"US/Central", "US/Eastern", "America/Puerto_Rico", "Canada/Newfoundland",
+	"America/Argentina/Buenos_Aires", "Atlantic/Cape_Verde", "Europe/London",
+	"Europe/Amsterdam", "Europe/Athens", "Africa/Nairobi", "Asia/Tehran",
+	"Indian/Mauritius", "Asia/Karachi", "Asia/Calcutta", "Asia/Dhaka",
+	"Asia/Bangkok", "Asia/Hong_Kong", "Asia/Tokyo", "Australia/North",
+	"Australia/Sydney", "Pacific/Ponape", "Antarctica/South_Pole",
+}
+
 // onOffScheduleHourAttribute returns the hour attribute for an on/off schedule
 // time boundary. The V4 API accepts hour values from 0 to 23 inclusive.
 func onOffScheduleHourAttribute() *schema.Int64Attribute {
@@ -33,7 +49,8 @@ func OnOffScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", onOffScheduleBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "project_id", onOffScheduleBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "cluster_id", onOffScheduleBuilder, requiredUUIDStringAttribute())
-	capellaschema.AddAttr(attrs, "timezone", onOffScheduleBuilder, stringAttribute([]string{required, requiresReplace}))
+	capellaschema.AddAttr(attrs, "timezone", onOffScheduleBuilder, stringAttribute([]string{required, requiresReplace},
+		validator.String(stringvalidator.OneOf(onOffScheduleTimezones...))))
 
 	timeBoundaryAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(timeBoundaryAttrs, "hour", onOffScheduleBuilder, onOffScheduleHourAttribute())


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-132232

## Description

### Problem                                                                                                                                                                                    
                                                                                                                                                                                                 
`couchbase-capella_cluster_onoff_schedule.timezone` is required for schedule interpretation, but had no local validation. `terraform validate` accepted `timezone = ""` (and any arbitrary string), deferring rejection to apply/API time.                                                                                                                                                
                                                                                                                                                                                                 
  ### Root Cause                                                                                                                                                                                 
                                                                                                                                                                                                 
  `SchemaBuilder.AddAttr` auto-attaches a `OneOf` enum validator via `enums.Lookup`. However, the generated `enumTable["ClusterOnOffSchedule"]["timezone"]` entry is empty `{}` — it derives from the *response* schema (`GetClusterOnOffScheduleResponse`), which carries no enum, and the builder resolves that schema name before the request schema. Since the empty `EnumDef` has `Type ==  ""`, `appendOneOfValidator`'s `def.Type != "string"` guard skips it, so no validator is attached.                                                                                              
                                                                                                                                                                                                 
  ### Change                                                                                                                                                                                     
                                                                                                                                                                                                 
  Added a hand-coded `stringvalidator.OneOf(onOffScheduleTimezones...)` at the `timezone` call site in `cluster_onoff_schedule_schema.go`, using the 27 documented V4 timezone values. This is the builder's intended override mechanism (a call-site validator wins over the auto-lookup) and matches how the `day` and `state` attributes in the same file already declare their enums. `OneOf` also covers the "must not be empty" requirement, since `""` is not a member of the set. 

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [X] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

**`terraform validate`** (dev-override build) against the Jira repro config:

- `timezone = ""` → rejected locally:
  ```
  Error: Invalid Attribute Value Match
    with couchbase-capella_cluster_onoff_schedule.empty_tz,
    on main.tf line 13, in resource "...":
    13:   timezone        = ""
  Attribute timezone value must be one of: ["Pacific/Midway" "US/Hawaii" ...], got: ""
  ```
- `timezone = "Mars/Olympus"` → rejected with the same enum diagnostic
- `timezone = "US/Pacific"` → `Success! The configuration is valid`

**Acceptance tests** — run against a live Capella sandbox cluster (`TF_ACC=1`):

```
--- PASS: TestAccClusterOnOffScheduleResource (4.37s)
--- PASS: TestAccClusterOnOffScheduleResourceInvalidTimezone (0.18s)
--- PASS: TestAccClusterOnOffScheduleEmptyTimezone (0.18s)
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests	793.884s
```

`TestAccClusterOnOffScheduleResource` confirms a valid timezone still creates/updates/imports correctly against the live cluster; the new `TestAccClusterOnOffScheduleEmptyTimezone` confirms `timezone = ""` is rejected at config validation.

</details>

## Further comments
