### PR TITLE
[AV-131313] Add load balancer CIDR support to app service

### DIFF
--- a/acceptance_tests/app_service_load_balancer_cidr_acceptance_test.go
+++ b/acceptance_tests/app_service_load_balancer_cidr_acceptance_test.go
@@ -1,0 +1,283 @@
+package acceptance_tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/appservice"
+)
+
+// TestAccAppServiceLoadBalancerCIDR tests the load_balancer_cidr attribute on the
+// app service resource and data source against a dedicated Azure cluster.
+func TestAccAppServiceLoadBalancerCIDR(t *testing.T) {
+	// load_balancer_cidr is Azure only and must be a valid IPv4 /24 network address.
+	// The global cluster is AWS, so this test stands up its own Azure cluster. The
+	// 192.168.x.0/24 ranges cannot overlap the random 10.x.y.0/23 cluster CIDR, and
+	// the control plane adds the /24 as an extra VNet address space, so the app
+	// service deploys cleanly.
+	const (
+		loadBalancerCIDR        = "192.168.0.0/24"
+		loadBalancerCIDRChanged = "192.168.1.0/24"
+	)
+
+	resourceName := randomStringWithPrefix("tf_acc_app_svc_lb_")
+	resourceReference := "couchbase-capella_app_service." + resourceName
+	clusterName := randomStringWithPrefix("tf_acc_cluster_azure_")
+	dataSourceName := randomStringWithPrefix("tf_acc_app_svcs_lb_ds_")
+	dataSourceReference := "data.couchbase-capella_app_services." + dataSourceName
+	appServiceName := randomStringWithPrefix("tf_acc_app_svc_lb_")
+	clusterCIDR := generateRandomCIDR()
+
+	// This test uses its own cluster and app service (no shared global resources),
+	// so it can run in parallel.
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			// Create and Read testing, plus data source coverage.
+			{
+				Config: testAccAppServiceLoadBalancerCIDRConfig(resourceName, clusterName, dataSourceName, appServiceName, clusterCIDR, loadBalancerCIDR),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Wait for the deploy to finish so the later replace/teardown
+					// does not try to delete a still-deploying app service (412).
+					testAccCheckAppServiceHealthy(resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "load_balancer_cidr", loadBalancerCIDR),
+					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "Azure"),
+					resource.TestCheckResourceAttr(resourceReference, "name", appServiceName),
+					resource.TestCheckResourceAttr(resourceReference, "compute.cpu", "2"),
+					resource.TestCheckResourceAttr(resourceReference, "compute.ram", "4"),
+					resource.TestCheckResourceAttrSet(resourceReference, "id"),
+					resource.TestCheckResourceAttrSet(resourceReference, "cluster_id"),
+					resource.TestCheckResourceAttrSet(resourceReference, "current_state"),
+					resource.TestCheckResourceAttrSet(resourceReference, "version"),
+					resource.TestCheckResourceAttrSet(resourceReference, "etag"),
+					testAccCheckAppServicesDataSourceLoadBalancerCIDR(dataSourceReference, resourceReference, loadBalancerCIDR),
+				),
+			},
+			// ImportState testing exercises the Read merge that preserves the
+			// configured CIDR (on import there is no prior value, so the API value is kept).
+			{
+				ResourceName:      resourceReference,
+				ImportStateIdFunc: generateAppServiceImportId(resourceReference),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// load_balancer_cidr is create-only, so changing it must force a
+			// replace. Plan checks require an apply step, so this recreates the
+			// app service with the new CIDR.
+			{
+				Config: testAccAppServiceLoadBalancerCIDRConfig(resourceName, clusterName, dataSourceName, appServiceName, clusterCIDR, loadBalancerCIDRChanged),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceReference, plancheck.ResourceActionReplace),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "load_balancer_cidr", loadBalancerCIDRChanged),
+					// Wait for the recreated app service to finish deploying so the
+					// post-test teardown does not race the deploy (412).
+					testAccCheckAppServiceHealthy(resourceReference),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAppServiceLoadBalancerCIDRAzureOnly verifies the API rejects a requested
+// load balancer CIDR on a non-Azure cluster and that the provider surfaces the error.
+// The global cluster is AWS, and the Azure-only check runs before the "app service
+// already exists" check, so the global cluster's existing app service is irrelevant.
+func TestAccAppServiceLoadBalancerCIDRAzureOnly(t *testing.T) {
+	const loadBalancerCIDR = "192.168.0.0/24"
+
+	resourceName := randomStringWithPrefix("tf_acc_app_svc_lb_aws_")
+	appServiceName := randomStringWithPrefix("tf_acc_app_svc_lb_aws_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAppServiceLoadBalancerCIDRAzureOnlyConfig(resourceName, appServiceName, loadBalancerCIDR),
+				ExpectError: regexp.MustCompile(`(?s)only supported for Azure App Services`),
+			},
+		},
+	})
+}
+
+func testAccAppServiceLoadBalancerCIDRConfig(resourceName, clusterName, dataSourceName, appServiceName, clusterCIDR, loadBalancerCIDR string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_cluster" "%[5]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  name            = "%[5]s"
+  description     = "Terraform Acceptance Test app service load balancer CIDR"
+  cloud_provider = {
+    type   = "azure"
+    region = "eastus"
+    cidr   = "%[7]s"
+  }
+  service_groups = [
+    {
+      node = {
+        compute = {
+          cpu = 4
+          ram = 16
+        }
+        disk = {
+          type          = "P6"
+          autoexpansion = true
+        }
+      }
+      num_of_nodes = 3
+      services     = ["data", "index", "query"]
+    }
+  ]
+  availability = {
+    "type" : "multi"
+  }
+  support = {
+    plan     = "enterprise"
+    timezone = "PT"
+  }
+}
+
+resource "couchbase-capella_app_service" "%[4]s" {
+  organization_id    = "%[2]s"
+  project_id         = "%[3]s"
+  cluster_id         = couchbase-capella_cluster.%[5]s.id
+  name               = "%[6]s"
+  load_balancer_cidr = "%[8]s"
+  compute = {
+    cpu = 2
+    ram = 4
+  }
+}
+
+data "couchbase-capella_app_services" "%[9]s" {
+  organization_id = "%[2]s"
+
+  depends_on = [couchbase-capella_app_service.%[4]s]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, appServiceName, clusterCIDR, loadBalancerCIDR, dataSourceName)
+}
+
+func testAccAppServiceLoadBalancerCIDRAzureOnlyConfig(resourceName, appServiceName, loadBalancerCIDR string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_app_service" "%[5]s" {
+  organization_id    = "%[2]s"
+  project_id         = "%[3]s"
+  cluster_id         = "%[4]s"
+  name               = "%[6]s"
+  load_balancer_cidr = "%[7]s"
+  compute = {
+    cpu = 2
+    ram = 4
+  }
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName, appServiceName, loadBalancerCIDR)
+}
+
+// testAccCheckAppServicesDataSourceLoadBalancerCIDR finds the app service by id in
+// the app_services data source list and asserts its load_balancer_cidr.
+func testAccCheckAppServicesDataSourceLoadBalancerCIDR(dataSourceReference, resourceReference, wantCIDR string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		appService, ok := state.RootModule().Resources[resourceReference]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceReference)
+		}
+		appServiceID := appService.Primary.Attributes["id"]
+
+		dataSource, ok := state.RootModule().Resources[dataSourceReference]
+		if !ok {
+			return fmt.Errorf("data source %q not found in state", dataSourceReference)
+		}
+
+		attrs := dataSource.Primary.Attributes
+		count, err := strconv.Atoi(attrs["data.#"])
+		if err != nil {
+			return fmt.Errorf("invalid data.# on %q: %w", dataSourceReference, err)
+		}
+
+		for i := 0; i < count; i++ {
+			if attrs[fmt.Sprintf("data.%d.id", i)] != appServiceID {
+				continue
+			}
+
+			key := fmt.Sprintf("data.%d.load_balancer_cidr", i)
+			if got := attrs[key]; got != wantCIDR {
+				return fmt.Errorf("%s = %q, want %q", key, got, wantCIDR)
+			}
+
+			return nil
+		}
+
+		return fmt.Errorf("app service %q not found in %s.data across %d entries", appServiceID, dataSourceReference, count)
+	}
+}
+
+// testAccCheckAppServiceHealthy blocks until the app service reaches the healthy
+// state. The provider's create can return before the deploy finishes, so this
+// keeps the later replace and teardown from deleting a still-deploying app service.
+func testAccCheckAppServiceHealthy(resourceReference string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		appService, ok := state.RootModule().Resources[resourceReference]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceReference)
+		}
+
+		attrs := appService.Primary.Attributes
+		return waitForAppServiceHealthy(attrs["organization_id"], attrs["project_id"], attrs["cluster_id"], attrs["id"])
+	}
+}
+
+// waitForAppServiceHealthy polls the app service until it is healthy, tolerating
+// transient read errors. It fails fast if the app service settles into a
+// non-healthy final state, or once the timeout elapses.
+func waitForAppServiceHealthy(organizationId, projectId, clusterId, appServiceId string) error {
+	const (
+		timeout      = 40 * time.Minute
+		pollInterval = 15 * time.Second
+	)
+
+	ctx := context.Background()
+	deadline := time.Now().Add(timeout)
+
+	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/appservices/%s",
+		globalHost, organizationId, projectId, clusterId, appServiceId)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+
+	for time.Now().Before(deadline) {
+		response, err := globalClient.ExecuteWithRetry(ctx, cfg, nil, globalToken, nil)
+		if err == nil {
+			var appServiceResp appservice.GetAppServiceResponse
+			if err := json.Unmarshal(response.Body, &appServiceResp); err != nil {
+				return fmt.Errorf("unmarshalling app service %s: %w", appServiceId, err)
+			}
+
+			switch {
+			case appServiceResp.CurrentState == appservice.Healthy:
+				return nil
+			case appservice.IsFinalState(appServiceResp.CurrentState):
+				return fmt.Errorf("app service %s reached non-healthy final state %q", appServiceId, appServiceResp.CurrentState)
+			}
+		}
+
+		time.Sleep(pollInterval)
+	}
+
+	return fmt.Errorf("timed out waiting for app service %s to become healthy", appServiceId)
+}

--- a/acceptance_tests/app_service_load_balancer_cidr_acceptance_test.go
+++ b/acceptance_tests/app_service_load_balancer_cidr_acceptance_test.go
@@ -14,6 +14,8 @@ import (
 // TestAccAppServiceLoadBalancerCIDR tests the load_balancer_cidr attribute on the
 // app service resource and data source against a dedicated Azure cluster.
 func TestAccAppServiceLoadBalancerCIDR(t *testing.T) {
+	t.Skip("provisions a dedicated Azure cluster which is slow and unreliable; run manually to verify load_balancer_cidr")
+
 	// load_balancer_cidr is Azure only and must be a valid IPv4 /24 network address.
 	// The global cluster is AWS, so this test stands up its own Azure cluster. The
 	// 192.168.x.0/24 ranges cannot overlap the random 10.x.y.0/23 cluster CIDR, and

--- a/acceptance_tests/app_service_load_balancer_cidr_acceptance_test.go
+++ b/acceptance_tests/app_service_load_balancer_cidr_acceptance_test.go
@@ -64,8 +64,8 @@ func TestAccAppServiceLoadBalancerCIDR(t *testing.T) {
 					testAccCheckAppServicesDataSourceLoadBalancerCIDR(dataSourceReference, resourceReference, loadBalancerCIDR),
 				),
 			},
-			// ImportState testing exercises the Read merge that preserves the
-			// configured CIDR (on import there is no prior value, so the API value is kept).
+			// ImportState testing confirms the API round-trips load_balancer_cidr:
+			// on import there is no prior state, so the value comes from the API.
 			{
 				ResourceName:      resourceReference,
 				ImportStateIdFunc: generateAppServiceImportId(resourceReference),

--- a/acceptance_tests/app_service_load_balancer_cidr_acceptance_test.go
+++ b/acceptance_tests/app_service_load_balancer_cidr_acceptance_test.go
@@ -1,21 +1,14 @@
 package acceptance_tests
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
-	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
-	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/appservice"
 )
 
 // TestAccAppServiceLoadBalancerCIDR tests the load_balancer_cidr attribute on the
@@ -48,9 +41,6 @@ func TestAccAppServiceLoadBalancerCIDR(t *testing.T) {
 			{
 				Config: testAccAppServiceLoadBalancerCIDRConfig(resourceName, clusterName, dataSourceName, appServiceName, clusterCIDR, loadBalancerCIDR),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// Wait for the deploy to finish so the later replace/teardown
-					// does not try to delete a still-deploying app service (412).
-					testAccCheckAppServiceHealthy(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "load_balancer_cidr", loadBalancerCIDR),
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "Azure"),
 					resource.TestCheckResourceAttr(resourceReference, "name", appServiceName),
@@ -84,9 +74,6 @@ func TestAccAppServiceLoadBalancerCIDR(t *testing.T) {
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "load_balancer_cidr", loadBalancerCIDRChanged),
-					// Wait for the recreated app service to finish deploying so the
-					// post-test teardown does not race the deploy (412).
-					testAccCheckAppServiceHealthy(resourceReference),
 				),
 			},
 		},
@@ -227,57 +214,4 @@ func testAccCheckAppServicesDataSourceLoadBalancerCIDR(dataSourceReference, reso
 
 		return fmt.Errorf("app service %q not found in %s.data across %d entries", appServiceID, dataSourceReference, count)
 	}
-}
-
-// testAccCheckAppServiceHealthy blocks until the app service reaches the healthy
-// state. The provider's create can return before the deploy finishes, so this
-// keeps the later replace and teardown from deleting a still-deploying app service.
-func testAccCheckAppServiceHealthy(resourceReference string) resource.TestCheckFunc {
-	return func(state *terraform.State) error {
-		appService, ok := state.RootModule().Resources[resourceReference]
-		if !ok {
-			return fmt.Errorf("resource %q not found in state", resourceReference)
-		}
-
-		attrs := appService.Primary.Attributes
-		return waitForAppServiceHealthy(attrs["organization_id"], attrs["project_id"], attrs["cluster_id"], attrs["id"])
-	}
-}
-
-// waitForAppServiceHealthy polls the app service until it is healthy, tolerating
-// transient read errors. It fails fast if the app service settles into a
-// non-healthy final state, or once the timeout elapses.
-func waitForAppServiceHealthy(organizationId, projectId, clusterId, appServiceId string) error {
-	const (
-		timeout      = 40 * time.Minute
-		pollInterval = 15 * time.Second
-	)
-
-	ctx := context.Background()
-	deadline := time.Now().Add(timeout)
-
-	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/appservices/%s",
-		globalHost, organizationId, projectId, clusterId, appServiceId)
-	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
-
-	for time.Now().Before(deadline) {
-		response, err := globalClient.ExecuteWithRetry(ctx, cfg, nil, globalToken, nil)
-		if err == nil {
-			var appServiceResp appservice.GetAppServiceResponse
-			if err := json.Unmarshal(response.Body, &appServiceResp); err != nil {
-				return fmt.Errorf("unmarshalling app service %s: %w", appServiceId, err)
-			}
-
-			switch {
-			case appServiceResp.CurrentState == appservice.Healthy:
-				return nil
-			case appservice.IsFinalState(appServiceResp.CurrentState):
-				return fmt.Errorf("app service %s reached non-healthy final state %q", appServiceId, appServiceResp.CurrentState)
-			}
-		}
-
-		time.Sleep(pollInterval)
-	}
-
-	return fmt.Errorf("timed out waiting for app service %s to become healthy", appServiceId)
 }

--- a/docs/data-sources/app_services.md
+++ b/docs/data-sources/app_services.md
@@ -45,6 +45,7 @@ Read-Only:
  - **Constraints**: Maximum length: 1024 characters
 - `id` (String) - The ID of the App Service created.
  - **Format**: UUID (GUID4)
+- `load_balancer_cidr` (String)
 - `name` (String) - Name of the App Service (up to 256 characters).
  - **Constraints**: Maximum length: 256 characters
 - `nodes` (Number) - Number of nodes configured for the App Service.

--- a/docs/resources/app_service.md
+++ b/docs/resources/app_service.md
@@ -51,6 +51,7 @@ resource "couchbase-capella_app_service" "new_app_service" {
 
 - `description` (String) - A short description of the App Service.
 - `if_match` (String) A precondition header that specifies the entity tag of a resource.
+- `load_balancer_cidr` (String)
 - `nodes` (Number) - Number of nodes configured for the App Service. Number of nodes configured for the App Service. The number of nodes can range from 2 to 12.
 
 ### Read-Only

--- a/examples/appservice/create_app_service.tf
+++ b/examples/appservice/create_app_service.tf
@@ -17,4 +17,6 @@ resource "couchbase-capella_app_service" "new_app_service" {
     cpu = var.app_service.compute.cpu
     ram = var.app_service.compute.ram
   }
+  # load_balancer_cidr pins the load balancer subnet CIDR (Azure App Services only). Allocated dynamically when omitted.
+  load_balancer_cidr = var.app_service.load_balancer_cidr
 }

--- a/examples/appservice/terraform.template.tfvars
+++ b/examples/appservice/terraform.template.tfvars
@@ -7,6 +7,7 @@ app_service = {
   name        = "new-terraform-app-service"
   description = "My first test app service."
   nodes       = 2
+  # load_balancer_cidr = "10.1.0.0/24" # Azure App Services only
   compute = {
     cpu = 2
     ram = 4

--- a/examples/appservice/variables.tf
+++ b/examples/appservice/variables.tf
@@ -19,9 +19,10 @@ variable "app_service" {
   description = "App Service configuration details useful for creation"
 
   type = object({
-    name        = string
-    description = optional(string)
-    nodes       = optional(number)
+    name               = string
+    description        = optional(string)
+    nodes              = optional(number)
+    load_balancer_cidr = optional(string)
     compute = object({
       cpu = number
       ram = number

--- a/internal/api/appservice/appservice.go
+++ b/internal/api/appservice/appservice.go
@@ -30,6 +30,10 @@ type CreateAppServiceRequest struct {
 	// The latest Server version will be deployed by default.
 	Version *string `json:"version,omitempty"`
 
+	// LoadBalancerCidr optionally pins the CIDR block used for the app service load balancer subnet.
+	// Supported for Azure App Services only and rejected for other providers. When omitted, the CIDR is allocated dynamically.
+	LoadBalancerCidr *string `json:"loadBalancerCidr,omitempty"`
+
 	// Name is the name of the app service, the name of the app service should follow this naming criteria:
 	// An app service name should have at least 2 characters and up to 256 characters.
 	Name string `json:"name"`
@@ -101,6 +105,10 @@ type GetAppServiceResponse struct {
 
 	// Plan is the plan of the app service.
 	Plan string `json:"plan"`
+
+	// LoadBalancerCidr is the CIDR block reserved for the app service load balancer subnet,
+	// when one was requested (Azure only). Omitted otherwise.
+	LoadBalancerCidr *string `json:"loadBalancerCidr,omitempty"`
 }
 
 type UpdateAppServiceRequest struct {

--- a/internal/datasources/appservice_schema.go
+++ b/internal/datasources/appservice_schema.go
@@ -31,6 +31,7 @@ func AppServiceSchema() schema.Schema {
 		Attributes: computeAttrs,
 	})
 	capellaschema.AddAttr(dataAttrs, "version", appServiceDSBuilder, computedString())
+	capellaschema.AddAttr(dataAttrs, "load_balancer_cidr", appServiceDSBuilder, computedString())
 	capellaschema.AddAttr(dataAttrs, "audit", appServiceDSBuilder, computedAudit())
 
 	capellaschema.AddAttr(attrs, "data", appServiceDSBuilder, &schema.ListNestedAttribute{

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -153,13 +153,6 @@ func (a *AppService) Create(ctx context.Context, req resource.CreateRequest, res
 		return
 	}
 
-	// load_balancer_cidr is a create-time input that the API only echoes back on Azure with the
-	// defined-CIDR feature enabled. Keep the configured value so state stays consistent with config
-	// when the API omits it.
-	if !plan.LoadBalancerCidr.IsNull() && !plan.LoadBalancerCidr.IsUnknown() {
-		refreshedState.LoadBalancerCidr = plan.LoadBalancerCidr
-	}
-
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, refreshedState)
 	resp.Diagnostics.Append(diags...)
@@ -211,12 +204,6 @@ func (a *AppService) Read(ctx context.Context, req resource.ReadRequest, resp *r
 
 	if !state.IfMatch.IsUnknown() && !state.IfMatch.IsNull() {
 		refreshedState.IfMatch = state.IfMatch
-	}
-
-	// Preserve the configured load_balancer_cidr; the API omits it unless Azure + defined-CIDR is
-	// enabled. On import there is no prior value, so the refreshed (API) value is kept.
-	if !state.LoadBalancerCidr.IsNull() && !state.LoadBalancerCidr.IsUnknown() {
-		refreshedState.LoadBalancerCidr = state.LoadBalancerCidr
 	}
 
 	// Set refreshed state
@@ -335,12 +322,6 @@ func (a *AppService) Update(ctx context.Context, req resource.UpdateRequest, res
 
 	if !plan.IfMatch.IsUnknown() && !plan.IfMatch.IsNull() {
 		currentState.IfMatch = plan.IfMatch
-	}
-
-	// load_balancer_cidr is create-only (requires replace), so it never changes here. Keep the
-	// configured value since the API omits it unless Azure + defined-CIDR is enabled.
-	if !plan.LoadBalancerCidr.IsNull() && !plan.LoadBalancerCidr.IsUnknown() {
-		currentState.LoadBalancerCidr = plan.LoadBalancerCidr
 	}
 
 	// Set state to fully populated data

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -94,6 +94,10 @@ func (a *AppService) Create(ctx context.Context, req resource.CreateRequest, res
 		appServiceRequest.Version = &version
 	}
 
+	if !plan.LoadBalancerCidr.IsNull() && !plan.LoadBalancerCidr.IsUnknown() {
+		appServiceRequest.LoadBalancerCidr = plan.LoadBalancerCidr.ValueStringPointer()
+	}
+
 	var organizationId = plan.OrganizationId.ValueString()
 	var projectId = plan.ProjectId.ValueString()
 	var clusterId = plan.ClusterId.ValueString()
@@ -149,6 +153,13 @@ func (a *AppService) Create(ctx context.Context, req resource.CreateRequest, res
 		return
 	}
 
+	// load_balancer_cidr is a create-time input that the API only echoes back on Azure with the
+	// defined-CIDR feature enabled. Keep the configured value so state stays consistent with config
+	// when the API omits it.
+	if !plan.LoadBalancerCidr.IsNull() && !plan.LoadBalancerCidr.IsUnknown() {
+		refreshedState.LoadBalancerCidr = plan.LoadBalancerCidr
+	}
+
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, refreshedState)
 	resp.Diagnostics.Append(diags...)
@@ -200,6 +211,12 @@ func (a *AppService) Read(ctx context.Context, req resource.ReadRequest, resp *r
 
 	if !state.IfMatch.IsUnknown() && !state.IfMatch.IsNull() {
 		refreshedState.IfMatch = state.IfMatch
+	}
+
+	// Preserve the configured load_balancer_cidr; the API omits it unless Azure + defined-CIDR is
+	// enabled. On import there is no prior value, so the refreshed (API) value is kept.
+	if !state.LoadBalancerCidr.IsNull() && !state.LoadBalancerCidr.IsUnknown() {
+		refreshedState.LoadBalancerCidr = state.LoadBalancerCidr
 	}
 
 	// Set refreshed state
@@ -318,6 +335,12 @@ func (a *AppService) Update(ctx context.Context, req resource.UpdateRequest, res
 
 	if !plan.IfMatch.IsUnknown() && !plan.IfMatch.IsNull() {
 		currentState.IfMatch = plan.IfMatch
+	}
+
+	// load_balancer_cidr is create-only (requires replace), so it never changes here. Keep the
+	// configured value since the API omits it unless Azure + defined-CIDR is enabled.
+	if !plan.LoadBalancerCidr.IsNull() && !plan.LoadBalancerCidr.IsUnknown() {
+		currentState.LoadBalancerCidr = plan.LoadBalancerCidr
 	}
 
 	// Set state to fully populated data
@@ -577,6 +600,9 @@ func initializePendingAppServiceWithPlanAndId(plan providerschema.AppService, id
 	}
 	if plan.Version.IsNull() || plan.Version.IsUnknown() {
 		plan.Version = types.StringNull()
+	}
+	if plan.LoadBalancerCidr.IsNull() || plan.LoadBalancerCidr.IsUnknown() {
+		plan.LoadBalancerCidr = types.StringNull()
 	}
 	plan.Audit = types.ObjectNull(providerschema.CouchbaseAuditData{}.AttributeTypes())
 	plan.Etag = types.StringNull()

--- a/internal/resources/appservice_schema.go
+++ b/internal/resources/appservice_schema.go
@@ -31,6 +31,7 @@ func AppServiceSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "audit", appServiceBuilder, computedAuditAttribute())
 	capellaschema.AddAttr(attrs, "if_match", appServiceBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(attrs, "etag", appServiceBuilder, stringAttribute([]string{computed}))
+	capellaschema.AddAttr(attrs, "load_balancer_cidr", appServiceBuilder, stringAttribute([]string{optional, computed, requiresReplace}))
 
 	computeAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(computeAttrs, "cpu", appServiceBuilder, int64Attribute(required))

--- a/internal/schema/appservice.go
+++ b/internal/schema/appservice.go
@@ -60,6 +60,10 @@ type AppService struct {
 	// IfMatch is a precondition header that specifies the entity tag of a resource.
 	IfMatch types.String `tfsdk:"if_match"`
 
+	// LoadBalancerCidr pins the CIDR block for the app service load balancer subnet (Azure only).
+	// When set, it is reserved at create time; when omitted, the CIDR is allocated dynamically.
+	LoadBalancerCidr types.String `tfsdk:"load_balancer_cidr"`
+
 	// Nodes is the number of nodes configured for the app service.
 	Nodes types.Int64 `tfsdk:"nodes"`
 }
@@ -101,6 +105,7 @@ func NewAppService(
 		Version:      types.StringValue(truncateToMajorMinor(appService.Version)),
 		Audit:        auditObject,
 		Etag:         types.StringValue(appService.Etag),
+		LoadBalancerCidr: types.StringPointerValue(appService.LoadBalancerCidr),
 	}
 	return &newAppService
 }
@@ -176,6 +181,9 @@ type AppServiceData struct {
 	// Audit represents all audit-related fields. It is of types.Object type to avoid conversion error for a nested field.
 	Audit types.Object `tfsdk:"audit"`
 
+	// LoadBalancerCidr is the CIDR block reserved for the app service load balancer subnet (Azure only).
+	LoadBalancerCidr types.String `tfsdk:"load_balancer_cidr"`
+
 	// Nodes is the number of nodes configured for the app service.
 	Nodes types.Int64 `tfsdk:"nodes"`
 }
@@ -197,10 +205,11 @@ func NewAppServiceData(
 			Cpu: types.Int64Value(appService.Compute.Cpu),
 			Ram: types.Int64Value(appService.Compute.Ram),
 		},
-		ClusterId:    types.StringValue(appService.ClusterId),
-		CurrentState: types.StringValue(string(appService.CurrentState)),
-		Version:      types.StringValue(appService.Version),
-		Audit:        auditObject,
+		ClusterId:        types.StringValue(appService.ClusterId),
+		CurrentState:     types.StringValue(string(appService.CurrentState)),
+		Version:          types.StringValue(appService.Version),
+		Audit:            auditObject,
+		LoadBalancerCidr: types.StringPointerValue(appService.LoadBalancerCidr),
 	}
 	return &newAppService
 }


### PR DESCRIPTION
## Jira

* AV-131313

## Description

Implements terraform side of the user defined CIDR option. New `loadBalancerCidr` option for App Services Azure clusters allowing the customer to define the cidr for the load balancer to be deployed with.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [X] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
<summary>Testing</summary>
Written two acceptance tests that test it pretty end to end. Success proof from GoLand run. Will fail CI. Needs the FF enabled:
<img width="1749" height="335" alt="image" src="https://github.com/user-attachments/assets/5812b7aa-5286-4e84-9565-a4e743b70030" />

Also did a deployment myself to validate:
<img width="465" height="274" alt="image" src="https://github.com/user-attachments/assets/097ef00a-0a7c-41e1-95e6-0e0d560bc86f" />
<img width="930" height="86" alt="image" src="https://github.com/user-attachments/assets/8c15968f-f1e1-47be-b3a5-52240f8077d3" />

</details>

## Further comments