### PR TITLE
[AV-132148] Validate free-tier cluster region at plan time

### DIFF
--- a/internal/resources/free_tier_cluster_schema.go
+++ b/internal/resources/free_tier_cluster_schema.go
@@ -8,9 +8,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+	customvalidator "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema/validator"
 )
 
 var freeTierClusterBuilder = capellaschema.NewSchemaBuilder("freeTierCluster")
+
+// freeTierClusterRegions maps a lowercased cloud provider type to the regions
+// Capella allows for free tier clusters. Sourced from the "Create Free Tier
+// Cluster" endpoint description; update when that changes:
+// https://docs.couchbase.com/cloud/management-api-reference/index.html#tag/Free-Tier
+var freeTierClusterRegions = map[string][]string{
+	"aws":   {"us-east-2", "eu-west-1", "ap-southeast-1"},
+	"gcp":   {"us-central1", "europe-west1", "asia-east1"},
+	"azure": {"eastus", "swedencentral", "koreacentral"},
+}
 
 func FreeTierClusterSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
@@ -47,6 +58,9 @@ func FreeTierClusterSchema() schema.Schema {
 		Attributes: cloudProviderAttrs,
 		PlanModifiers: []planmodifier.Object{
 			objectplanmodifier.RequiresReplace(),
+		},
+		Validators: []validator.Object{
+			customvalidator.CloudProviderRegion(freeTierClusterRegions),
 		},
 	})
 

--- a/internal/schema/validator/cloud_provider_region_validator.go
+++ b/internal/schema/validator/cloud_provider_region_validator.go
@@ -15,9 +15,9 @@ var _ validator.Object = (*cloudProviderRegionValidator)(nil)
 
 // CloudProviderRegion returns an object validator for a cloud_provider block that
 // rejects a region not supported for the configured provider type. allowed maps a
-// lowercased provider type (e.g. "aws") to its supported region codes. The check
-// is skipped when type or region is null/unknown, or when the provider type is
-// absent from the map (its own enum validator reports that).
+// provider type (e.g. "aws", matching the type enum's casing) to its supported
+// region codes. The check is skipped when type or region is null/unknown, or when
+// the provider type is absent from the map (its own enum validator reports that).
 func CloudProviderRegion(allowed map[string][]string) validator.Object {
 	return &cloudProviderRegionValidator{allowed: allowed}
 }
@@ -50,7 +50,7 @@ func (v *cloudProviderRegionValidator) ValidateObject(_ context.Context, req val
 		return
 	}
 
-	regions, ok := v.allowed[strings.ToLower(providerType)]
+	regions, ok := v.allowed[providerType]
 	if !ok {
 		// Unknown provider type — the type attribute's own enum validator reports it.
 		return

--- a/internal/schema/validator/cloud_provider_region_validator.go
+++ b/internal/schema/validator/cloud_provider_region_validator.go
@@ -1,0 +1,81 @@
+package validator
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ validator.Object = (*cloudProviderRegionValidator)(nil)
+
+// CloudProviderRegion returns an object validator for a cloud_provider block that
+// rejects a region not supported for the configured provider type. allowed maps a
+// lowercased provider type (e.g. "aws") to its supported region codes. The check
+// is skipped when type or region is null/unknown, or when the provider type is
+// absent from the map (its own enum validator reports that).
+func CloudProviderRegion(allowed map[string][]string) validator.Object {
+	return &cloudProviderRegionValidator{allowed: allowed}
+}
+
+type cloudProviderRegionValidator struct {
+	allowed map[string][]string
+}
+
+func (v *cloudProviderRegionValidator) Description(_ context.Context) string {
+	return v.MarkdownDescription(context.Background())
+}
+
+func (v *cloudProviderRegionValidator) MarkdownDescription(_ context.Context) string {
+	return "region must be one of the supported regions for the configured cloud provider type"
+}
+
+func (v *cloudProviderRegionValidator) ValidateObject(_ context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	attrs := req.ConfigValue.Attributes()
+
+	providerType, ok := stringValue(attrs["type"])
+	if !ok {
+		return
+	}
+	region, ok := stringValue(attrs["region"])
+	if !ok {
+		return
+	}
+
+	regions, ok := v.allowed[strings.ToLower(providerType)]
+	if !ok {
+		// Unknown provider type — the type attribute's own enum validator reports it.
+		return
+	}
+
+	if slices.Contains(regions, region) {
+		return
+	}
+
+	sorted := append([]string(nil), regions...)
+	sort.Strings(sorted)
+	resp.Diagnostics.AddAttributeError(
+		req.Path.AtName("region"),
+		"Unsupported Region",
+		fmt.Sprintf("region %q is not supported for cloud provider %q. Supported regions are: %s.",
+			region, providerType, strings.Join(sorted, ", ")),
+	)
+}
+
+// stringValue returns the string and true only when value is a known, non-null
+// String; otherwise it returns false so the caller can skip validation.
+func stringValue(value any) (string, bool) {
+	s, ok := value.(types.String)
+	if !ok || s.IsNull() || s.IsUnknown() {
+		return "", false
+	}
+	return s.ValueString(), true
+}

--- a/internal/schema/validator/cloud_provider_region_validator_test.go
+++ b/internal/schema/validator/cloud_provider_region_validator_test.go
@@ -9,71 +9,72 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var testRegions = map[string][]string{
-	"aws":   {"us-west-2", "eu-west-1"},
-	"azure": {"eastus", "swedencentral"},
-}
+func TestCloudProviderRegion(t *testing.T) {
+	allowed := map[string][]string{
+		"aws":   {"us-west-2", "eu-west-1"},
+		"azure": {"eastus", "swedencentral"},
+	}
 
-func cloudProviderObject(t *testing.T, provider, region attr.Value) types.Object {
-	t.Helper()
-	obj, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"type":   types.StringType,
-			"region": types.StringType,
+	objectType := map[string]attr.Type{
+		"type":   types.StringType,
+		"region": types.StringType,
+	}
+
+	tests := []struct {
+		name      string
+		provider  attr.Value
+		region    attr.Value
+		wantError bool
+	}{
+		{
+			name:     "supported region",
+			provider: types.StringValue("aws"),
+			region:   types.StringValue("us-west-2"),
 		},
-		map[string]attr.Value{
-			"type":   provider,
-			"region": region,
+		{
+			name:      "unsupported region",
+			provider:  types.StringValue("aws"),
+			region:    types.StringValue("us-east-99"),
+			wantError: true,
 		},
-	)
-	if diags.HasError() {
-		t.Fatalf("failed to build object: %v", diags)
+		{
+			name:     "unknown provider type is skipped (its enum validator reports it)",
+			provider: types.StringValue("gcp"),
+			region:   types.StringValue("anything"),
+		},
+		{
+			name:     "unknown region value is skipped",
+			provider: types.StringValue("aws"),
+			region:   types.StringUnknown(),
+		},
+		{
+			name:     "null region value is skipped",
+			provider: types.StringValue("aws"),
+			region:   types.StringNull(),
+		},
 	}
-	return obj
-}
 
-func runRegionValidator(t *testing.T, obj types.Object) *validator.ObjectResponse {
-	t.Helper()
-	v := CloudProviderRegion(testRegions)
-	resp := &validator.ObjectResponse{}
-	v.ValidateObject(context.Background(), validator.ObjectRequest{ConfigValue: obj}, resp)
-	return resp
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj, diags := types.ObjectValue(objectType, map[string]attr.Value{
+				"type":   tc.provider,
+				"region": tc.region,
+			})
+			if diags.HasError() {
+				t.Fatalf("failed to build object: %v", diags)
+			}
 
-func TestCloudProviderRegion_SupportedRegion(t *testing.T) {
-	obj := cloudProviderObject(t, types.StringValue("aws"), types.StringValue("us-west-2"))
-	if resp := runRegionValidator(t, obj); resp.Diagnostics.HasError() {
-		t.Errorf("expected no error for supported region, got: %v", resp.Diagnostics)
-	}
-}
+			resp := &validator.ObjectResponse{}
+			CloudProviderRegion(allowed).ValidateObject(
+				context.Background(),
+				validator.ObjectRequest{ConfigValue: obj},
+				resp,
+			)
 
-func TestCloudProviderRegion_UnsupportedRegion(t *testing.T) {
-	obj := cloudProviderObject(t, types.StringValue("aws"), types.StringValue("us-east-99"))
-	resp := runRegionValidator(t, obj)
-	if !resp.Diagnostics.HasError() {
-		t.Fatalf("expected an error for unsupported region, got none")
-	}
-}
-
-func TestCloudProviderRegion_CaseInsensitiveProviderType(t *testing.T) {
-	obj := cloudProviderObject(t, types.StringValue("AWS"), types.StringValue("eu-west-1"))
-	if resp := runRegionValidator(t, obj); resp.Diagnostics.HasError() {
-		t.Errorf("expected provider type match to be case-insensitive, got: %v", resp.Diagnostics)
-	}
-}
-
-func TestCloudProviderRegion_UnknownProviderSkipped(t *testing.T) {
-	// gcp is absent from testRegions; the type enum validator owns that error.
-	obj := cloudProviderObject(t, types.StringValue("gcp"), types.StringValue("anything"))
-	if resp := runRegionValidator(t, obj); resp.Diagnostics.HasError() {
-		t.Errorf("expected unknown provider type to be skipped, got: %v", resp.Diagnostics)
-	}
-}
-
-func TestCloudProviderRegion_UnknownValuesSkipped(t *testing.T) {
-	obj := cloudProviderObject(t, types.StringValue("aws"), types.StringUnknown())
-	if resp := runRegionValidator(t, obj); resp.Diagnostics.HasError() {
-		t.Errorf("expected unknown region to be skipped, got: %v", resp.Diagnostics)
+			if got := resp.Diagnostics.HasError(); got != tc.wantError {
+				t.Errorf("HasError() = %v, want %v (diags: %v)", got, tc.wantError, resp.Diagnostics)
+			}
+		})
 	}
 }
 
@@ -82,7 +83,15 @@ func TestCloudProviderRegion_NullObjectSkipped(t *testing.T) {
 		"type":   types.StringType,
 		"region": types.StringType,
 	})
-	if resp := runRegionValidator(t, obj); resp.Diagnostics.HasError() {
+
+	resp := &validator.ObjectResponse{}
+	CloudProviderRegion(map[string][]string{"aws": {"us-west-2"}}).ValidateObject(
+		context.Background(),
+		validator.ObjectRequest{ConfigValue: obj},
+		resp,
+	)
+
+	if resp.Diagnostics.HasError() {
 		t.Errorf("expected null object to be skipped, got: %v", resp.Diagnostics)
 	}
 }

--- a/internal/schema/validator/cloud_provider_region_validator_test.go
+++ b/internal/schema/validator/cloud_provider_region_validator_test.go
@@ -1,0 +1,88 @@
+package validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var testRegions = map[string][]string{
+	"aws":   {"us-west-2", "eu-west-1"},
+	"azure": {"eastus", "swedencentral"},
+}
+
+func cloudProviderObject(t *testing.T, provider, region attr.Value) types.Object {
+	t.Helper()
+	obj, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"type":   types.StringType,
+			"region": types.StringType,
+		},
+		map[string]attr.Value{
+			"type":   provider,
+			"region": region,
+		},
+	)
+	if diags.HasError() {
+		t.Fatalf("failed to build object: %v", diags)
+	}
+	return obj
+}
+
+func runRegionValidator(t *testing.T, obj types.Object) *validator.ObjectResponse {
+	t.Helper()
+	v := CloudProviderRegion(testRegions)
+	resp := &validator.ObjectResponse{}
+	v.ValidateObject(context.Background(), validator.ObjectRequest{ConfigValue: obj}, resp)
+	return resp
+}
+
+func TestCloudProviderRegion_SupportedRegion(t *testing.T) {
+	obj := cloudProviderObject(t, types.StringValue("aws"), types.StringValue("us-west-2"))
+	if resp := runRegionValidator(t, obj); resp.Diagnostics.HasError() {
+		t.Errorf("expected no error for supported region, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestCloudProviderRegion_UnsupportedRegion(t *testing.T) {
+	obj := cloudProviderObject(t, types.StringValue("aws"), types.StringValue("us-east-99"))
+	resp := runRegionValidator(t, obj)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected an error for unsupported region, got none")
+	}
+}
+
+func TestCloudProviderRegion_CaseInsensitiveProviderType(t *testing.T) {
+	obj := cloudProviderObject(t, types.StringValue("AWS"), types.StringValue("eu-west-1"))
+	if resp := runRegionValidator(t, obj); resp.Diagnostics.HasError() {
+		t.Errorf("expected provider type match to be case-insensitive, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestCloudProviderRegion_UnknownProviderSkipped(t *testing.T) {
+	// gcp is absent from testRegions; the type enum validator owns that error.
+	obj := cloudProviderObject(t, types.StringValue("gcp"), types.StringValue("anything"))
+	if resp := runRegionValidator(t, obj); resp.Diagnostics.HasError() {
+		t.Errorf("expected unknown provider type to be skipped, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestCloudProviderRegion_UnknownValuesSkipped(t *testing.T) {
+	obj := cloudProviderObject(t, types.StringValue("aws"), types.StringUnknown())
+	if resp := runRegionValidator(t, obj); resp.Diagnostics.HasError() {
+		t.Errorf("expected unknown region to be skipped, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestCloudProviderRegion_NullObjectSkipped(t *testing.T) {
+	obj := types.ObjectNull(map[string]attr.Type{
+		"type":   types.StringType,
+		"region": types.StringType,
+	})
+	if resp := runRegionValidator(t, obj); resp.Diagnostics.HasError() {
+		t.Errorf("expected null object to be skipped, got: %v", resp.Diagnostics)
+	}
+}


### PR DESCRIPTION
## Jira

* AV-132148

## Description

### Problem

`couchbase-capella_free_tier_cluster` only validated cloud_provider.type as an enum; cloud_provider.region was an unvalidated free-form string. An unsupported provider/region combination passed terraform validate and terraform plan, then failed at terraform apply with an API 422: The region provided, us-east-1, is not valid for the provider aws.

Free tier supports only a limited set of regions per provider, documented in the Create Free Tier Cluster endpoint description (it isn't an enum in the OpenAPI spec, so it couldn't be auto-attached by the enum generator):
  - AWS: us-east-2, eu-west-1, ap-southeast-1
  - GCP: us-central1, europe-west1, asia-east1
  - Azure: eastus, swedencentral, koreacentral

### Fix

Added a cross-field object validator on the cloud_provider block. Region validity depends on the sibling type field, so a plain string enum can't express it — the validator reads both type and region and errors if the region isn't allowed for that provider.

  - `internal/schema/validator/cloud_provider_region_validator.go` — generic `CloudProviderRegion(allowed map[string][]string)` object validator. Skips null/unknown values (computed refs) and unknown provider types (the type enum owns that error); provider-type match is case-insensitive.
  - `internal/resources/free_tier_cluster_schema.go` — defines the free-tier region allowlist per provider (sourced from the Management API reference) and wires the validator onto cloud_provider.
  - `internal/schema/validator/cloud_provider_region_validator_test.go` — unit tests (supported, unsupported, case-insensitive, unknown-provider skip, unknown-value skip, null-object skip).

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [X] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

**1. Unit tests**

```
$ go test ./internal/schema/validator/ -run TestCloudProviderRegion -v
=== RUN   TestCloudProviderRegion_SupportedRegion
--- PASS: TestCloudProviderRegion_SupportedRegion (0.00s)
=== RUN   TestCloudProviderRegion_UnsupportedRegion
--- PASS: TestCloudProviderRegion_UnsupportedRegion (0.00s)
=== RUN   TestCloudProviderRegion_CaseInsensitiveProviderType
--- PASS: TestCloudProviderRegion_CaseInsensitiveProviderType (0.00s)
=== RUN   TestCloudProviderRegion_UnknownProviderSkipped
--- PASS: TestCloudProviderRegion_UnknownProviderSkipped (0.00s)
=== RUN   TestCloudProviderRegion_UnknownValuesSkipped
--- PASS: TestCloudProviderRegion_UnknownValuesSkipped (0.00s)
=== RUN   TestCloudProviderRegion_NullObjectSkipped
--- PASS: TestCloudProviderRegion_NullObjectSkipped (0.00s)
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema/validator	0.299s
```

**2. Manual `terraform validate`** (dev override pointing at the local provider build, so the validator runs against this change). Schema validators run at validate time before the provider is configured, so no API call or real credentials are involved.

**Case A — invalid region (the ticket repro):** `aws` + `us-east-1`

Config:
```hcl
resource "couchbase-capella_free_tier_cluster" "invalid" {
  organization_id = "4678e0a6-1e5c-4859-99ce-d2f735287910"
  project_id      = "e752bfc8-f9e4-42a2-9721-555d4452a518"
  name            = "qe-free-tier-aws"
  description     = "Invalid free tier AWS cluster."
  cloud_provider = {
    type   = "aws"
    region = "us-east-1"
    cidr   = "10.10.0.0/20"
  }
}
```

Command and output:
```
$ terraform validate
╷
│ Error: Unsupported Region
│
│   with couchbase-capella_free_tier_cluster.invalid,
│   on main.tf line 11, in resource "couchbase-capella_free_tier_cluster" "invalid":
│   11: resource "couchbase-capella_free_tier_cluster" "invalid" {
│
│ region "us-east-1" is not supported for cloud provider "aws". Supported
│ regions are: ap-southeast-1, eu-west-1, us-east-2.
╵
```

**Case B — valid region:** `aws` + `us-east-2` (only the `region` value changed)

Config:
```hcl
resource "couchbase-capella_free_tier_cluster" "valid" {
  organization_id = "4678e0a6-1e5c-4859-99ce-d2f735287910"
  project_id      = "e752bfc8-f9e4-42a2-9721-555d4452a518"
  name            = "qe-free-tier-aws"
  description     = "Valid free tier AWS cluster."
  cloud_provider = {
    type   = "aws"
    region = "us-east-2"
    cidr   = "10.10.0.0/20"
  }
}
```

Command and output:
```
$ terraform validate
Success! The configuration is valid, but there were some
validation warnings as shown above.
```

</details>