### PR TITLE
[AV-128971] Add certificate datasource tests; provision DM cluster lazily

### DIFF
--- a/acceptance_tests/certificate_datasource_test.go
+++ b/acceptance_tests/certificate_datasource_test.go
@@ -21,6 +21,7 @@ func TestAccDatasourceCertificate(t *testing.T) {
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
 					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(dsReference, "data.#", "1"),
 					resource.TestCheckResourceAttrSet(dsReference, "data.0.certificate"),
 				),
 			},
@@ -44,7 +45,7 @@ data "couchbase-capella_certificate" "%[2]s" {
   cluster_id      = "00000000-0000-0000-0000-000000000000"
 }
 `, globalProviderBlock, dsName, globalOrgId, globalProjectId),
-				ExpectError: regexp.MustCompile(`Error Reading Capella Certificate`),
+				ExpectError: regexp.MustCompile(`(?s)Error Reading Capella Certificate.*"httpStatusCode":(403|404)`),
 			},
 		},
 	})

--- a/acceptance_tests/certificate_datasource_test.go
+++ b/acceptance_tests/certificate_datasource_test.go
@@ -1,0 +1,63 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDatasourceCertificate(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_certificate_ds_")
+	dsReference := "data.couchbase-capella_certificate." + dsName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateDatasourceConfig(dsName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttrSet(dsReference, "data.0.certificate"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceCertificateInvalidCluster(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_certificate_ds_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_certificate" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "00000000-0000-0000-0000-000000000000"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId),
+				ExpectError: regexp.MustCompile(`Error Reading Capella Certificate`),
+			},
+		},
+	})
+}
+
+func testAccCertificateDatasourceConfig(dsName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_certificate" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId, globalClusterId)
+}

--- a/acceptance_tests/data_management_acceptance_test.go
+++ b/acceptance_tests/data_management_acceptance_test.go
@@ -10,9 +10,7 @@ import (
 )
 
 func TestAccBucketResourceRequiredOnly(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_req_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -51,9 +49,7 @@ func TestAccBucketResourceRequiredOnly(t *testing.T) {
 }
 
 func TestAccBucketResourceAllOptionalFields(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_full_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -84,9 +80,7 @@ func TestAccBucketResourceAllOptionalFields(t *testing.T) {
 }
 
 func TestAccBucketResourceUpdate(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_upd_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -120,9 +114,7 @@ func TestAccBucketResourceUpdate(t *testing.T) {
 }
 
 func TestAccBucketResourceEphemeralType(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_eph_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -165,9 +157,7 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccBucketResourceInvalidProject(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_bad_project_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -191,9 +181,7 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccBucketResourceInvalidDurabilityLevel(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_bad_dur_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -218,9 +206,7 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccBucketResourceInvalidReplicaCount(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_bad_rep_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -245,9 +231,7 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccScopeResource(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_scope_bkt_")
 	scopeName := randomStringWithPrefix("tf_acc_scope_")
 	bucketReference := "couchbase-capella_bucket." + bucketName
@@ -278,9 +262,7 @@ func TestAccScopeResource(t *testing.T) {
 }
 
 func TestAccScopeResourceInvalidBucket(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	scopeName := randomStringWithPrefix("tf_acc_scope_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -305,9 +287,7 @@ resource "couchbase-capella_scope" "%[2]s" {
 }
 
 func TestAccScopeResourceInvalidCluster(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	scopeName := randomStringWithPrefix("tf_acc_scope_bad_cluster_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -332,9 +312,7 @@ resource "couchbase-capella_scope" "%[2]s" {
 }
 
 func TestAccCollectionResourceNoTTL(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_coll_bkt_nottl_")
 	scopeName := randomStringWithPrefix("tf_acc_coll_scope_nottl_")
 	collName := randomStringWithPrefix("tf_acc_coll_nottl_")
@@ -366,9 +344,7 @@ func TestAccCollectionResourceNoTTL(t *testing.T) {
 }
 
 func TestAccCollectionResourceWithTTL(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_coll_bkt_ttl_")
 	scopeName := randomStringWithPrefix("tf_acc_coll_scope_ttl_")
 	collName := randomStringWithPrefix("tf_acc_coll_ttl_")
@@ -406,9 +382,7 @@ func TestAccCollectionResourceWithTTL(t *testing.T) {
 }
 
 func TestAccCollectionResourceInvalidScope(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	collName := randomStringWithPrefix("tf_acc_coll_bad_scope_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -423,9 +397,7 @@ func TestAccCollectionResourceInvalidScope(t *testing.T) {
 }
 
 func TestAccCollectionResourceInvalidBucket(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	collName := randomStringWithPrefix("tf_acc_coll_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -452,9 +424,7 @@ resource "couchbase-capella_collection" "%[2]s" {
 
 // AV-132307: API accepts negative max_ttl; restore ExpectError once fixed.
 func TestAccCollectionResourceNegativeTTL(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_coll_neg_ttl_bkt_")
 	scopeName := randomStringWithPrefix("tf_acc_coll_neg_ttl_scope_")
 	collName := randomStringWithPrefix("tf_acc_coll_neg_ttl_")
@@ -475,9 +445,7 @@ func TestAccCollectionResourceNegativeTTL(t *testing.T) {
 }
 
 func TestAccFlushBucketResource(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_flush_bkt_")
 	flushName := randomStringWithPrefix("tf_acc_flush_")
 	bucketReference := "couchbase-capella_bucket." + bucketName
@@ -500,9 +468,7 @@ func TestAccFlushBucketResource(t *testing.T) {
 }
 
 func TestAccFlushBucketResourceFlushDisabled(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_flush_disabled_bkt_")
 	flushName := randomStringWithPrefix("tf_acc_flush_disabled_")
 
@@ -518,9 +484,7 @@ func TestAccFlushBucketResourceFlushDisabled(t *testing.T) {
 }
 
 func TestAccFlushBucketResourceInvalidBucket(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	flushName := randomStringWithPrefix("tf_acc_flush_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -544,9 +508,7 @@ resource "couchbase-capella_flush" "%[2]s" {
 }
 
 func TestAccDatasourceBuckets(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_buckets_")
 	dsReference := "data.couchbase-capella_buckets." + dsName
 
@@ -592,9 +554,7 @@ data "couchbase-capella_buckets" "%[2]s" {
 }
 
 func TestAccDatasourceScopes(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_scopes_")
 	dsReference := "data.couchbase-capella_scopes." + dsName
 
@@ -617,9 +577,7 @@ func TestAccDatasourceScopes(t *testing.T) {
 }
 
 func TestAccDatasourceScopesInvalidBucket(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_scopes_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -643,9 +601,7 @@ data "couchbase-capella_scopes" "%[2]s" {
 }
 
 func TestAccDatasourceCollections(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_collections_")
 	dsReference := "data.couchbase-capella_collections." + dsName
 
@@ -670,9 +626,7 @@ func TestAccDatasourceCollections(t *testing.T) {
 }
 
 func TestAccDatasourceCollectionsInvalidScope(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_collections_bad_scope_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -697,9 +651,7 @@ data "couchbase-capella_collections" "%[2]s" {
 }
 
 func TestAccDatasourceCollectionsInvalidBucket(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_collections_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -724,9 +676,7 @@ data "couchbase-capella_collections" "%[2]s" {
 }
 
 func TestAccDatasourceSampleBuckets(t *testing.T) {
-	if err := ensureDMCluster(); err != nil {
-		t.Fatalf("ensureDMCluster: %v", err)
-	}
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_sample_buckets_")
 	dsReference := "data.couchbase-capella_sample_buckets." + dsName
 

--- a/acceptance_tests/data_management_acceptance_test.go
+++ b/acceptance_tests/data_management_acceptance_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestAccBucketResourceRequiredOnly(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	resourceName := randomStringWithPrefix("tf_acc_bkt_req_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -48,6 +51,9 @@ func TestAccBucketResourceRequiredOnly(t *testing.T) {
 }
 
 func TestAccBucketResourceAllOptionalFields(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	resourceName := randomStringWithPrefix("tf_acc_bkt_full_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -78,6 +84,9 @@ func TestAccBucketResourceAllOptionalFields(t *testing.T) {
 }
 
 func TestAccBucketResourceUpdate(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	resourceName := randomStringWithPrefix("tf_acc_bkt_upd_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -111,6 +120,9 @@ func TestAccBucketResourceUpdate(t *testing.T) {
 }
 
 func TestAccBucketResourceEphemeralType(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	resourceName := randomStringWithPrefix("tf_acc_bkt_eph_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -153,6 +165,9 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccBucketResourceInvalidProject(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	resourceName := randomStringWithPrefix("tf_acc_bkt_bad_project_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -176,6 +191,9 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccBucketResourceInvalidDurabilityLevel(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	resourceName := randomStringWithPrefix("tf_acc_bkt_bad_dur_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -200,6 +218,9 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccBucketResourceInvalidReplicaCount(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	resourceName := randomStringWithPrefix("tf_acc_bkt_bad_rep_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -224,6 +245,9 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccScopeResource(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	bucketName := randomStringWithPrefix("tf_acc_scope_bkt_")
 	scopeName := randomStringWithPrefix("tf_acc_scope_")
 	bucketReference := "couchbase-capella_bucket." + bucketName
@@ -254,6 +278,9 @@ func TestAccScopeResource(t *testing.T) {
 }
 
 func TestAccScopeResourceInvalidBucket(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	scopeName := randomStringWithPrefix("tf_acc_scope_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -278,6 +305,9 @@ resource "couchbase-capella_scope" "%[2]s" {
 }
 
 func TestAccScopeResourceInvalidCluster(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	scopeName := randomStringWithPrefix("tf_acc_scope_bad_cluster_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -302,6 +332,9 @@ resource "couchbase-capella_scope" "%[2]s" {
 }
 
 func TestAccCollectionResourceNoTTL(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	bucketName := randomStringWithPrefix("tf_acc_coll_bkt_nottl_")
 	scopeName := randomStringWithPrefix("tf_acc_coll_scope_nottl_")
 	collName := randomStringWithPrefix("tf_acc_coll_nottl_")
@@ -333,6 +366,9 @@ func TestAccCollectionResourceNoTTL(t *testing.T) {
 }
 
 func TestAccCollectionResourceWithTTL(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	bucketName := randomStringWithPrefix("tf_acc_coll_bkt_ttl_")
 	scopeName := randomStringWithPrefix("tf_acc_coll_scope_ttl_")
 	collName := randomStringWithPrefix("tf_acc_coll_ttl_")
@@ -370,6 +406,9 @@ func TestAccCollectionResourceWithTTL(t *testing.T) {
 }
 
 func TestAccCollectionResourceInvalidScope(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	collName := randomStringWithPrefix("tf_acc_coll_bad_scope_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -384,6 +423,9 @@ func TestAccCollectionResourceInvalidScope(t *testing.T) {
 }
 
 func TestAccCollectionResourceInvalidBucket(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	collName := randomStringWithPrefix("tf_acc_coll_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -410,6 +452,9 @@ resource "couchbase-capella_collection" "%[2]s" {
 
 // AV-132307: API accepts negative max_ttl; restore ExpectError once fixed.
 func TestAccCollectionResourceNegativeTTL(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	bucketName := randomStringWithPrefix("tf_acc_coll_neg_ttl_bkt_")
 	scopeName := randomStringWithPrefix("tf_acc_coll_neg_ttl_scope_")
 	collName := randomStringWithPrefix("tf_acc_coll_neg_ttl_")
@@ -430,6 +475,9 @@ func TestAccCollectionResourceNegativeTTL(t *testing.T) {
 }
 
 func TestAccFlushBucketResource(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	bucketName := randomStringWithPrefix("tf_acc_flush_bkt_")
 	flushName := randomStringWithPrefix("tf_acc_flush_")
 	bucketReference := "couchbase-capella_bucket." + bucketName
@@ -452,6 +500,9 @@ func TestAccFlushBucketResource(t *testing.T) {
 }
 
 func TestAccFlushBucketResourceFlushDisabled(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	bucketName := randomStringWithPrefix("tf_acc_flush_disabled_bkt_")
 	flushName := randomStringWithPrefix("tf_acc_flush_disabled_")
 
@@ -467,6 +518,9 @@ func TestAccFlushBucketResourceFlushDisabled(t *testing.T) {
 }
 
 func TestAccFlushBucketResourceInvalidBucket(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	flushName := randomStringWithPrefix("tf_acc_flush_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -490,6 +544,9 @@ resource "couchbase-capella_flush" "%[2]s" {
 }
 
 func TestAccDatasourceBuckets(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	dsName := randomStringWithPrefix("tf_acc_ds_buckets_")
 	dsReference := "data.couchbase-capella_buckets." + dsName
 
@@ -535,6 +592,9 @@ data "couchbase-capella_buckets" "%[2]s" {
 }
 
 func TestAccDatasourceScopes(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	dsName := randomStringWithPrefix("tf_acc_ds_scopes_")
 	dsReference := "data.couchbase-capella_scopes." + dsName
 
@@ -557,6 +617,9 @@ func TestAccDatasourceScopes(t *testing.T) {
 }
 
 func TestAccDatasourceScopesInvalidBucket(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	dsName := randomStringWithPrefix("tf_acc_ds_scopes_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -580,6 +643,9 @@ data "couchbase-capella_scopes" "%[2]s" {
 }
 
 func TestAccDatasourceCollections(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	dsName := randomStringWithPrefix("tf_acc_ds_collections_")
 	dsReference := "data.couchbase-capella_collections." + dsName
 
@@ -604,6 +670,9 @@ func TestAccDatasourceCollections(t *testing.T) {
 }
 
 func TestAccDatasourceCollectionsInvalidScope(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	dsName := randomStringWithPrefix("tf_acc_ds_collections_bad_scope_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -628,6 +697,9 @@ data "couchbase-capella_collections" "%[2]s" {
 }
 
 func TestAccDatasourceCollectionsInvalidBucket(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	dsName := randomStringWithPrefix("tf_acc_ds_collections_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -652,6 +724,9 @@ data "couchbase-capella_collections" "%[2]s" {
 }
 
 func TestAccDatasourceSampleBuckets(t *testing.T) {
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
 	dsName := randomStringWithPrefix("tf_acc_ds_sample_buckets_")
 	dsReference := "data.couchbase-capella_sample_buckets." + dsName
 

--- a/acceptance_tests/dm_setup.go
+++ b/acceptance_tests/dm_setup.go
@@ -1,0 +1,43 @@
+package acceptance_tests
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+)
+
+var (
+	dmClusterOnce sync.Once
+	dmClusterErr  error
+)
+
+// ensureDMCluster lazily provisions the dedicated data-management cluster (and
+// its bucket) used by the data_management_* acceptance tests. It is built on
+// first call from the first DM test that runs and reused thereafter, so runs
+// that exercise no DM tests don't pay the cluster-creation cost. cleanup()
+// tears it down via the dmClusterCreated/dmBucketCreated flags.
+func ensureDMCluster() error {
+	dmClusterOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Minute)
+		defer cancel()
+		client := api.NewClient(timeout)
+
+		if err := setupDMCluster(ctx, client); err != nil {
+			dmClusterErr = err
+			return
+		}
+		if err := resolveDMBucket(ctx, client); err != nil {
+			dmClusterErr = err
+			return
+		}
+		// Bucket creation triggers a rebalance; wait for the cluster to return
+		// to Healthy before dependent resources are created.
+		if err := dmClusterWait(ctx, client, false); err != nil {
+			dmClusterErr = err
+			return
+		}
+	})
+	return dmClusterErr
+}

--- a/acceptance_tests/dm_setup.go
+++ b/acceptance_tests/dm_setup.go
@@ -3,6 +3,7 @@ package acceptance_tests
 import (
 	"context"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
@@ -12,6 +13,16 @@ var (
 	dmClusterOnce sync.Once
 	dmClusterErr  error
 )
+
+// requireDMCluster ensures the data-management cluster is provisioned, failing
+// the test if provisioning errored. DM tests call this before building their
+// config so dmClusterId/dmBucketId are populated.
+func requireDMCluster(t *testing.T) {
+	t.Helper()
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
+}
 
 // ensureDMCluster lazily provisions the dedicated data-management cluster (and
 // its bucket) used by the data_management_* acceptance tests. It is built on

--- a/acceptance_tests/setup_test.go
+++ b/acceptance_tests/setup_test.go
@@ -104,16 +104,8 @@ func setup(ctx context.Context, client *api.Client) error {
 		return err
 	}
 
-	if err := setupDMCluster(ctx, client); err != nil {
-		return err
-	}
-
-	if err := resolveDMBucket(ctx, client); err != nil {
-		return err
-	}
-	if err := dmClusterWait(ctx, client, false); err != nil {
-		return err
-	}
+	// The data-management cluster is provisioned lazily by ensureDMCluster()
+	// from the first data_management_* test that runs, so non-DM runs skip it.
 
 	// Create app service only if not provided via env var
 	if globalAppServiceId == "" {


### PR DESCRIPTION
## Jira

* [AV-128971](https://jira.issues.couchbase.com/browse/AV-128971)

## Description

Two changes, both scoped to the acceptance-test harness:

1. **Certificate datasource tests** — adds coverage for the existing `couchbase-capella_certificate` data source. Tests run against the shared global test cluster (`globalClusterId`); no dedicated cluster is created.
   - `TestAccDatasourceCertificate` — reads the certificate for the shared cluster and asserts the identifiers, that exactly one certificate object is returned (`data.# == 1`), and that `data.0.certificate` is populated.
   - `TestAccDatasourceCertificateInvalidCluster` — asserts the read fails for a non-existent cluster ID, matching the `Error Reading Capella Certificate` diagnostic and the embedded `httpStatusCode` (403/404).

2. **Lazy data-management cluster provisioning** — the DM cluster/bucket used by the `data_management_*` tests was created eagerly in `TestMain` setup, so *every* acceptance run (including the certificate-only run) paid the ~30-min DM cluster cost. It is now provisioned on demand via `ensureDMCluster()` (mirroring the existing `ensureSnapshotCluster()` pattern): the 25 DM tests that need the cluster call it up front, and runs that exercise no DM tests skip it entirely. Teardown is unchanged — `cleanup()` already tears down conditionally via the `dmClusterCreated`/`dmBucketCreated` flags.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  Local goimports, go vet, build, and `go test -c ./acceptance_tests` all pass. Behavior is verified by the Acceptance Tests CI run on this PR.
</details>

## Further comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AV-128971]: https://couchbasecloud.atlassian.net/browse/AV-128971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ