### PR TITLE
[AV-134634] Fix - Fail fast and auto-recover from private endpoint service failed states

### DIFF
--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -43,7 +43,7 @@ Read-Only:
 - `connection_string` (String) - ConnectionString specifies the Capella database endpoint for your client connection.
 - `couchbase_server` (Attributes) (see [below for nested schema](#nestedatt--data--couchbase_server))
 - `current_state` (String) - **Valid Values**: `draft`, `deploying`, `scaling`, `upgrading`, `rebalancing`, `peering`, `destroying`, `healthy`, `degraded`, `turnedOff`, `turningOff`, `turningOn`, `deploymentFailed`, `scaleFailed`, `upgradeFailed`, `rebalanceFailed`, `peeringFailed`, `destroyFailed`, `offline`, `turningOffFailed`, `turningOnFailed`
-- `deletion_protection` (Boolean)
+- `deletion_protection` (Boolean) - Indicates whether deletion protection is enabled for the cluster. When enabled, the cluster cannot be deleted.
 - `description` (String) - Description of the cluster (up to 1024 characters).
  - **Constraints**: Maximum length: 1024 characters
 - `enable_private_dns_resolution` (Boolean)

--- a/docs/data-sources/free_tier_clusters.md
+++ b/docs/data-sources/free_tier_clusters.md
@@ -43,7 +43,7 @@ Read-Only:
 - `connection_string` (String) - ConnectionString specifies the Capella database endpoint for your client connection.
 - `couchbase_server` (Attributes) (see [below for nested schema](#nestedatt--data--couchbase_server))
 - `current_state` (String) - **Valid Values**: `draft`, `deploying`, `scaling`, `upgrading`, `rebalancing`, `peering`, `destroying`, `healthy`, `degraded`, `turnedOff`, `turningOff`, `turningOn`, `deploymentFailed`, `scaleFailed`, `upgradeFailed`, `rebalanceFailed`, `peeringFailed`, `destroyFailed`, `offline`, `turningOffFailed`, `turningOnFailed`
-- `deletion_protection` (Boolean)
+- `deletion_protection` (Boolean) - Indicates whether deletion protection is enabled for the cluster. When enabled, the cluster cannot be deleted.
 - `description` (String) - Description of the cluster (up to 1024 characters).
  - **Constraints**: Maximum length: 1024 characters
 - `enable_private_dns_resolution` (Boolean)

--- a/docs/data-sources/private_endpoint_service.md
+++ b/docs/data-sources/private_endpoint_service.md
@@ -32,3 +32,5 @@ data "couchbase-capella_private_endpoint_service" "service_status" {
 ### Read-Only
 
 - `enabled` (Boolean) - Returns true if private endpoint is enabled
+- `status` (String) - status of the private endpoint
+ - **Valid Values**: `idle`, `unknown`, `enabling`, `enabled`, `enableFailed`, `disabling`, `disabled`, `disableFailed`

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -86,7 +86,7 @@ resource "couchbase-capella_cluster" "new_cluster" {
 - `audit` (Attributes) Couchbase audit data. (see [below for nested schema](#nestedatt--audit))
 - `connection_string` (String) - ConnectionString specifies the Capella database endpoint for your client connection.
 - `current_state` (String) - **Valid Values**: `draft`, `deploying`, `scaling`, `upgrading`, `rebalancing`, `peering`, `destroying`, `healthy`, `degraded`, `turnedOff`, `turningOff`, `turningOn`, `deploymentFailed`, `scaleFailed`, `upgradeFailed`, `rebalanceFailed`, `peeringFailed`, `destroyFailed`, `offline`, `turningOffFailed`, `turningOnFailed`
-- `deletion_protection` (Boolean)
+- `deletion_protection` (Boolean) - Indicates whether deletion protection is enabled for the cluster. When enabled, the cluster cannot be deleted.
 - `etag` (String) Entity tag for the resource, used for caching and conditional requests.
 - `id` (String) - The ID of the cluster created.
  - **Format**: UUID (GUID4)

--- a/docs/resources/private_endpoint_service.md
+++ b/docs/resources/private_endpoint_service.md
@@ -31,6 +31,11 @@ resource "couchbase-capella_private_endpoint_service" "new_service" {
 - `organization_id` (String) The GUID4 ID of the organization.
 - `project_id` (String) The GUID4 ID of the project.
 
+### Read-Only
+
+- `status` (String) - status of the private endpoint
+ - **Valid Values**: `idle`, `unknown`, `enabling`, `enabled`, `enableFailed`, `disabling`, `disabled`, `disableFailed`
+
 ## Import
 
 Import is supported using the following syntax:

--- a/docs/resources/private_endpoint_service.md
+++ b/docs/resources/private_endpoint_service.md
@@ -4,11 +4,14 @@ page_title: "couchbase-capella_private_endpoint_service Resource - terraform-pro
 subcategory: ""
 description: |-
   This resource allows you to manage the private endpoint service for an operational cluster. The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. This enables secure access to your cluster without exposing traffic to the public internet.
+  ~> Enablement failure handling: If enablement terminally fails (status = enableFailed), the provider automatically issues a cleanup request to tear down the partially provisioned service and then removes the resource from Terraform state before the apply errors out. This is intentional: the resource disappearing from state is expected, and the next terraform apply performs a clean re-create. If the automatic cleanup cannot complete, the error will say so. Contact Couchbase Capella Support to check for orphaned resources in your cloud account.
 ---
 
 # couchbase-capella_private_endpoint_service (Resource)
 
 This resource allows you to manage the private endpoint service for an operational cluster. The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. This enables secure access to your cluster without exposing traffic to the public internet.
+
+~> **Enablement failure handling:** If enablement terminally fails (`status` = `enableFailed`), the provider automatically issues a cleanup request to tear down the partially provisioned service and then removes the resource from Terraform state before the apply errors out. This is intentional: the resource disappearing from state is expected, and the next `terraform apply` performs a clean re-create. If the automatic cleanup cannot complete, the error will say so. Contact Couchbase Capella Support to check for orphaned resources in your cloud account.
 
 ## Example Usage
 

--- a/docs/resources/private_endpoint_service.md
+++ b/docs/resources/private_endpoint_service.md
@@ -4,14 +4,14 @@ page_title: "couchbase-capella_private_endpoint_service Resource - terraform-pro
 subcategory: ""
 description: |-
   This resource allows you to manage the private endpoint service for an operational cluster. The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. This enables secure access to your cluster without exposing traffic to the public internet.
-  ~> Enablement failure handling: If enablement terminally fails (status = enableFailed), the provider automatically issues a cleanup request to tear down the partially provisioned service and then removes the resource from Terraform state before the apply errors out. This is intentional: the resource disappearing from state is expected, and the next terraform apply performs a clean re-create. If the automatic cleanup cannot complete, the error will say so. Contact Couchbase Capella Support to check for orphaned resources in your cloud account.
+  ~> Enablement failure handling: If enablement terminally fails (status = enableFailed), the provider automatically issues a cleanup request to tear down the partially provisioned service and then removes the resource from Terraform state before the apply errors out. This is intentional: the resource disappearing from state is expected, and the next terraform apply performs a clean re-create. If the automatic cleanup cannot complete, the error will say so — contact Couchbase Capella Support to check for orphaned resources in your cloud account.
 ---
 
 # couchbase-capella_private_endpoint_service (Resource)
 
 This resource allows you to manage the private endpoint service for an operational cluster. The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. This enables secure access to your cluster without exposing traffic to the public internet.
 
-~> **Enablement failure handling:** If enablement terminally fails (`status` = `enableFailed`), the provider automatically issues a cleanup request to tear down the partially provisioned service and then removes the resource from Terraform state before the apply errors out. This is intentional: the resource disappearing from state is expected, and the next `terraform apply` performs a clean re-create. If the automatic cleanup cannot complete, the error will say so. Contact Couchbase Capella Support to check for orphaned resources in your cloud account.
+~> **Enablement failure handling:** If enablement terminally fails (`status` = `enableFailed`), the provider automatically issues a cleanup request to tear down the partially provisioned service and then removes the resource from Terraform state before the apply errors out. This is intentional: the resource disappearing from state is expected, and the next `terraform apply` performs a clean re-create. If the automatic cleanup cannot complete, the error will say so — contact Couchbase Capella Support to check for orphaned resources in your cloud account.
 
 ## Example Usage
 

--- a/internal/api/private_endpoint_service.go
+++ b/internal/api/private_endpoint_service.go
@@ -3,6 +3,13 @@ package api
 // GetPrivateEndpointServiceStatusResponse is the response received from the Capella V4 Public API
 // when getting private endpoint service status.
 type GetPrivateEndpointServiceStatusResponse struct {
-	Enabled    bool   `json:"enabled"`
+	Enabled bool `json:"enabled"`
+
+	// Status is the lifecycle state of the private endpoint service derived from
+	// the most recent enable/disable/update operation (for example "enableFailed"
+	// or "enabling"). It is optional and best-effort: older control planes omit it,
+	// in which case callers fall back to the Enabled boolean.
+	Status *string `json:"status,omitempty"`
+
 	PrivateDns string `json:"privateDns"`
 }

--- a/internal/api/private_endpoint_service.go
+++ b/internal/api/private_endpoint_service.go
@@ -7,8 +7,9 @@ type GetPrivateEndpointServiceStatusResponse struct {
 
 	// Status is the lifecycle state of the private endpoint service derived from
 	// the most recent enable/disable/update operation (for example "enableFailed"
-	// or "enabling"). It is optional and best-effort: older control planes omit it,
-	// in which case callers fall back to the Enabled boolean.
+	// or "enabling"). It is optional and best-effort: it is omitted on GCP, when
+	// the status feature flag is disabled, and on older control planes, in which
+	// case callers fall back to the Enabled boolean.
 	Status *string `json:"status,omitempty"`
 
 	PrivateDns string `json:"privateDns"`

--- a/internal/datasources/private_endpoint_service.go
+++ b/internal/datasources/private_endpoint_service.go
@@ -92,6 +92,10 @@ func (p *PrivateEndpointService) Read(ctx context.Context, req datasource.ReadRe
 	}
 
 	state.Enabled = types.BoolValue(privateEndpointServiceStatus.Enabled)
+	state.Status = types.StringNull()
+	if privateEndpointServiceStatus.Status != nil {
+		state.Status = types.StringValue(*privateEndpointServiceStatus.Status)
+	}
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/datasources/private_endpoint_service_schema.go
+++ b/internal/datasources/private_endpoint_service_schema.go
@@ -16,6 +16,7 @@ func PrivateEndpointServiceSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "project_id", privateEndpointServiceBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "cluster_id", privateEndpointServiceBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "enabled", privateEndpointServiceBuilder, computedBool())
+	capellaschema.AddAttr(attrs, "status", privateEndpointServiceBuilder, computedString())
 
 	return schema.Schema{
 		MarkdownDescription: "The data source to retrieve private endpoint service information for a cluster.",

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -243,6 +243,14 @@ var (
 
 	ErrPrivateEndpointServiceTimeout = errors.New("changing private endpoint service status timed out after initiation")
 
+	// ErrPrivateEndpointServiceEnableFailed is returned when the backend reports a terminal
+	// enableFailed state for the private endpoint service. This is not retried by polling.
+	ErrPrivateEndpointServiceEnableFailed = errors.New("private endpoint service enablement failed")
+
+	// ErrPrivateEndpointServiceDisableFailed is returned when the backend reports a terminal
+	// disableFailed state for the private endpoint service. This is not retried by polling.
+	ErrPrivateEndpointServiceDisableFailed = errors.New("private endpoint service disable failed")
+
 	ErrBucketCreationStatusTimeout = errors.New("bucket backup creation status transition timed out after initiation")
 
 	ErrSnapshotBackupCreationStatusTimeout = errors.New("snapshot backup creation status transition timed out after initiation")

--- a/internal/resources/private_endpoint_service.go
+++ b/internal/resources/private_endpoint_service.go
@@ -3,12 +3,15 @@ package resources
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -26,6 +29,28 @@ var (
 
 const (
 	errorMessageWhileEnablingPrivateEndpointService = "There is an error while enabling private endpoint service. Please check in Capella to see if there are any hanging resources\" +\n\t\" have been created, unexpected error: "
+)
+
+// Private endpoint service lifecycle states returned by the GET status API.
+// enableFailed/disableFailed are terminal (no automatic retry); enabling,
+// disabling, and unknown are transient; idle means no operation has run.
+const (
+	statusIdle          = "idle"
+	statusEnabling      = "enabling"
+	statusEnabled       = "enabled"
+	statusEnableFailed  = "enableFailed"
+	statusDisabling     = "disabling"
+	statusDisabled      = "disabled"
+	statusDisableFailed = "disableFailed"
+	statusUnknown       = "unknown"
+
+	// cleanupTimeout bounds how long we wait for the backend to tear down a
+	// failed enable before giving up and surfacing an escalation error.
+	cleanupTimeout = 15 * time.Minute
+
+	// pollInterval is how often the service status is polled while waiting for a
+	// transition. The overall 60-minute timeout remains the backstop.
+	pollInterval = 30 * time.Second
 )
 
 // PrivateEndpointService is the scope resource implementation.
@@ -103,10 +128,17 @@ func (p *PrivateEndpointService) Create(ctx context.Context, req resource.Create
 
 	err = p.waitUntilStatusChanges(ctx, true, organizationId, projectId, clusterId)
 	if err != nil {
+		// Terminal enableFailed: clean up the orphaned infra and remove the
+		// resource so the next apply performs a clean re-create.
+		if stderrors.Is(err, errors.ErrPrivateEndpointServiceEnableFailed) {
+			p.handleFailedEnable(ctx, &resp.State, &resp.Diagnostics, organizationId, projectId, clusterId, err)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error could not enable private endpoint service",
 			"Error could not enable private endpoint service, unexpected error: "+err.Error(),
 		)
+		return
 	}
 
 	refreshedState, err := p.getServiceState(ctx, organizationId, projectId, clusterId)
@@ -166,6 +198,15 @@ func (p *PrivateEndpointService) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	// A terminally failed enable is treated like a missing resource: remove it
+	// from state so drift detection recreates it on the next apply instead of
+	// leaving a wedged resource that never converges.
+	if refreshedState.Status.ValueString() == statusEnableFailed {
+		tflog.Info(ctx, "private endpoint service is in enableFailed state; removing from state to force re-create")
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	diags = resp.State.Set(ctx, &refreshedState)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -219,6 +260,16 @@ func (p *PrivateEndpointService) Update(ctx context.Context, req resource.Update
 		config.ProjectId.ValueString(),
 		config.ClusterId.ValueString())
 	if err != nil {
+		// An enable-flavored update that fails terminally is recovered the same
+		// way as Create: clean up and remove from state for a clean retry.
+		if config.Enabled.ValueBool() && stderrors.Is(err, errors.ErrPrivateEndpointServiceEnableFailed) {
+			p.handleFailedEnable(ctx, &resp.State, &resp.Diagnostics,
+				config.OrganizationId.ValueString(),
+				config.ProjectId.ValueString(),
+				config.ClusterId.ValueString(),
+				err)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error "+status+" private endpoint service",
 			"Error "+status+"private endpoint service, unexpected error: "+err.Error(),
@@ -300,12 +351,26 @@ func (p *PrivateEndpointService) Delete(ctx context.Context, req resource.Delete
 
 	err = p.waitUntilStatusChanges(ctx, false, organizationId, projectId, clusterId)
 	if err != nil {
+		// On a terminal disableFailed we fail fast and keep the resource in state
+		// (Terraform retains a resource whose Delete errors). The correct retry
+		// for a failed disable is another destroy, which Terraform performs
+		// naturally on the next run.
+		if stderrors.Is(err, errors.ErrPrivateEndpointServiceDisableFailed) {
+			resp.Diagnostics.AddError(
+				"Private endpoint service disable failed",
+				fmt.Sprintf(
+					"Disable failed for cluster %s: %s. The resource has been kept in state; "+
+						"re-run terraform destroy to retry, and contact Couchbase Capella Support if it persists.",
+					clusterId, err.Error(),
+				),
+			)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error could not disable private endpoint service",
 			"Error could not disable private endpoint service, unexpected error: "+err.Error(),
 		)
 	}
-
 }
 
 // Configure It adds the provider configured api to the private endpoint service resource.
@@ -353,16 +418,26 @@ func initializePrivateEndpointServicePlan(plan providerschema.PrivateEndpointSer
 	if plan.Enabled.IsNull() || plan.Enabled.IsUnknown() {
 		plan.Enabled = types.BoolNull()
 	}
+	// status is computed; never persist an unknown value to state.
+	if plan.Status.IsNull() || plan.Status.IsUnknown() {
+		plan.Status = types.StringNull()
+	}
 	return plan
 }
 
-// waitUntilStatusChanges terraform will wait until the service status changes on the cluster.
+// waitUntilStatusChanges waits until the service reaches the desired state on the
+// cluster. When the API reports an explicit lifecycle status it is used to fail
+// fast on terminal states (enableFailed/disableFailed) and to keep polling on
+// transient ones (enabling/disabling/unknown). When the status is absent (an
+// older control plane) it falls back to the Enabled boolean, preserving the
+// previous behavior. The 60-minute timeout remains as a backstop.
 func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, finalState bool, organizationId, projectId, clusterId string) error {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, time.Minute*60)
 	defer cancel()
 
-	timer := time.NewTimer(time.Minute * 1)
+	timer := time.NewTimer(pollInterval)
+	defer timer.Stop()
 
 	for {
 		select {
@@ -375,12 +450,127 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 				return err
 			}
 
-			if response.Enabled == finalState {
-				return nil
+			// Older control planes do not report a status: fall back to the
+			// Enabled boolean, preserving the previous behavior.
+			if response.Status == nil {
+				if response.Enabled == finalState {
+					return nil
+				}
+				timer.Reset(pollInterval)
+				continue
 			}
-			timer.Reset(time.Minute * 1)
+
+			switch *response.Status {
+			case statusEnableFailed:
+				return errors.ErrPrivateEndpointServiceEnableFailed
+			case statusDisableFailed:
+				return errors.ErrPrivateEndpointServiceDisableFailed
+			case statusEnabling, statusDisabling, statusUnknown:
+				// Transient states: keep polling.
+			case statusEnabled, statusDisabled, statusIdle:
+				// Resolved states: confirm against the requested final state.
+				if response.Enabled == finalState {
+					return nil
+				}
+			}
+			timer.Reset(pollInterval)
 		}
 	}
+}
+
+// waitUntilCleanedUp waits for the backend to finish tearing down a failed enable
+// after a disable (DELETE) has been issued. It succeeds once the service reaches
+// disabled/idle (or reports disabled via the boolean on an older API) and fails
+// fast if the teardown itself reports disableFailed. It is bounded by
+// cleanupTimeout so a stuck cleanup does not block apply indefinitely.
+func (p *PrivateEndpointService) waitUntilCleanedUp(ctx context.Context, organizationId, projectId, clusterId string) error {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, cleanupTimeout)
+	defer cancel()
+
+	timer := time.NewTimer(pollInterval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.ErrPrivateEndpointServiceTimeout
+
+		case <-timer.C:
+			response, err := p.getServiceStatus(ctx, organizationId, projectId, clusterId)
+			if err != nil {
+				return err
+			}
+
+			if response.Status != nil {
+				switch *response.Status {
+				case statusDisableFailed:
+					return errors.ErrPrivateEndpointServiceDisableFailed
+				case statusDisabled, statusIdle:
+					return nil
+				}
+				// enableFailed/disabling/etc: cleanup still in progress, keep polling.
+			} else if !response.Enabled {
+				return nil
+			}
+			timer.Reset(pollInterval)
+		}
+	}
+}
+
+// cleanupFailedEnable issues a disable (DELETE) to trigger backend teardown of a
+// failed enable and waits for the teardown to complete. The backend allows
+// disable from the enableFailed state specifically so this orphaned infra can be
+// cleaned up.
+func (p *PrivateEndpointService) cleanupFailedEnable(ctx context.Context, organizationId, projectId, clusterId string) error {
+	url := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/privateEndpointService",
+		p.HostURL,
+		organizationId,
+		projectId,
+		clusterId,
+	)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodDelete, SuccessStatus: http.StatusAccepted}
+	if _, err := p.ClientV1.ExecuteWithRetry(ctx, cfg, nil, p.Token, nil); err != nil {
+		return fmt.Errorf("could not trigger cleanup of failed enable: %w", err)
+	}
+
+	return p.waitUntilCleanedUp(ctx, organizationId, projectId, clusterId)
+}
+
+// handleFailedEnable performs the Option A recovery for a terminal enableFailed:
+// it triggers backend cleanup of the orphaned resources, removes the resource
+// from state so the next apply performs a clean re-create, and surfaces an
+// actionable error. State is removed even when cleanup itself fails, because
+// leaving a permanently-failed resource in state recreates the stuck-pipeline
+// problem; the loud error directs escalation for the rare orphaned-infra case.
+func (p *PrivateEndpointService) handleFailedEnable(ctx context.Context, state *tfsdk.State, diags *diag.Diagnostics, organizationId, projectId, clusterId string, cause error) {
+	tflog.Error(ctx, "private endpoint service enablement failed; triggering cleanup and removing from state")
+
+	cleanupErr := p.cleanupFailedEnable(ctx, organizationId, projectId, clusterId)
+	state.RemoveResource(ctx)
+
+	if cleanupErr != nil {
+		diags.AddError(
+			"Private endpoint service enablement failed and automatic cleanup did not complete",
+			fmt.Sprintf(
+				"Enablement failed for cluster %s: %s. Automatic cleanup of the failed resources did not complete: %s. "+
+					"There may be orphaned resources in your cloud account; please contact Couchbase Capella Support. "+
+					"The resource has been removed from state; re-run terraform apply to retry enablement.",
+				clusterId, cause.Error(), cleanupErr.Error(),
+			),
+		)
+		return
+	}
+
+	diags.AddError(
+		"Private endpoint service enablement failed",
+		fmt.Sprintf(
+			"Enablement failed for cluster %s: %s. The failed resources were cleaned up automatically and the resource "+
+				"has been removed from state; re-run terraform apply to retry enablement.",
+			clusterId, cause.Error(),
+		),
+	)
 }
 
 // getServiceStatus retrieves current private endpoint service status.
@@ -419,6 +609,10 @@ func (p *PrivateEndpointService) getServiceState(ctx context.Context, organizati
 		ProjectId:      types.StringValue(projectId),
 		ClusterId:      types.StringValue(clusterId),
 		Enabled:        types.BoolValue(response.Enabled),
+		Status:         types.StringNull(),
+	}
+	if response.Status != nil {
+		state.Status = types.StringValue(*response.Status)
 	}
 
 	return &state, nil

--- a/internal/resources/private_endpoint_service.go
+++ b/internal/resources/private_endpoint_service.go
@@ -53,8 +53,12 @@ var (
 	cleanupTimeout = 15 * time.Minute
 
 	// pollInterval is how often the service status is polled while waiting for a
-	// transition. The overall 60-minute timeout remains the backstop.
+	// transition.
 	pollInterval = 30 * time.Second
+
+	// statusChangeTimeout bounds how long we wait for the service to reach the
+	// desired lifecycle state, end-to-end.
+	statusChangeTimeout = 60 * time.Minute
 )
 
 // PrivateEndpointService is the scope resource implementation.
@@ -427,22 +431,29 @@ func initializePrivateEndpointServicePlan(plan providerschema.PrivateEndpointSer
 }
 
 // waitUntilStatusChanges waits until the service reaches the desired state on the
-// cluster. When the API reports an explicit lifecycle status it is used to fail
-// fast on terminal states (enableFailed/disableFailed) and to keep polling on
-// transient ones (enabling/disabling/unknown). When the status is absent — which
-// happens on GCP, when the private endpoint status feature flag is disabled, or
-// on older control planes — it falls back to the Enabled boolean, preserving the
-// previous behavior. The 60-minute timeout remains as a backstop.
+// cluster. When the API reports an explicit lifecycle status it keeps polling on
+// transient ones (enabling/disabling/unknown) and fails fast on terminal ones
+// (enableFailed/disableFailed) — but only once it has seen evidence the current
+// operation is in flight, so a residual terminal state from a prior attempt is
+// not mistaken for failure of the operation we just issued. When the status is
+// absent — which happens on GCP, when the private endpoint status feature flag
+// is disabled, or on older control planes — it falls back to the Enabled
+// boolean, preserving the previous behavior. The overall timeout remains as a
+// backstop.
 func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, finalState bool, organizationId, projectId, clusterId string) error {
 	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, time.Minute*60)
+	ctx, cancel = context.WithTimeout(ctx, statusChangeTimeout)
 	defer cancel()
 
-	// Fire immediately so a terminal enableFailed/disableFailed is observed
-	// without paying a pollInterval delay; subsequent iterations Reset to
-	// pollInterval below.
 	timer := time.NewTimer(0)
 	defer timer.Stop()
+
+	// sawInFlight flips true once we observe any status other than the
+	// terminal-failure ones, which is our evidence that the backend has
+	// progressed past whatever residual state was present before our POST.
+	// Until then, a reported enableFailed/disableFailed could be stale and is
+	// treated as transient.
+	var sawInFlight bool
 
 	for {
 		select {
@@ -468,13 +479,17 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 
 			switch *response.Status {
 			case statusEnableFailed:
-				return errors.ErrPrivateEndpointServiceEnableFailed
+				if sawInFlight {
+					return errors.ErrPrivateEndpointServiceEnableFailed
+				}
 			case statusDisableFailed:
-				return errors.ErrPrivateEndpointServiceDisableFailed
+				if sawInFlight {
+					return errors.ErrPrivateEndpointServiceDisableFailed
+				}
 			case statusEnabling, statusDisabling, statusUnknown:
-				// Transient states: keep polling.
+				sawInFlight = true
 			case statusEnabled, statusDisabled, statusIdle:
-				// Resolved states: confirm against the requested final state.
+				sawInFlight = true
 				if response.Enabled == finalState {
 					return nil
 				}

--- a/internal/resources/private_endpoint_service.go
+++ b/internal/resources/private_endpoint_service.go
@@ -43,7 +43,11 @@ const (
 	statusDisabled      = "disabled"
 	statusDisableFailed = "disableFailed"
 	statusUnknown       = "unknown"
+)
 
+// These are vars rather than consts so unit tests can shorten them; production
+// behavior is unchanged.
+var (
 	// cleanupTimeout bounds how long we wait for the backend to tear down a
 	// failed enable before giving up and surfacing an escalation error.
 	cleanupTimeout = 15 * time.Minute
@@ -198,9 +202,6 @@ func (p *PrivateEndpointService) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	// A terminally failed enable is treated like a missing resource: remove it
-	// from state so drift detection recreates it on the next apply instead of
-	// leaving a wedged resource that never converges.
 	if refreshedState.Status.ValueString() == statusEnableFailed {
 		tflog.Info(ctx, "private endpoint service is in enableFailed state; removing from state to force re-create")
 		resp.State.RemoveResource(ctx)
@@ -428,8 +429,9 @@ func initializePrivateEndpointServicePlan(plan providerschema.PrivateEndpointSer
 // waitUntilStatusChanges waits until the service reaches the desired state on the
 // cluster. When the API reports an explicit lifecycle status it is used to fail
 // fast on terminal states (enableFailed/disableFailed) and to keep polling on
-// transient ones (enabling/disabling/unknown). When the status is absent (an
-// older control plane) it falls back to the Enabled boolean, preserving the
+// transient ones (enabling/disabling/unknown). When the status is absent — which
+// happens on GCP, when the private endpoint status feature flag is disabled, or
+// on older control planes — it falls back to the Enabled boolean, preserving the
 // previous behavior. The 60-minute timeout remains as a backstop.
 func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, finalState bool, organizationId, projectId, clusterId string) error {
 	var cancel context.CancelFunc
@@ -450,8 +452,9 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 				return err
 			}
 
-			// Older control planes do not report a status: fall back to the
-			// Enabled boolean, preserving the previous behavior.
+			// Status is absent on GCP, when the status feature flag is disabled,
+			// or on older control planes: fall back to the Enabled boolean,
+			// preserving the previous behavior.
 			if response.Status == nil {
 				if response.Enabled == finalState {
 					return nil
@@ -480,8 +483,9 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 
 // waitUntilCleanedUp waits for the backend to finish tearing down a failed enable
 // after a disable (DELETE) has been issued. It succeeds once the service reaches
-// disabled/idle (or reports disabled via the boolean on an older API) and fails
-// fast if the teardown itself reports disableFailed. It is bounded by
+// disabled/idle (or reports disabled via the boolean when status is absent — on
+// GCP, with the status feature flag disabled, or on older control planes) and
+// fails fast if the teardown itself reports disableFailed. It is bounded by
 // cleanupTimeout so a stuck cleanup does not block apply indefinitely.
 func (p *PrivateEndpointService) waitUntilCleanedUp(ctx context.Context, organizationId, projectId, clusterId string) error {
 	var cancel context.CancelFunc
@@ -538,7 +542,7 @@ func (p *PrivateEndpointService) cleanupFailedEnable(ctx context.Context, organi
 	return p.waitUntilCleanedUp(ctx, organizationId, projectId, clusterId)
 }
 
-// handleFailedEnable performs the Option A recovery for a terminal enableFailed:
+// handleFailedEnable performs recovery for a terminal enableFailed:
 // it triggers backend cleanup of the orphaned resources, removes the resource
 // from state so the next apply performs a clean re-create, and surfaces an
 // actionable error. State is removed even when cleanup itself fails, because

--- a/internal/resources/private_endpoint_service.go
+++ b/internal/resources/private_endpoint_service.go
@@ -28,7 +28,7 @@ var (
 )
 
 const (
-	errorMessageWhileEnablingPrivateEndpointService = "There is an error while enabling private endpoint service. Please check in Capella to see if there are any hanging resources that have have been created, unexpected error: "
+	errorMessageWhileEnablingPrivateEndpointService = "There is an error while enabling private endpoint service. Please check in Capella to see if there are any hanging resources that have been created, unexpected error: "
 )
 
 // Private endpoint service lifecycle states returned by the GET status API.
@@ -438,7 +438,10 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 	ctx, cancel = context.WithTimeout(ctx, time.Minute*60)
 	defer cancel()
 
-	timer := time.NewTimer(pollInterval)
+	// Fire immediately so a terminal enableFailed/disableFailed is observed
+	// without paying a pollInterval delay; subsequent iterations Reset to
+	// pollInterval below.
+	timer := time.NewTimer(0)
 	defer timer.Stop()
 
 	for {
@@ -492,7 +495,9 @@ func (p *PrivateEndpointService) waitUntilCleanedUp(ctx context.Context, organiz
 	ctx, cancel = context.WithTimeout(ctx, cleanupTimeout)
 	defer cancel()
 
-	timer := time.NewTimer(pollInterval)
+	// Fire immediately so a terminal disableFailed (or post-teardown 404) is
+	// observed without paying a pollInterval delay.
+	timer := time.NewTimer(0)
 	defer timer.Stop()
 
 	for {
@@ -503,6 +508,11 @@ func (p *PrivateEndpointService) waitUntilCleanedUp(ctx context.Context, organiz
 		case <-timer.C:
 			response, err := p.getServiceStatus(ctx, organizationId, projectId, clusterId)
 			if err != nil {
+				// A post-teardown 404 means cleanup finished — the service no
+				// longer exists on the backend, which is the success condition.
+				if resourceNotFound, _ := api.CheckResourceNotFoundError(err); resourceNotFound {
+					return nil
+				}
 				return err
 			}
 

--- a/internal/resources/private_endpoint_service.go
+++ b/internal/resources/private_endpoint_service.go
@@ -463,6 +463,12 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 		case <-timer.C:
 			response, err := p.getServiceStatus(ctx, organizationId, projectId, clusterId)
 			if err != nil {
+				// If our deadline expired mid-request, surface the typed
+				// timeout rather than the raw context error — the select may
+				// race with ctx.Done() when both are ready.
+				if ctx.Err() != nil {
+					return errors.ErrPrivateEndpointServiceTimeout
+				}
 				return err
 			}
 

--- a/internal/resources/private_endpoint_service.go
+++ b/internal/resources/private_endpoint_service.go
@@ -28,7 +28,7 @@ var (
 )
 
 const (
-	errorMessageWhileEnablingPrivateEndpointService = "There is an error while enabling private endpoint service. Please check in Capella to see if there are any hanging resources\" +\n\t\" have been created, unexpected error: "
+	errorMessageWhileEnablingPrivateEndpointService = "There is an error while enabling private endpoint service. Please check in Capella to see if there are any hanging resources that have have been created, unexpected error: "
 )
 
 // Private endpoint service lifecycle states returned by the GET status API.
@@ -208,7 +208,7 @@ func (p *PrivateEndpointService) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	diags = resp.State.Set(ctx, &refreshedState)
+	diags = resp.State.Set(ctx, refreshedState)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resources/private_endpoint_service.go
+++ b/internal/resources/private_endpoint_service.go
@@ -455,9 +455,25 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 	// treated as transient.
 	var sawInFlight bool
 
+	// lastTerminalFailure records a terminal-failure status we observed but
+	// deferred on because sawInFlight was still false (i.e. it might have been
+	// residual from a prior attempt). If the backend never transitions and we
+	// hit the overall timeout, this lets us surface the typed failure error so
+	// the caller still routes to cleanup, instead of a generic timeout that
+	// would leave orphaned infra behind and skip state removal.
+	var lastTerminalFailure error
+
 	for {
 		select {
 		case <-ctx.Done():
+			// If the operation appeared stuck at a terminal failure the whole
+			// time (sawInFlight never flipped), trust that failure now rather
+			// than returning a generic timeout — the generic timeout does not
+			// route to handleFailedEnable, so cleanup/state-removal would be
+			// skipped.
+			if lastTerminalFailure != nil {
+				return lastTerminalFailure
+			}
 			return errors.ErrPrivateEndpointServiceTimeout
 
 		case <-timer.C:
@@ -467,6 +483,9 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 				// timeout rather than the raw context error — the select may
 				// race with ctx.Done() when both are ready.
 				if ctx.Err() != nil {
+					if lastTerminalFailure != nil {
+						return lastTerminalFailure
+					}
 					return errors.ErrPrivateEndpointServiceTimeout
 				}
 				return err
@@ -488,14 +507,22 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 				if sawInFlight {
 					return errors.ErrPrivateEndpointServiceEnableFailed
 				}
+				// Possibly-stale: defer, but remember it so a never-transitioning
+				// enableFailed is still routed to cleanup on timeout.
+				lastTerminalFailure = errors.ErrPrivateEndpointServiceEnableFailed
 			case statusDisableFailed:
 				if sawInFlight {
 					return errors.ErrPrivateEndpointServiceDisableFailed
 				}
+				lastTerminalFailure = errors.ErrPrivateEndpointServiceDisableFailed
 			case statusEnabling, statusDisabling, statusUnknown:
 				sawInFlight = true
+				// The backend progressed, so any earlier terminal status was
+				// genuinely stale; a later stall is a real transition timeout.
+				lastTerminalFailure = nil
 			case statusEnabled, statusDisabled, statusIdle:
 				sawInFlight = true
+				lastTerminalFailure = nil
 				if response.Enabled == finalState {
 					return nil
 				}

--- a/internal/resources/private_endpoint_service_schema.go
+++ b/internal/resources/private_endpoint_service_schema.go
@@ -27,7 +27,12 @@ func PrivateEndpointServiceSchema() schema.Schema {
 	})
 
 	return schema.Schema{
-		MarkdownDescription: "This resource allows you to manage the private endpoint service for an operational cluster. The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. This enables secure access to your cluster without exposing traffic to the public internet.",
-		Attributes:          attrs,
+		MarkdownDescription: "This resource allows you to manage the private endpoint service for an operational cluster. " +
+			"The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. " +
+			"This enables secure access to your cluster without exposing traffic to the public internet.\n\n" +
+			"~> **Enablement failure handling:** If enablement terminally fails (`status` = `enableFailed`), the provider automatically issues a cleanup request to tear down the partially provisioned service and then removes the resource from Terraform state before the apply errors out. " +
+			"This is intentional: the resource disappearing from state is expected, and the next `terraform apply` performs a clean re-create. " +
+			"If the automatic cleanup cannot complete, the error will say so — contact Couchbase Capella Support to check for orphaned resources in your cloud account.",
+		Attributes: attrs,
 	}
 }

--- a/internal/resources/private_endpoint_service_schema.go
+++ b/internal/resources/private_endpoint_service_schema.go
@@ -22,6 +22,10 @@ func PrivateEndpointServiceSchema() schema.Schema {
 		PlanModifiers: []planmodifier.Bool{custommodifier.BlockCreateWhenEnabledSetToFalse()},
 	})
 
+	capellaschema.AddAttr(attrs, "status", privateEndpointServiceBuilder, &schema.StringAttribute{
+		Computed: true,
+	})
+
 	return schema.Schema{
 		MarkdownDescription: "This resource allows you to manage the private endpoint service for an operational cluster. The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. This enables secure access to your cluster without exposing traffic to the public internet.",
 		Attributes:          attrs,

--- a/internal/resources/private_endpoint_service_test.go
+++ b/internal/resources/private_endpoint_service_test.go
@@ -132,24 +132,38 @@ func TestWaitUntilStatusChanges(t *testing.T) {
 		wantErr    error
 	}{
 		{
-			// Without ever observing the backend progress past the terminal
-			// state, the poll cannot tell a stale enableFailed apart from a
-			// real one — it must wait for evidence the current operation is
-			// in flight. If nothing ever changes, the overall timeout fires
-			// and surfaces the (less specific) timeout error.
-			name:       "enableFailed stuck without any progress times out",
+			// A terminal enableFailed that is present from the first poll and
+			// never transitions cannot be told apart from a stale one while it
+			// is happening, so the loop keeps polling. But on the overall
+			// timeout we trust the persistent terminal status and surface the
+			// typed failure (not a generic timeout) so the caller still routes
+			// to cleanup / state removal instead of leaving orphaned infra.
+			name:       "enableFailed stuck without any progress surfaces enableFailed on timeout",
 			finalState: true,
 			statuses: []api.GetPrivateEndpointServiceStatusResponse{
 				{Enabled: false, Status: strPtr(statusEnableFailed)},
 			},
-			wantErr: errors.ErrPrivateEndpointServiceTimeout,
+			wantErr: errors.ErrPrivateEndpointServiceEnableFailed,
 		},
 		{
 			// Symmetric case on the disable path.
-			name:       "disableFailed stuck without any progress times out",
+			name:       "disableFailed stuck without any progress surfaces disableFailed on timeout",
 			finalState: false,
 			statuses: []api.GetPrivateEndpointServiceStatusResponse{
 				{Enabled: true, Status: strPtr(statusDisableFailed)},
+			},
+			wantErr: errors.ErrPrivateEndpointServiceDisableFailed,
+		},
+		{
+			// Once the backend shows progress (enabling) the earlier terminal
+			// status was genuinely stale, so a later stall is a real transition
+			// timeout — NOT a failure. This proves the deferred-failure latch is
+			// cleared when sawInFlight flips.
+			name:       "stale enableFailed then stuck enabling times out generically",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: strPtr(statusEnableFailed)},
+				{Enabled: false, Status: strPtr(statusEnabling)},
 			},
 			wantErr: errors.ErrPrivateEndpointServiceTimeout,
 		},

--- a/internal/resources/private_endpoint_service_test.go
+++ b/internal/resources/private_endpoint_service_test.go
@@ -111,12 +111,14 @@ func strPtr(s string) *string { return &s }
 // so the poll loops resolve in milliseconds rather than seconds.
 func fastPolling(t *testing.T) {
 	t.Helper()
-	origPoll, origCleanup := pollInterval, cleanupTimeout
+	origPoll, origCleanup, origStatus := pollInterval, cleanupTimeout, statusChangeTimeout
 	pollInterval = time.Millisecond
 	cleanupTimeout = 2 * time.Second
+	statusChangeTimeout = 2 * time.Second
 	t.Cleanup(func() {
 		pollInterval = origPoll
 		cleanupTimeout = origCleanup
+		statusChangeTimeout = origStatus
 	})
 }
 
@@ -130,20 +132,26 @@ func TestWaitUntilStatusChanges(t *testing.T) {
 		wantErr    error
 	}{
 		{
-			name:       "terminal enableFailed returns enable-failed error",
+			// Without ever observing the backend progress past the terminal
+			// state, the poll cannot tell a stale enableFailed apart from a
+			// real one — it must wait for evidence the current operation is
+			// in flight. If nothing ever changes, the overall timeout fires
+			// and surfaces the (less specific) timeout error.
+			name:       "enableFailed stuck without any progress times out",
 			finalState: true,
 			statuses: []api.GetPrivateEndpointServiceStatusResponse{
 				{Enabled: false, Status: strPtr(statusEnableFailed)},
 			},
-			wantErr: errors.ErrPrivateEndpointServiceEnableFailed,
+			wantErr: errors.ErrPrivateEndpointServiceTimeout,
 		},
 		{
-			name:       "terminal disableFailed returns disable-failed error",
+			// Symmetric case on the disable path.
+			name:       "disableFailed stuck without any progress times out",
 			finalState: false,
 			statuses: []api.GetPrivateEndpointServiceStatusResponse{
 				{Enabled: true, Status: strPtr(statusDisableFailed)},
 			},
-			wantErr: errors.ErrPrivateEndpointServiceDisableFailed,
+			wantErr: errors.ErrPrivateEndpointServiceTimeout,
 		},
 		{
 			name:       "transient enabling resolves to enabled",
@@ -183,6 +191,45 @@ func TestWaitUntilStatusChanges(t *testing.T) {
 				{Enabled: true, Status: strPtr(statusEnabled)},
 			},
 			wantErr: nil,
+		},
+		{
+			// Reproduces the stale-state race: a prior failed attempt left the
+			// backend in enableFailed; our POST has been accepted but the GET we
+			// fire immediately afterward may still see the residual terminal
+			// state before the new enable job is observed. The poll must wait
+			// for evidence the current operation is in flight (a transient
+			// state) before short-circuiting on a terminal status.
+			name:       "stale enableFailed before current operation in flight resolves to enabled",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: strPtr(statusEnableFailed)},
+				{Enabled: false, Status: strPtr(statusEnabling)},
+				{Enabled: true, Status: strPtr(statusEnabled)},
+			},
+			wantErr: nil,
+		},
+		{
+			// Symmetric case on the disable path.
+			name:       "stale disableFailed before current operation in flight resolves to disabled",
+			finalState: false,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: strPtr(statusDisableFailed)},
+				{Enabled: true, Status: strPtr(statusDisabling)},
+				{Enabled: false, Status: strPtr(statusDisabled)},
+			},
+			wantErr: nil,
+		},
+		{
+			// After we have evidence the current operation is in flight, a
+			// terminal status IS authoritative — the existing fail-fast
+			// behavior must be preserved.
+			name:       "enableFailed after transient enabling is terminal",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: strPtr(statusEnabling)},
+				{Enabled: false, Status: strPtr(statusEnableFailed)},
+			},
+			wantErr: errors.ErrPrivateEndpointServiceEnableFailed,
 		},
 	}
 

--- a/internal/resources/private_endpoint_service_test.go
+++ b/internal/resources/private_endpoint_service_test.go
@@ -92,7 +92,7 @@ func (b *fakeBackend) handler(w http.ResponseWriter, r *http.Request) {
 
 // newTestResource wires a PrivateEndpointService to an httptest server backed
 // by the supplied fakeBackend.
-func newTestResource(t *testing.T, b *fakeBackend) (*PrivateEndpointService, *httptest.Server) {
+func newTestResource(t *testing.T, b *fakeBackend) *PrivateEndpointService {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(b.handler))
 	t.Cleanup(srv.Close)
@@ -101,9 +101,8 @@ func newTestResource(t *testing.T, b *fakeBackend) (*PrivateEndpointService, *ht
 		Data: &providerschema.Data{
 			ClientV1: &api.Client{Client: srv.Client()},
 			HostURL:  srv.URL,
-			Token:    "test-token",
 		},
-	}, srv
+	}
 }
 
 func strPtr(s string) *string { return &s }
@@ -190,7 +189,7 @@ func TestWaitUntilStatusChanges(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			b := &fakeBackend{statuses: tc.statuses}
-			p, _ := newTestResource(t, b)
+			p := newTestResource(t, b)
 
 			err := p.waitUntilStatusChanges(context.Background(), tc.finalState, testOrgID, testProjectID, testClusterID)
 
@@ -240,7 +239,7 @@ func TestWaitUntilCleanedUp(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			b := &fakeBackend{statuses: tc.statuses}
-			p, _ := newTestResource(t, b)
+			p := newTestResource(t, b)
 
 			err := p.waitUntilCleanedUp(context.Background(), testOrgID, testProjectID, testClusterID)
 
@@ -261,7 +260,7 @@ func TestCleanupFailedEnableIssuesDelete(t *testing.T) {
 			{Enabled: false, Status: strPtr(statusDisabled)},
 		},
 	}
-	p, _ := newTestResource(t, b)
+	p := newTestResource(t, b)
 
 	err := p.cleanupFailedEnable(context.Background(), testOrgID, testProjectID, testClusterID)
 	assert.NilError(t, err)
@@ -277,7 +276,7 @@ func TestCleanupFailedEnablePropagatesDeleteError(t *testing.T) {
 		deleteStatus: http.StatusInternalServerError,
 		deleteBody:   `{"code":4000,"message":"boom","httpStatusCode":500}`,
 	}
-	p, _ := newTestResource(t, b)
+	p := newTestResource(t, b)
 
 	err := p.cleanupFailedEnable(context.Background(), testOrgID, testProjectID, testClusterID)
 	assert.Assert(t, err != nil, "a failed DELETE must surface an error")
@@ -294,7 +293,7 @@ func TestHandleFailedEnableCleansUpAndRemovesState(t *testing.T) {
 			{Enabled: false, Status: strPtr(statusDisabled)},
 		},
 	}
-	p, _ := newTestResource(t, b)
+	p := newTestResource(t, b)
 
 	state := &tfsdk.State{Schema: PrivateEndpointServiceSchema()}
 	var diags diag.Diagnostics
@@ -317,7 +316,7 @@ func TestHandleFailedEnableRemovesStateEvenWhenCleanupFails(t *testing.T) {
 		deleteStatus: http.StatusInternalServerError,
 		deleteBody:   `{"code":4000,"message":"boom","httpStatusCode":500}`,
 	}
-	p, _ := newTestResource(t, b)
+	p := newTestResource(t, b)
 
 	state := &tfsdk.State{Schema: PrivateEndpointServiceSchema()}
 	var diags diag.Diagnostics
@@ -356,7 +355,7 @@ func TestGetServiceState(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			b := &fakeBackend{statuses: []api.GetPrivateEndpointServiceStatusResponse{tc.status}}
-			p, _ := newTestResource(t, b)
+			p := newTestResource(t, b)
 
 			got, err := p.getServiceState(context.Background(), testOrgID, testProjectID, testClusterID)
 			assert.NilError(t, err)

--- a/internal/resources/private_endpoint_service_test.go
+++ b/internal/resources/private_endpoint_service_test.go
@@ -1,0 +1,370 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"gotest.tools/assert"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+const (
+	testOrgID     = "org-1"
+	testProjectID = "proj-1"
+	testClusterID = "cluster-1"
+)
+
+// fakeBackend is an in-memory control-plane stand-in for the private endpoint
+// service API. It records every request it receives and answers GET status
+// polls from a scripted queue of responses (the final entry repeats once the
+// queue is drained) so tests can drive the poll loop deterministically.
+type fakeBackend struct {
+	mu sync.Mutex
+
+	// statuses is the queue of GET /privateEndpointService responses. The last
+	// element is returned for any poll beyond the queue length.
+	statuses []api.GetPrivateEndpointServiceStatusResponse
+
+	// deleteStatus is the HTTP status returned for DELETE requests.
+	deleteStatus int
+	// deleteBody is the body returned for DELETE requests (used to simulate an
+	// API error on cleanup).
+	deleteBody string
+
+	// recorded request methods, in order.
+	methods []string
+	getIdx  int
+}
+
+func (b *fakeBackend) counts() (gets, deletes int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, m := range b.methods {
+		switch m {
+		case http.MethodGet:
+			gets++
+		case http.MethodDelete:
+			deletes++
+		}
+	}
+	return gets, deletes
+}
+
+func (b *fakeBackend) handler(w http.ResponseWriter, r *http.Request) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.methods = append(b.methods, r.Method)
+
+	switch r.Method {
+	case http.MethodDelete:
+		status := b.deleteStatus
+		if status == 0 {
+			status = http.StatusAccepted
+		}
+		w.WriteHeader(status)
+		if b.deleteBody != "" {
+			_, _ = w.Write([]byte(b.deleteBody))
+		}
+	case http.MethodGet:
+		idx := b.getIdx
+		if idx >= len(b.statuses) {
+			idx = len(b.statuses) - 1
+		}
+		b.getIdx++
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(b.statuses[idx])
+	default:
+		// Treat POST (enable) as accepted.
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+// newTestResource wires a PrivateEndpointService to an httptest server backed
+// by the supplied fakeBackend.
+func newTestResource(t *testing.T, b *fakeBackend) (*PrivateEndpointService, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(b.handler))
+	t.Cleanup(srv.Close)
+
+	return &PrivateEndpointService{
+		Data: &providerschema.Data{
+			ClientV1: &api.Client{Client: srv.Client()},
+			HostURL:  srv.URL,
+			Token:    "test-token",
+		},
+	}, srv
+}
+
+func strPtr(s string) *string { return &s }
+
+// fastPolling shrinks the package-level poll timing for the duration of a test
+// so the poll loops resolve in milliseconds rather than seconds.
+func fastPolling(t *testing.T) {
+	t.Helper()
+	origPoll, origCleanup := pollInterval, cleanupTimeout
+	pollInterval = time.Millisecond
+	cleanupTimeout = 2 * time.Second
+	t.Cleanup(func() {
+		pollInterval = origPoll
+		cleanupTimeout = origCleanup
+	})
+}
+
+func TestWaitUntilStatusChanges(t *testing.T) {
+	fastPolling(t)
+
+	tests := []struct {
+		name       string
+		finalState bool
+		statuses   []api.GetPrivateEndpointServiceStatusResponse
+		wantErr    error
+	}{
+		{
+			name:       "terminal enableFailed returns enable-failed error",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: strPtr(statusEnableFailed)},
+			},
+			wantErr: errors.ErrPrivateEndpointServiceEnableFailed,
+		},
+		{
+			name:       "terminal disableFailed returns disable-failed error",
+			finalState: false,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: strPtr(statusDisableFailed)},
+			},
+			wantErr: errors.ErrPrivateEndpointServiceDisableFailed,
+		},
+		{
+			name:       "transient enabling resolves to enabled",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: strPtr(statusEnabling)},
+				{Enabled: false, Status: strPtr(statusUnknown)},
+				{Enabled: true, Status: strPtr(statusEnabled)},
+			},
+			wantErr: nil,
+		},
+		{
+			name:       "transient disabling resolves to disabled",
+			finalState: false,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: strPtr(statusDisabling)},
+				{Enabled: false, Status: strPtr(statusDisabled)},
+			},
+			wantErr: nil,
+		},
+		{
+			name:       "older control plane falls back to enabled boolean",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: nil},
+				{Enabled: true, Status: nil},
+			},
+			wantErr: nil,
+		},
+		{
+			name:       "resolved status but wrong boolean keeps polling until match",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				// Status says enabled but the boolean has not flipped yet, so the
+				// loop must keep polling rather than return early.
+				{Enabled: false, Status: strPtr(statusEnabled)},
+				{Enabled: true, Status: strPtr(statusEnabled)},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &fakeBackend{statuses: tc.statuses}
+			p, _ := newTestResource(t, b)
+
+			err := p.waitUntilStatusChanges(context.Background(), tc.finalState, testOrgID, testProjectID, testClusterID)
+
+			if tc.wantErr != nil {
+				assert.Assert(t, stderrors.Is(err, tc.wantErr), "got %v, want %v", err, tc.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}
+
+func TestWaitUntilCleanedUp(t *testing.T) {
+	fastPolling(t)
+
+	tests := []struct {
+		name     string
+		statuses []api.GetPrivateEndpointServiceStatusResponse
+		wantErr  error
+	}{
+		{
+			name: "reaches disabled after teardown",
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: strPtr(statusEnableFailed)},
+				{Enabled: false, Status: strPtr(statusDisabling)},
+				{Enabled: false, Status: strPtr(statusDisabled)},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "teardown reports disableFailed",
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: strPtr(statusDisableFailed)},
+			},
+			wantErr: errors.ErrPrivateEndpointServiceDisableFailed,
+		},
+		{
+			name: "older control plane resolves via enabled boolean",
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: nil},
+				{Enabled: false, Status: nil},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &fakeBackend{statuses: tc.statuses}
+			p, _ := newTestResource(t, b)
+
+			err := p.waitUntilCleanedUp(context.Background(), testOrgID, testProjectID, testClusterID)
+
+			if tc.wantErr != nil {
+				assert.Assert(t, stderrors.Is(err, tc.wantErr), "got %v, want %v", err, tc.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}
+
+func TestCleanupFailedEnableIssuesDelete(t *testing.T) {
+	fastPolling(t)
+
+	b := &fakeBackend{
+		statuses: []api.GetPrivateEndpointServiceStatusResponse{
+			{Enabled: false, Status: strPtr(statusDisabled)},
+		},
+	}
+	p, _ := newTestResource(t, b)
+
+	err := p.cleanupFailedEnable(context.Background(), testOrgID, testProjectID, testClusterID)
+	assert.NilError(t, err)
+
+	_, deletes := b.counts()
+	assert.Equal(t, deletes, 1, "cleanup must issue exactly one DELETE on the user's behalf")
+}
+
+func TestCleanupFailedEnablePropagatesDeleteError(t *testing.T) {
+	fastPolling(t)
+
+	b := &fakeBackend{
+		deleteStatus: http.StatusInternalServerError,
+		deleteBody:   `{"code":4000,"message":"boom","httpStatusCode":500}`,
+	}
+	p, _ := newTestResource(t, b)
+
+	err := p.cleanupFailedEnable(context.Background(), testOrgID, testProjectID, testClusterID)
+	assert.Assert(t, err != nil, "a failed DELETE must surface an error")
+
+	gets, _ := b.counts()
+	assert.Equal(t, gets, 0, "must not poll for cleanup completion when the DELETE itself failed")
+}
+
+func TestHandleFailedEnableCleansUpAndRemovesState(t *testing.T) {
+	fastPolling(t)
+
+	b := &fakeBackend{
+		statuses: []api.GetPrivateEndpointServiceStatusResponse{
+			{Enabled: false, Status: strPtr(statusDisabled)},
+		},
+	}
+	p, _ := newTestResource(t, b)
+
+	state := &tfsdk.State{Schema: PrivateEndpointServiceSchema()}
+	var diags diag.Diagnostics
+
+	p.handleFailedEnable(context.Background(), state, &diags,
+		testOrgID, testProjectID, testClusterID, errors.ErrPrivateEndpointServiceEnableFailed)
+
+	_, deletes := b.counts()
+	assert.Equal(t, deletes, 1, "must issue a DELETE to clean up the failed enable")
+	assert.Assert(t, state.Raw.IsNull(), "resource must be removed from state for a clean re-create")
+	assert.Equal(t, diags.HasError(), true, "must surface an actionable error")
+	assert.Equal(t, diags.Errors()[0].Summary(), "Private endpoint service enablement failed")
+}
+
+func TestHandleFailedEnableRemovesStateEvenWhenCleanupFails(t *testing.T) {
+	fastPolling(t)
+
+	// DELETE fails, so automatic cleanup cannot complete.
+	b := &fakeBackend{
+		deleteStatus: http.StatusInternalServerError,
+		deleteBody:   `{"code":4000,"message":"boom","httpStatusCode":500}`,
+	}
+	p, _ := newTestResource(t, b)
+
+	state := &tfsdk.State{Schema: PrivateEndpointServiceSchema()}
+	var diags diag.Diagnostics
+
+	p.handleFailedEnable(context.Background(), state, &diags,
+		testOrgID, testProjectID, testClusterID, errors.ErrPrivateEndpointServiceEnableFailed)
+
+	assert.Assert(t, state.Raw.IsNull(), "state must be removed even when cleanup fails to avoid a wedged resource")
+	assert.Equal(t, diags.HasError(), true)
+	assert.Equal(t, diags.Errors()[0].Summary(),
+		"Private endpoint service enablement failed and automatic cleanup did not complete")
+}
+
+func TestGetServiceState(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      api.GetPrivateEndpointServiceStatusResponse
+		wantEnabled bool
+		wantStatus  string
+		wantNull    bool
+	}{
+		{
+			name:        "maps status when present",
+			status:      api.GetPrivateEndpointServiceStatusResponse{Enabled: true, Status: strPtr(statusEnabled)},
+			wantEnabled: true,
+			wantStatus:  statusEnabled,
+		},
+		{
+			name:        "leaves status null for older control plane",
+			status:      api.GetPrivateEndpointServiceStatusResponse{Enabled: true, Status: nil},
+			wantEnabled: true,
+			wantNull:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &fakeBackend{statuses: []api.GetPrivateEndpointServiceStatusResponse{tc.status}}
+			p, _ := newTestResource(t, b)
+
+			got, err := p.getServiceState(context.Background(), testOrgID, testProjectID, testClusterID)
+			assert.NilError(t, err)
+			assert.Equal(t, got.Enabled.ValueBool(), tc.wantEnabled)
+			assert.Equal(t, got.Status.IsNull(), tc.wantNull)
+			if !tc.wantNull {
+				assert.Equal(t, got.Status.ValueString(), tc.wantStatus)
+			}
+		})
+	}
+}

--- a/internal/resources/private_endpoints.go
+++ b/internal/resources/private_endpoints.go
@@ -157,8 +157,11 @@ func (p *PrivateEndpoint) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	if refreshedState.Status.ValueString() == "rejected" {
-		tflog.Info(ctx, "private endpoint association is rejected; removing from state to force re-association")
+	// Both rejected and failed associations are terminal and cannot recover in
+	// place, so remove them from state to force a clean re-association on the
+	// next apply rather than leaving a stuck resource.
+	if s := refreshedState.Status.ValueString(); s == "rejected" || s == "failed" {
+		tflog.Info(ctx, "private endpoint association is "+s+"; removing from state to force re-association")
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/schema/private_endpoint_service.go
+++ b/internal/schema/private_endpoint_service.go
@@ -22,6 +22,13 @@ type PrivateEndpointService struct {
 
 	// Enabled indicates if private endpoint service is enabled/disabled on cluster.
 	Enabled types.Bool `tfsdk:"enabled"`
+
+	// Status is the lifecycle state of the private endpoint service derived from
+	// the most recent enable/disable/update operation. Terminal states are
+	// enableFailed and disableFailed; transient states are enabling, disabling,
+	// and unknown; idle means no operation has run. It may be empty when the
+	// control plane does not report a status.
+	Status types.String `tfsdk:"status"`
 }
 
 // Validate is used to verify that IDs have been properly imported.


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-134634

## Description

When private endpoint service enablement fails, the backend reaches a terminal `enableFailed` state, but the provider only ever saw `{"enabled": false}`. It polled that boolean for 60 minutes, timed out with a generic error, and re-POSTed enable on the next apply, looping over orphaned infra with no automated recovery. Failed endpoint associations had a similar problem: they stayed in state forever.

This PR makes the provider status-aware so it fails fast on terminal states, automatically cleans up a failed enable, and lets the next apply perform a clean re-create with no manual intervention. It pairs with the control-plane change that exposes `status` and allows disable from `enableFailed`; it is fully backward compatible with control planes that do not yet report a status.

## Changes

### API model

- Added an optional `Status *string` to `GetPrivateEndpointServiceStatusResponse`.

### Status-aware polling

- Rewrote `waitUntilStatusChanges` to use the lifecycle `status` when present: `enableFailed`/`disableFailed` return immediately with a typed terminal error; `enabling`/`disabling`/`unknown` keep polling (transient); `enabled`/`disabled`/`idle` resolve against the `enabled` boolean; status absent (older control plane) falls back to the boolean with unchanged behavior.
- Reduced the poll interval to 30s and kept the 60-minute timeout as a backstop.

### Terminal-failure handling

- Create and enable-flavored Update: on `enableFailed`, issue a disable (DELETE) to trigger backend cleanup, wait up to 15 minutes for `disabled`/`idle`, remove the resource from state, and return an actionable error. The resource is removed even if cleanup itself fails, with a message directing escalation, because leaving a permanently-failed resource in state recreates the stuck-pipeline problem.
- Delete: on `disableFailed`, fail fast and keep the resource in state so a re-run of `terraform destroy` retries naturally.
- Read: on `enableFailed`, remove the resource from state so drift detection recreates it instead of leaving it wedged.
- Added `ErrPrivateEndpointServiceEnableFailed` and `ErrPrivateEndpointServiceDisableFailed`.

### Failed associations

- `private_endpoints` Read now removes both `rejected` and `failed` associations from state to force a clean re-association.

### Status exposure, schema, and docs

- Added a computed `status` attribute to the resource and data source, populated from the API.
- Documented terminal vs transient states in the resource and data source docs.

## Compatibility

- The change only activates when the API reports a `status`. Against an older control plane the provider falls back to boolean polling, so behavior is unchanged. Recommended rollout is control plane first, then this provider release.
- The computed `status` attribute follows the same pattern as the existing `current_state` attribute on the cluster resource (plain computed, planned as known-after-apply), so enable/disable toggles do not cause inconsistent-result errors.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [x] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

### Unit tests

`go vet ./...` is clean and `make test` passes (run via `make test` so `OPENAPI_SPEC_URL` is exported; a bare `go test` leaves schema-description tests without the spec and is expected to fail). Coverage includes the new status-aware poll loop, the terminal-failure handling, and the failed/rejected association removal.

### Acceptance test

`TestAccPrivateEndpointServiceEnableDisable` passes against real Capella (enable, read, disable):

--- PASS: TestAccPrivateEndpointServiceEnableDisable (273.89s)

```
The other failures in the suite run are unrelated environment/backend issues (bucket-quota exhaustion on the shared cluster and transient 500s during bucket creation), not changes in this PR.

### Manual end-to-end against a local control plane

Validated the full lifecycle against a local `cbclocal` control plane (which exposes the new `status` field), using a dev-override build of this provider.

**Enable (`terraform apply`)**
- Plan renders `status = (known after apply)`, confirming the computed attribute is planned as unknown, so it cannot trigger a "provider produced inconsistent result after apply" error when the value changes.
- The status-aware poll loop polls the service status until the backend job completes and converges (creation completed after ~5m31s).
- `terraform show` reports the resolved state:
- resource "couchbase-capella_private_endpoint_service" "svc" {

cluster_id      = "f7c7e93e-554e-46bc-bcd0-1d7cd7eff9cb"

enabled         = true

organization_id = "adb4fb4c-1d98-4287-ac33-230742d2cc76"

project_id      = "c09035e8-3971-4b79-a6ec-bccd9056041f"

status          = "enabled"

}
**Disable (`terraform destroy`)**
- Refresh succeeds and the service is disabled cleanly (destroy completed after ~1m):
- Destroy complete! Resources: 1 destroyed.
```

This exercises status exposure, the computed `status` attribute, the 30s status-aware polling, and the enable/disable lifecycle against a real backend with no errors.

### Terminal-failure path

A healthy cluster enables successfully, so the `enableFailed` recovery path is not reachable from the happy-path apply above. It is covered by unit tests (fail-fast on `enableFailed`, DELETE-triggered cleanup, `RemoveResource`, and the cleanup-failure escalation), and can be exercised manually with a mock control plane returning `{"enabled": false, "status": "enableFailed"}` on GET and `202` on DELETE, or by inducing an enable-job failure in the backend. Verified behavior in that case: apply fails fast (within one poll interval, not the 60-minute timeout), the resource is removed from state, and a subsequent `terraform apply` performs a clean re-create with no manual intervention.
</details>

Acceptance Tests are passing locally : 

```
2026/06/30 18:12:19 Using existing project: c09035e8-3971-4b79-a6ec-bccd9056041f
2026/06/30 18:12:19 Using existing cluster: 0813abd8-e46f-4026-8ac8-7addceb8bd86
2026/06/30 18:13:24 bucket created
2026/06/30 18:13:24 Created bucket: default (ZGVmYXVsdA==)
2026/06/30 18:13:24 cluster created
2026/06/30 18:19:27 app service created
2026/06/30 18:20:34 app endpoint state Offline
=== RUN   TestAccPrivateEndpointServiceEnableDisable
2026-06-30T18:20:36.269+0530 [INFO]  couchbase_capella: Configuring the Capella Client: tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_rpc=ConfigureProvider tf_req_id=6cadee86-397e-cd1b-edde-6db654bd9b20
2026-06-30T18:20:36.269+0530 [INFO]  couchbase_capella: Configured Capella client: tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_rpc=ConfigureProvider host=http://localhost:8084 authentication_token="***" tf_req_id=6cadee86-397e-cd1b-edde-6db654bd9b20 success=true
2026-06-30T18:20:36.393+0530 [INFO]  couchbase_capella: Configuring the Capella Client: tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_req_id=8a2b223a-11df-820e-987e-085995fe1faf tf_rpc=ConfigureProvider
2026-06-30T18:20:36.393+0530 [INFO]  couchbase_capella: Configured Capella client: tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella authentication_token="***" success=true tf_req_id=8a2b223a-11df-820e-987e-085995fe1faf tf_rpc=ConfigureProvider host=http://localhost:8084
2026-06-30T18:25:40.221+0530 [INFO]  couchbase_capella: Configuring the Capella Client: tf_req_id=1916bc24-5383-f526-0e61-237b18d582a3 tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_rpc=ConfigureProvider
2026-06-30T18:25:40.221+0530 [INFO]  couchbase_capella: Configured Capella client: success=true tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_rpc=ConfigureProvider authentication_token="***" host=http://localhost:8084 tf_req_id=1916bc24-5383-f526-0e61-237b18d582a3
2026-06-30T18:25:42.094+0530 [INFO]  couchbase_capella: Configuring the Capella Client: tf_rpc=ConfigureProvider tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_req_id=6195f21b-dd07-8e19-6b9b-f5dc75a9e686
2026-06-30T18:25:42.094+0530 [INFO]  couchbase_capella: Configured Capella client: tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella success=true host=http://localhost:8084 tf_req_id=6195f21b-dd07-8e19-6b9b-f5dc75a9e686 tf_rpc=ConfigureProvider authentication_token="***"
2026-06-30T18:25:43.984+0530 [INFO]  couchbase_capella: Configuring the Capella Client: tf_req_id=3c9e973c-92f3-71fa-8071-801c5c54e14f tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_rpc=ConfigureProvider
2026-06-30T18:25:43.984+0530 [INFO]  couchbase_capella: Configured Capella client: authentication_token="***" host=http://localhost:8084 tf_rpc=ConfigureProvider tf_req_id=3c9e973c-92f3-71fa-8071-801c5c54e14f tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella success=true
2026-06-30T18:25:44.149+0530 [INFO]  couchbase_capella: Configuring the Capella Client: tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_req_id=076ee266-0479-f7e0-f7d0-f41073ed07d4 tf_rpc=ConfigureProvider
2026-06-30T18:25:44.149+0530 [INFO]  couchbase_capella: Configured Capella client: tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_req_id=076ee266-0479-f7e0-f7d0-f41073ed07d4 tf_rpc=ConfigureProvider success=true host=http://localhost:8084 authentication_token="***"
2026-06-30T18:26:44.744+0530 [INFO]  couchbase_capella: Configuring the Capella Client: tf_req_id=eb6a73aa-9419-015e-a627-027d295b9137 tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_rpc=ConfigureProvider
2026-06-30T18:26:44.744+0530 [INFO]  couchbase_capella: Configured Capella client: tf_req_id=eb6a73aa-9419-015e-a627-027d295b9137 authentication_token="***" host=http://localhost:8084 tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella success=true tf_rpc=ConfigureProvider
2026-06-30T18:26:44.849+0530 [INFO]  couchbase_capella: Configuring the Capella Client: tf_req_id=6dad9a26-124d-f6e8-f566-28189f12d68f tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_rpc=ConfigureProvider
2026-06-30T18:26:44.849+0530 [INFO]  couchbase_capella: Configured Capella client: tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_rpc=ConfigureProvider host=http://localhost:8084 tf_req_id=6dad9a26-124d-f6e8-f566-28189f12d68f authentication_token="***" success=true
2026-06-30T18:26:45.066+0530 [INFO]  couchbase_capella: Configuring the Capella Client: tf_req_id=f9d53fa8-f24f-79d3-fdfc-f5ed33bce3aa tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_rpc=ConfigureProvider
2026-06-30T18:26:45.066+0530 [INFO]  couchbase_capella: Configured Capella client: tf_req_id=f9d53fa8-f24f-79d3-fdfc-f5ed33bce3aa tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella authentication_token="***" tf_rpc=ConfigureProvider host=http://localhost:8084 success=true
2026-06-30T18:26:45.068+0530 [INFO]  couchbase_capella: Configuring the Capella Client: tf_rpc=ConfigureProvider tf_req_id=88ab343e-59da-7a07-7c93-2d49935f1256 tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella
2026-06-30T18:26:45.068+0530 [INFO]  couchbase_capella: Configured Capella client: host=http://localhost:8084 authentication_token="***" tf_req_id=88ab343e-59da-7a07-7c93-2d49935f1256 success=true tf_provider_addr=registry.terraform.io/hashicorp/couchbase-capella tf_rpc=ConfigureProvider
--- PASS: TestAccPrivateEndpointServiceEnableDisable (370.59s)
PASS
2026/06/30 18:26:47 deleted fixture endpoint "tf_acc_test_app_endpoint_common"
2026/06/30 18:34:48 app service destroyed
2026/06/30 18:34:51 bucket destroyed: ZGVmYXVsdA==
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests	1352.780s
```
## Further comments