### PR TITLE
[AV-131924] Fix provider_type erased on import/read

### DIFF
--- a/acceptance_tests/access_management_membership_test.go
+++ b/acceptance_tests/access_management_membership_test.go
@@ -180,9 +180,9 @@ func TestAccDatasourceUsersFullFieldContent(t *testing.T) {
 
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
 					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
-						"name":              username,
-						"email":             email,
-						"organization_id":   globalOrgId,
+						"name":                 username,
+						"email":                email,
+						"organization_id":      globalOrgId,
 						"organization_roles.#": "1",
 						"organization_roles.0": "organizationMember",
 					}),

--- a/internal/resources/network_peer.go
+++ b/internal/resources/network_peer.go
@@ -507,7 +507,7 @@ func defineProviderForResponse(networkResp *network_peer_api.GetNetworkPeeringRe
 	case aws.AWSConfigData.VpcId != "":
 		networkResp.ProviderType = "aws"
 	default:
-		return fmt.Errorf("%s: %w", errors.ErrReadingProviderConfig, err)
+		return errors.ErrReadingProviderConfig
 	}
 
 	return nil

--- a/internal/resources/network_peer.go
+++ b/internal/resources/network_peer.go
@@ -442,7 +442,9 @@ func (n *NetworkPeer) retrieveNetworkPeer(
 		return nil, fmt.Errorf("%s: %w", errors.ErrRefreshingState, err)
 	}
 
-	refreshedState.ProviderType = types.StringValue(providerType)
+	if providerType != "" {
+		refreshedState.ProviderType = types.StringValue(providerType)
+	}
 
 	return refreshedState, nil
 }
@@ -471,7 +473,7 @@ func (n *NetworkPeer) getNetworkPeer(
 		return nil, fmt.Errorf("%s: %w", errors.ErrUnmarshallingResponse, err)
 	}
 
-	if err := defineProviderForResponse(networkResp); err != nil {
+	if err := defineProviderForResponse(&networkResp); err != nil {
 		return nil, err
 	}
 
@@ -480,7 +482,7 @@ func (n *NetworkPeer) getNetworkPeer(
 
 // defineProviderForResponse sets the provider type in the retrieved network peer as per the fields populated in the provider config.
 // If the provider type is not set through terraform separately in this manner, it will throw error as v4 get doesn't return it, but it's a field in resources.
-func defineProviderForResponse(networkResp network_peer_api.GetNetworkPeeringRecordResponse) error {
+func defineProviderForResponse(networkResp *network_peer_api.GetNetworkPeeringRecordResponse) error {
 	azure, err := networkResp.AsAZURE()
 	if err != nil {
 		return fmt.Errorf("%s: %w", errors.ErrReadingAzureConfig, err)


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-131924

## Description

  - Pass GetNetworkPeeringRecordResponse by pointer to defineProviderForResponse so the derived `provider_type` actually persists on the response instead of being written to a discarded copy.
  - Guard the provider_type assignment in retrieveNetworkPeer so it is only overwritten when a value is present.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

```
tanush.golwala@RYR66FLM2G network_peer % terraform import couchbase-capella_network_peer.new_network_peer \
    'id=24e612b4-1849-4a9e-8680-d69ccf18946c,cluster_id=822564ef-3063-4022-badb-45db7b9d9d95,project_id=c09035e8-3971-4b79-a6ec-bccd9056041f,organization_id=adb4fb4c-1d98-4287-ac33-230742d2cc76'
couchbase-capella_network_peer.new_network_peer: Importing from ID "id=24e612b4-1849-4a9e-8680-d69ccf18946c,cluster_id=822564ef-3063-4022-badb-45db7b9d9d95,project_id=c09035e8-3971-4b79-a6ec-bccd9056041f,organization_id=adb4fb4c-1d98-4287-ac33-230742d2cc76"...
couchbase-capella_network_peer.new_network_peer: Import prepared!
  Prepared couchbase-capella_network_peer for import
couchbase-capella_network_peer.new_network_peer: Refreshing state... [id=id=24e612b4-1849-4a9e-8680-d69ccf18946c,cluster_id=822564ef-3063-4022-badb-45db7b9d9d95,project_id=c09035e8-3971-4b79-a6ec-bccd9056041f,organization_id=adb4fb4c-1d98-4287-ac33-230742d2cc76]

Import successful!                                                                                                                                                                                             
                                                                                                                                                                                                               
The resources that were imported are shown above. These resources are now in                                                                                                                                   
your Terraform state and will henceforth be managed by Terraform.                                                                                                                                              
                                                                                                                                                                                                               
tanush.golwala@RYR66FLM2G network_peer %   terraform show | grep provider_type

    provider_type   = "azure"
    provider_type   = "azure"
```

</details>

## Further comments