### PR TITLE
[AV-134037] Auto-attach enum validators for -to-named-enum fields

### DIFF
--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -81,7 +81,26 @@ func TestAccClusterOnOffScheduleResourceInvalidTimezone(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccClusterOnOffScheduleResourceConfig(resourceName, "Mars/Olympus"),
-				ExpectError: regexp.MustCompile(`(?s)timezone|invalid value|Validation Error`),
+				ExpectError: regexp.MustCompile(`must be one of`),
+			},
+		},
+	})
+}
+
+// TestAccClusterOnOffScheduleEmptyTimezone verifies that an empty timezone is
+// rejected by local config validation at terraform validate. The timezone enum
+// validator is attached automatically by the schema builder from the OpenAPI
+// spec (no hand-coded list), so this also exercises the generator's handling of
+// $ref-to-named-enum properties.
+func TestAccClusterOnOffScheduleEmptyTimezone(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_empty_tz_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccClusterOnOffScheduleResourceConfig(resourceName, ""),
+				ExpectError: regexp.MustCompile(`must be one of`),
 			},
 		},
 	})

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -81,7 +81,7 @@ func TestAccClusterOnOffScheduleResourceInvalidTimezone(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccClusterOnOffScheduleResourceConfig(resourceName, "Mars/Olympus"),
-				ExpectError: regexp.MustCompile(`must be one of`),
+				ExpectError: regexp.MustCompile(`timezone value must be one of`),
 			},
 		},
 	})
@@ -100,7 +100,7 @@ func TestAccClusterOnOffScheduleEmptyTimezone(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccClusterOnOffScheduleResourceConfig(resourceName, ""),
-				ExpectError: regexp.MustCompile(`must be one of`),
+				ExpectError: regexp.MustCompile(`timezone value must be one of`),
 			},
 		},
 	})

--- a/internal/generated/enums/enums.gen.go
+++ b/internal/generated/enums/enums.gen.go
@@ -43,6 +43,9 @@ var enumTable = map[string]map[string]EnumDef{
 	"CloudProvider": {
 		"type": {Type: "string", Values: []string{"aws", "gcp", "azure"}},
 	},
+	"ClusterOnOffSchedule": {
+		"timezone": {Type: "string", Values: []string{"Pacific/Midway", "US/Hawaii", "US/Alaska", "US/Pacific", "US/Mountain", "US/Central", "US/Eastern", "America/Puerto_Rico", "Canada/Newfoundland", "America/Argentina/Buenos_Aires", "Atlantic/Cape_Verde", "Europe/London", "Europe/Amsterdam", "Europe/Athens", "Africa/Nairobi", "Asia/Tehran", "Indian/Mauritius", "Asia/Karachi", "Asia/Calcutta", "Asia/Dhaka", "Asia/Bangkok", "Asia/Hong_Kong", "Asia/Tokyo", "Australia/North", "Australia/Sydney", "Pacific/Ponape", "Antarctica/South_Pole"}},
+	},
 	"ColumnarAnalyticsOnOffSchedule": {
 		"timezone": {Type: "string", Values: []string{"Pacific/Midway", "US/Hawaii", "US/Alaska", "US/Pacific", "US/Mountain", "US/Central", "US/Eastern", "America/Puerto_Rico", "Canada/Newfoundland", "America/Argentina/Buenos_Aires", "Atlantic/Cape_Verde", "Europe/London", "Europe/Amsterdam", "Europe/Athens", "Africa/Nairobi", "Asia/Tehran", "Indian/Mauritius", "Asia/Karachi", "Asia/Calcutta", "Asia/Dhaka", "Asia/Bangkok", "Asia/Hong_Kong", "Asia/Tokyo", "Australia/North", "Australia/Sydney", "Pacific/Ponape", "Antarctica/South_Pole"}},
 	},
@@ -60,17 +63,30 @@ var enumTable = map[string]map[string]EnumDef{
 		"logKeys":  {Type: "string", IsArray: true, Values: []string{"Admin", "Access", "Auth", "Cache", "Changes", "CRUD", "HTTP", "HTTP+", "Import", "Javascript", "Query", "Sync", "SyncMsg"}},
 		"logLevel": {Type: "string", Values: []string{"info", "warn", "error"}},
 	},
+	"CreateAPIKeyRequest": {
+		"organizationRoles": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator"}},
+	},
 	"CreateAlertRequest": {
 		"kind": {Type: "string", Values: []string{"webhook"}},
 	},
 	"CreateBucketRequest": {
-		"vbuckets": {Type: "integer", Values: []string{"128", "1024"}},
+		"bucketConflictResolution": {Type: "string", Values: []string{"seqno", "lww"}},
+		"durabilityLevel":          {Type: "string", Values: []string{"none", "majority", "majorityAndPersistActive", "persistToMajority"}},
+		"evictionPolicy":           {Type: "string", Values: []string{"fullEviction", "noEviction", "nruEviction"}},
+		"replicas":                 {Type: "integer", Values: []string{"1", "2", "3"}},
+		"storageBackend":           {Type: "string", Values: []string{"couchstore", "magma"}},
+		"type":                     {Type: "string", Values: []string{"couchbase", "ephemeral"}},
+		"vbuckets":                 {Type: "integer", Values: []string{"128", "1024"}},
+	},
+	"CreateClusterRequest": {
+		"configurationType": {Type: "string", Values: []string{"singleNode", "multiNode"}},
 	},
 	"CreateColumnarAnalyticsClusterRequest": {
 		"cloudProvider": {Type: "string", Values: []string{"aws", "gcp"}},
 	},
 	"CreateOnDemandRestoreRequest": {
 		"replaceTTL": {Type: "string", Values: []string{"none", "all", "expired"}},
+		"services":   {Type: "string", IsArray: true, Values: []string{"data", "query"}},
 	},
 	"CreatePrivateEndpointResponse": {
 		"status": {Type: "string", Values: []string{"pending", "pendingAcceptance", "linked", "rejected", "failed", "unrecognized"}},
@@ -98,6 +114,9 @@ var enumTable = map[string]map[string]EnumDef{
 		"unstructuredDataProcessingConfig.chunkingStrategy.strategyType": {Type: "string", Values: []string{"RECURSIVE_SPLITTER", "SEMANTIC_SPLITTER", "PARAGRAPH_SPLITTER", "SENTENCE_SPLITTER", "FIXED_TOKEN_SPLITTER"}},
 		"unstructuredDataProcessingConfig.exclusions":                    {Type: "string", IsArray: true, Values: []string{"header", "footer", "table"}},
 	},
+	"CreateUserRequest": {
+		"organizationRoles": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator"}},
+	},
 	"CreateWorkflowRequest": {
 		"type": {Type: "string", Values: []string{"structuredDataProcessing", "unstructuredDataProcessing", "vectorization"}},
 	},
@@ -121,6 +140,9 @@ var enumTable = map[string]map[string]EnumDef{
 	"ExternalModel": {
 		"external.modelName": {Type: "string", Values: []string{"text-embedding-3-small", "text-embedding-3-large", "text-embedding-ada-002"}},
 	},
+	"GetAPIKey": {
+		"organizationRoles": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator"}},
+	},
 	"GetAlertResponse": {
 		"kind": {Type: "string", Values: []string{"webhook"}},
 	},
@@ -128,17 +150,45 @@ var enumTable = map[string]map[string]EnumDef{
 		"state":       {Type: "string", Values: []string{"enabled", "enabling", "disabled", "disabling", "failed"}},
 		"targetState": {Type: "string", Values: []string{"enabled", "disabled"}},
 	},
+	"GetAppServiceResponse": {
+		"currentState": {Type: "string", Values: []string{"pending", "deploying", "deploymentFailed", "destroying", "destroyFailed", "healthy", "degraded", "scaling", "scaleFailed", "upgrading", "upgradeFailed", "turnedOff", "turningOff", "turnOffFailed", "turningOn", "turnOnFailed"}},
+		"plan":         {Type: "string", Values: []string{"basic", "developer pro", "enterprise"}},
+	},
+	"GetBackupByIDResponse": {
+		"method": {Type: "string", Values: []string{"incremental", "full"}},
+		"source": {Type: "string", Values: []string{"manual", "scheduled"}},
+		"status": {Type: "string", Values: []string{"pending", "ready", "failed"}},
+	},
+	"GetBackupResponse": {
+		"method": {Type: "string", Values: []string{"incremental", "full"}},
+		"source": {Type: "string", Values: []string{"manual", "scheduled"}},
+		"status": {Type: "string", Values: []string{"pending", "ready", "failed"}},
+	},
 	"GetBucketResponse": {
-		"vbuckets": {Type: "integer", Values: []string{"128", "1024"}},
+		"evictionPolicy": {Type: "string", Values: []string{"fullEviction", "noEviction", "nruEviction"}},
+		"vbuckets":       {Type: "integer", Values: []string{"128", "1024"}},
 	},
 	"GetClusterAuditLogExportResponse": {
 		"status": {Type: "string", Values: []string{"In Progress", "Completed", "Queued", "Failed"}},
 	},
 	"GetClusterOnOffScheduleResponse": {
 		"activationStatus": {Type: "string", Values: []string{"active", "paused"}},
+		"timezone":         {Type: "string", Values: []string{"Pacific/Midway", "US/Hawaii", "US/Alaska", "US/Pacific", "US/Mountain", "US/Central", "US/Eastern", "America/Puerto_Rico", "Canada/Newfoundland", "America/Argentina/Buenos_Aires", "Atlantic/Cape_Verde", "Europe/London", "Europe/Amsterdam", "Europe/Athens", "Africa/Nairobi", "Asia/Tehran", "Indian/Mauritius", "Asia/Karachi", "Asia/Calcutta", "Asia/Dhaka", "Asia/Bangkok", "Asia/Hong_Kong", "Asia/Tokyo", "Australia/North", "Australia/Sydney", "Pacific/Ponape", "Antarctica/South_Pole"}},
 	},
 	"GetClusterResponse": {
-		"expressScaling": {Type: "string", Values: []string{"enabled", "disabled"}},
+		"configurationType": {Type: "string", Values: []string{"singleNode", "multiNode"}},
+		"currentState":      {Type: "string", Values: []string{"draft", "deploying", "scaling", "upgrading", "rebalancing", "peering", "destroying", "healthy", "degraded", "turnedOff", "turningOff", "turningOn", "deploymentFailed", "scaleFailed", "upgradeFailed", "rebalanceFailed", "peeringFailed", "destroyFailed", "offline", "turningOffFailed", "turningOnFailed"}},
+		"expressScaling":    {Type: "string", Values: []string{"enabled", "disabled"}},
+	},
+	"GetClusterSupport": {
+		"plan":     {Type: "string", Values: []string{"basic", "developer pro", "enterprise"}},
+		"timezone": {Type: "string", Values: []string{"ET", "GMT", "IST", "PT"}},
+	},
+	"GetColumnarAnalyticsClusterResponse": {
+		"currentState": {Type: "string", Values: []string{"deploying", "deploymentFailed", "destroying", "destroyFailed", "healthy", "scaling", "scaleFailed", "turningOff", "turnedOff", "turningOn"}},
+	},
+	"GetLanguageModelResponse": {
+		"model.actions": {Type: "string", IsArray: true, Values: []string{"deploy", "delete", "pause", "resume"}},
 	},
 	"GetLogStreamingResponse": {
 		"configState":    {Type: "string", Values: []string{"disabled", "disabling", "enabled", "enabling", "paused", "pausing", "errored"}},
@@ -167,7 +217,8 @@ var enumTable = map[string]map[string]EnumDef{
 		"unstructuredDataProcessingConfig.exclusions":                    {Type: "string", IsArray: true, Values: []string{"header", "footer", "table"}},
 	},
 	"GetUserResponse": {
-		"status": {Type: "string", Values: []string{"verified", "not-verified", "pending-primary"}},
+		"organizationRoles": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator"}},
+		"status":            {Type: "string", Values: []string{"verified", "not-verified", "pending-primary"}},
 	},
 	"GetWorkflowResponse": {
 		"type": {Type: "string", Values: []string{"structuredDataProcessing", "unstructuredDataProcessing", "vectorization"}},
@@ -188,7 +239,8 @@ var enumTable = map[string]map[string]EnumDef{
 		"op": {Type: "string", Values: []string{"update"}},
 	},
 	"PatchEntry": {
-		"op": {Type: "string", Values: []string{"add", "remove"}},
+		"op":    {Type: "string", Values: []string{"add", "remove"}},
+		"value": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator", "projectOwner", "projectManager", "projectViewer", "projectDataReaderWriter", "projectDataReader"}},
 	},
 	"PostLogStreamingRequest": {
 		"outputType": {Type: "string", Values: []string{"datadog", "generic_http", "sumologic", "loki", "elastic", "splunk", "dynatrace"}},
@@ -205,15 +257,29 @@ var enumTable = map[string]map[string]EnumDef{
 	"RequestWebhook": {
 		"method": {Type: "string", Values: []string{"POST", "PUT"}},
 	},
+	"Resource": {
+		"roles": {Type: "string", IsArray: true, Values: []string{"projectOwner", "projectManager", "projectViewer", "projectDataReaderWriter", "projectDataReader"}},
+		"type":  {Type: "string", Values: []string{"project"}},
+	},
 	"ResponseWebhook": {
 		"method": {Type: "string", Values: []string{"POST", "PUT"}},
 	},
 	"ResyncStatus": {
 		"state": {Type: "string", Values: []string{"running", "completed", "stopping", "stopped", "error"}},
 	},
+	"ServiceGroup": {
+		"services": {Type: "string", IsArray: true, Values: []string{"data", "query", "index", "search", "analytics", "eventing"}},
+	},
+	"Support": {
+		"plan":     {Type: "string", Values: []string{"basic", "developer pro", "enterprise"}},
+		"timezone": {Type: "string", Values: []string{"ET", "GMT", "IST", "PT"}},
+	},
 	"UpdateBucketRequest": {
 		"durabilityLevel": {Type: "string", Values: []string{"none", "majority", "majorityAndPersistActive", "persistToMajority"}},
 		"replicas":        {Type: "integer", Values: []string{"1", "2", "3"}},
+	},
+	"UpdateClusterResponse": {
+		"currentState": {Type: "string", Values: []string{"draft", "deploying", "scaling", "upgrading", "rebalancing", "peering", "destroying", "healthy", "degraded", "turnedOff", "turningOff", "turningOn", "deploymentFailed", "scaleFailed", "upgradeFailed", "rebalanceFailed", "peeringFailed", "destroyFailed", "offline", "turningOffFailed", "turningOnFailed"}},
 	},
 	"UpdateReplicationRequest": {
 		"priority": {Type: "string", Values: []string{"low", "medium", "high"}},

--- a/internal/generated/enums/generate/discover.go
+++ b/internal/generated/enums/generate/discover.go
@@ -332,10 +332,10 @@ func (w *walker) run() {
 	}
 }
 
-// schema visits a single schema node. Property $refs are skipped — those schemas
-// are visited independently as top-level entries in run. Composition keywords
-// (allOf/oneOf/anyOf) are traversed transparently: branches contribute to the
-// same logical field, and dedupByID merges any colliding sites at the end.
+// schema visits a single schema node. Object-typed property $refs are skipped
+// (visited as top-level entries in run); scalar-enum $refs are captured via
+// refEnum. Composition keywords (allOf/oneOf/anyOf) are traversed transparently
+// and dedupByID merges colliding sites at the end.
 func (w *walker) schema(id string, s *openapi3.Schema, schemaName, fieldPath, sourcePath string, sc scope) {
 	if s == nil {
 		return
@@ -370,16 +370,52 @@ func (w *walker) schema(id string, s *openapi3.Schema, schemaName, fieldPath, so
 		w.recordConstraints(s, schemaName, fieldPath, sourcePath)
 	}
 	for fieldName, propRef := range s.Properties {
-		if propRef == nil || propRef.Ref != "" || propRef.Value == nil {
+		if propRef == nil || propRef.Value == nil {
 			continue
 		}
-		w.schema(
-			id+"_"+toPascal(fieldName), propRef.Value,
-			schemaName, joinPath(fieldPath, fieldName),
-			sourcePath+".properties."+fieldName, sc,
-		)
+		childID := id + "_" + toPascal(fieldName)
+		childPath := joinPath(fieldPath, fieldName)
+		childSource := sourcePath + ".properties." + fieldName
+		// Skip object $refs (walked top-level); capture scalar-enum $refs.
+		if propRef.Ref != "" {
+			w.refEnum(childID, propRef.Value, schemaName, childPath, childSource, sc)
+			continue
+		}
+		w.schema(childID, propRef.Value, schemaName, childPath, childSource, sc)
 	}
 	w.items(id, s, schemaName, fieldPath, sourcePath, sc)
+}
+
+// refEnum records an enum site for a $ref target that is a scalar enum (or an
+// array of one). Object targets are ignored — they are walked top-level.
+func (w *walker) refEnum(id string, v *openapi3.Schema, schemaName, fieldPath, sourcePath string, sc scope) {
+	if v == nil {
+		return
+	}
+	if len(v.Enum) > 0 {
+		w.sites = append(w.sites, enumSite{
+			ID:         id,
+			Scope:      sc,
+			SchemaName: schemaName,
+			FieldPath:  fieldPath,
+			Type:       typeOf(v),
+			Values:     enumValues(v.Enum),
+			SourcePath: sourcePath,
+		})
+		return
+	}
+	if v.Items != nil && v.Items.Value != nil && len(v.Items.Value.Enum) > 0 {
+		iv := v.Items.Value
+		w.sites = append(w.sites, enumSite{
+			ID:         id + "_Item",
+			Scope:      sc,
+			SchemaName: schemaName,
+			FieldPath:  joinPath(fieldPath, "[]"),
+			Type:       typeOf(iv),
+			Values:     enumValues(iv.Enum),
+			SourcePath: sourcePath + ".items",
+		})
+	}
 }
 
 func (w *walker) composition(id string, refs openapi3.SchemaRefs, schemaName, fieldPath, sourcePath string, sc scope, kw string) {
@@ -502,7 +538,12 @@ func (w *walker) recordConstraints(s *openapi3.Schema, schemaName, fieldPath, so
 }
 
 func (w *walker) items(id string, s *openapi3.Schema, schemaName, fieldPath, sourcePath string, sc scope) {
-	if s.Items == nil || s.Items.Ref != "" || s.Items.Value == nil {
+	if s.Items == nil || s.Items.Value == nil {
+		return
+	}
+	// Skip object $ref items (walked top-level); capture scalar-enum ones.
+	if s.Items.Ref != "" {
+		w.refEnum(id+"_Item", s.Items.Value, schemaName, joinPath(fieldPath, "[]"), sourcePath+".items", sc)
 		return
 	}
 	w.schema(id+"_Item", s.Items.Value, schemaName, joinPath(fieldPath, "[]"), sourcePath+".items", sc)

--- a/internal/generated/enums/generate/discover_test.go
+++ b/internal/generated/enums/generate/discover_test.go
@@ -241,8 +241,9 @@ func TestWalker_NestedProperty(t *testing.T) {
 }
 
 func TestWalker_PropertyRefSkipped(t *testing.T) {
-	// A $ref'd property should not be inlined; the referenced schema is
-	// visited as its own top-level entry instead.
+	// An unresolved $ref property (Value nil) is skipped; the referenced schema
+	// is visited as its own top-level entry instead. (Resolved scalar-enum refs
+	// are captured — see TestWalker_PropertyRefScalarEnumCaptured.)
 	doc := &openapi3.T{
 		Components: &openapi3.Components{
 			Schemas: openapi3.Schemas{
@@ -299,6 +300,100 @@ func TestWalker_ArrayItems(t *testing.T) {
 	}
 	if got.ID != "Roles_Roles_Item" {
 		t.Errorf("ID = %q, want Roles_Roles_Item", got.ID)
+	}
+}
+
+func TestWalker_PropertyRefScalarEnumCaptured(t *testing.T) {
+	// A property whose resolved $ref target is a scalar enum is captured under
+	// (schema, field) — the case the generator previously dropped (the enum
+	// reached only the field-less top-level site, which buildEnumTable discards).
+	tz := &openapi3.Schema{Type: &openapi3.Types{"string"}, Enum: []any{"PT", "ET"}}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"onOffTimezone": refOf(tz),
+				"Schedule": refOf(&openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"timezone": resolvedRef("#/components/schemas/onOffTimezone", tz),
+					},
+				}),
+			},
+		},
+	}
+
+	sites := runWalker(t, doc)
+	got, ok := findSite(sites, "Schedule", "timezone")
+	if !ok {
+		t.Fatalf("want a Schedule.timezone site, got %v", idsOf(sites))
+	}
+	if got.ID != "Schedule_Timezone" || got.Type != "string" {
+		t.Errorf("unexpected site: %+v", got)
+	}
+	if !equalStrings(got.Values, []string{"PT", "ET"}) {
+		t.Errorf("values = %v, want [PT ET]", got.Values)
+	}
+}
+
+func TestWalker_ArrayItemRefScalarEnumCaptured(t *testing.T) {
+	// An array whose items resolve to a scalar-enum $ref is captured at "[]".
+	role := &openapi3.Schema{Type: &openapi3.Types{"string"}, Enum: []any{"admin", "viewer"}}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"Role": refOf(role),
+				"User": refOf(&openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"roles": refOf(&openapi3.Schema{
+							Type:  &openapi3.Types{"array"},
+							Items: resolvedRef("#/components/schemas/Role", role),
+						}),
+					},
+				}),
+			},
+		},
+	}
+
+	sites := runWalker(t, doc)
+	got, ok := findSite(sites, "User", "roles.[]")
+	if !ok {
+		t.Fatalf("want a User.roles.[] site, got %v", idsOf(sites))
+	}
+	if !equalStrings(got.Values, []string{"admin", "viewer"}) {
+		t.Errorf("values = %v, want [admin viewer]", got.Values)
+	}
+}
+
+func TestWalker_ObjectRefPropertyNotInlined(t *testing.T) {
+	// A property whose resolved $ref target is an object is NOT inlined; only
+	// the object's own top-level visit records its inner enum.
+	inner := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"kind": refOf(&openapi3.Schema{Type: &openapi3.Types{"string"}, Enum: []any{"a", "b"}}),
+		},
+	}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"Inner": refOf(inner),
+				"Container": refOf(&openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"inner": resolvedRef("#/components/schemas/Inner", inner),
+					},
+				}),
+			},
+		},
+	}
+
+	sites := runWalker(t, doc)
+	if _, ok := findSite(sites, "Container", "inner.kind"); ok {
+		t.Errorf("object $ref property must not be inlined; got Container.inner.kind in %v", idsOf(sites))
+	}
+	if _, ok := findSite(sites, "Inner", "kind"); !ok {
+		t.Errorf("want Inner.kind from the top-level visit, got %v", idsOf(sites))
 	}
 }
 
@@ -416,6 +511,21 @@ func TestWalker_SortedOutput(t *testing.T) {
 
 func refOf(s *openapi3.Schema) *openapi3.SchemaRef {
 	return &openapi3.SchemaRef{Value: s}
+}
+
+// resolvedRef mimics what the OpenAPI loader produces for a property/item $ref:
+// both the Ref string and the resolved target Value are populated.
+func resolvedRef(ref string, s *openapi3.Schema) *openapi3.SchemaRef {
+	return &openapi3.SchemaRef{Ref: ref, Value: s}
+}
+
+func findSite(sites []enumSite, schemaName, fieldPath string) (enumSite, bool) {
+	for _, s := range sites {
+		if s.SchemaName == schemaName && s.FieldPath == fieldPath {
+			return s, true
+		}
+	}
+	return enumSite{}, false
 }
 
 func runWalker(t *testing.T, doc *openapi3.T) []enumSite {

--- a/internal/generated/enums/generate/generator_test.go
+++ b/internal/generated/enums/generate/generator_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 func TestBuildEnumTable(t *testing.T) {
@@ -92,6 +94,39 @@ func TestBuildEnumTable(t *testing.T) {
 			t.Errorf("top-level enum sites must be excluded, got %#v", got)
 		}
 	})
+}
+
+func TestBuildEnumTable_RefEnumPopulatesField(t *testing.T) {
+	// End-to-end regression for the $ref-to-named-enum gap: a property that
+	// $refs a scalar enum schema must yield a populated (schema, field) entry
+	// instead of being dropped as a field-less top-level enum.
+	tz := &openapi3.Schema{Type: &openapi3.Types{"string"}, Enum: []any{"PT", "ET"}}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"onOffTimezone": {Value: tz},
+				"Schedule": {Value: &openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"timezone": {Ref: "#/components/schemas/onOffTimezone", Value: tz},
+					},
+				}},
+			},
+		},
+	}
+
+	sites, err := discoverDoc(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	table := buildEnumTable(sites)
+	def, ok := table["Schedule"]["timezone"]
+	if !ok {
+		t.Fatalf("Schedule.timezone missing from enum table: %#v", table)
+	}
+	if def.Type != "string" || !reflect.DeepEqual(def.Values, []string{"PT", "ET"}) {
+		t.Errorf("unexpected def: %#v", def)
+	}
 }
 
 func TestIsArrayLiteral(t *testing.T) {


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-134037
* AV-132232

## Description

 ### Problem                                                                                                                                                                                    
                                                                                                                                                                                                 
  The enum generator silently dropped enum metadata for any schema property whose OpenAPI type is a **`$ref` to a named scalar-enum schema**, so `SchemaBuilder.AddAttr` attached no `OneOf` validator for those fields. Invalid values passed `terraform validate` and were only rejected later by the API. This is the root cause behind AV-132232 (cluster on/off schedule accepted an empty `timezone`), and it affected other fields too.                                                                                                                                           
                                                                                                                                                                                                 
  ### Root cause                                                                                                                                                                                 
                                                                                                                                                                                                 
  1. `discover.go` skips property `$ref`s (`propRef.Ref != "" -> continue`), assuming the target schema is captured independently as a top-level component.                                      
  2. In the spec, `ClusterOnOffSchedule.timezone` is `{"$ref": "#/components/schemas/onOffTimezone"}` (a shared `string` enum), so the property is skipped.                                      
  3. `onOffTimezone` is visited top-level, but as a bare enum it produces a site with an **empty field path**, which `buildEnumTable` discards.                                                  
                                                                                                                                                                                                 
The enum reached neither the property nor the table. (`ColumnarAnalyticsOnOffSchedule.timezone` only worked because the spec defines it **inline**.)    

### Change                                                                                                                                                                                     
                                                                                                                                                                                                 
  - `discover.go`: capture the enum on a property/array item when its `$ref` target is a scalar enum, via a new `refEnum` helper. Object `$ref`s are still walked top-level (unchanged).         
  - Regenerated `internal/generated/enums/enums.gen.go` — **24 previously missing entries** are now populated, so the builder auto-attaches `OneOf` validators (no hand-coded lists).            
  - Added `TestAccClusterOnOffScheduleEmptyTimezone`; tightened the invalid-timezone test regex to the `OneOf` message.  

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

**Generator / unit:** `go test ./internal/generated/enums/...` passes; versioned build and `go vet` clean. The regeneration populated 24 previously-missing enum entries.

**`terraform validate`** (dev-override build) across every newly-enforced writable field:

- Invalid values rejected locally with the `OneOf` diagnostic:
  - `timezone = ""` (cluster on/off schedule) → `Attribute timezone value must be one of: ["Pacific/Midway" ...]`
  - `bucket_conflict_resolution = "bogus"` → `must be one of: ["seqno" "lww"]`
  - `configuration_type = "tripleNode"` → `must be one of: ["singleNode" "multiNode"]`
  - `support.timezone = "ZZ"` → `must be one of: ["ET" "GMT" "IST" "PT"]`
- Valid values pass — `US/Pacific`, `seqno`, `multiNode`, `PT` → `Success! The configuration is valid`.

**Acceptance tests** — run against a live Capella sandbox (`TF_ACC=1`):

```
--- PASS: TestAccClusterOnOffScheduleResourceInvalidTimezone (2.16s)
--- PASS: TestAccClusterOnOffScheduleEmptyTimezone (2.16s)
--- PASS: TestAccBucketResourceRequiredOnly (5.12s)
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests	854.280s
```

`TestAccClusterOnOffScheduleEmptyTimezone` confirms the timezone enum is now validated automatically (no hand-coded list — the validator is attached by the generator-populated table). `TestAccBucketResourceRequiredOnly` confirms the newly-enforced `bucket_conflict_resolution` default does not break bucket creation.

</details>

## Further comments
