### PR TITLE
[AV-129960] Add handling for service unavailable errors

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -123,7 +123,7 @@ func (c *Client) ExecuteWithRetry(
 			})
 			return nil, dur, errors.ErrRatelimit
 		case http.StatusServiceUnavailable:
-			retryAfter := dur
+			var retryAfter time.Duration
 			if header := apiRes.Header.Get("Retry-After"); header != "" {
 				if secs, parseErr := strconv.Atoi(header); parseErr == nil {
 					retryAfter = time.Second * time.Duration(secs)
@@ -132,7 +132,6 @@ func (c *Client) ExecuteWithRetry(
 			tflog.Debug(ctx, "API returned 503 Service Unavailable, retrying", map[string]interface{}{
 				"method": endpointCfg.Method,
 				"url":    endpointCfg.Url,
-				"body":   string(responseBody),
 			})
 			return nil, retryAfter, errors.ErrServiceUnavailable
 		case http.StatusGatewayTimeout:

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -122,6 +122,19 @@ func (c *Client) ExecuteWithRetry(
 				"retry_after": dur.Seconds(),
 			})
 			return nil, dur, errors.ErrRatelimit
+		case http.StatusServiceUnavailable:
+			retryAfter := dur
+			if header := apiRes.Header.Get("Retry-After"); header != "" {
+				if secs, parseErr := strconv.Atoi(header); parseErr == nil {
+					retryAfter = time.Second * time.Duration(secs)
+				}
+			}
+			tflog.Debug(ctx, "API returned 503 Service Unavailable, retrying", map[string]interface{}{
+				"method": endpointCfg.Method,
+				"url":    endpointCfg.Url,
+				"body":   string(responseBody),
+			})
+			return nil, retryAfter, errors.ErrServiceUnavailable
 		case http.StatusGatewayTimeout:
 			var apiError Error
 			if err := json.Unmarshal(responseBody, &apiError); err != nil {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -188,6 +188,7 @@ func exec(
 			case err == nil:
 				return response, nil
 			case goer.Is(err, errors.ErrRatelimit):
+			case goer.Is(err, errors.ErrServiceUnavailable):
 			case !goer.Is(err, errors.ErrGatewayTimeout):
 				return response, err
 			}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -205,6 +205,9 @@ var (
 	// ErrGatewayTimeoutForIndexDDL is returned when API server times out while waiting for response for index DDL.
 	ErrGatewayTimeoutForIndexDDL = errors.New("timeout waiting for response for index DDL")
 
+	// ErrServiceUnavailable is returned when the API returns 503 due to a transient condition (e.g. bucket deletion in progress).
+	ErrServiceUnavailable = errors.New("service unavailable")
+
 	// ErrNotTrimmed is returned when any attribute has leading or trailing spaces.
 	ErrNotTrimmed = errors.New("attribute has leading or trailing spaces")
 

--- a/internal/generated/api/retry_http_client.go
+++ b/internal/generated/api/retry_http_client.go
@@ -61,6 +61,11 @@ func customRetryPolicy(ctx context.Context, resp *http.Response, err error) (boo
 		// Always retry 429 responses - retryablehttp handles Retry-After header automatically
 		return true, nil
 
+	case http.StatusServiceUnavailable:
+		// Retry 503 responses - these indicate transient conditions such as a bucket
+		// deletion in progress that prevents creation of another bucket.
+		return true, nil
+
 	case http.StatusGatewayTimeout:
 		// Check for special code 7001 (do not retry)
 		var apiErr struct {

--- a/internal/generated/api/retry_http_client.go
+++ b/internal/generated/api/retry_http_client.go
@@ -57,11 +57,8 @@ func customRetryPolicy(ctx context.Context, resp *http.Response, err error) (boo
 	}
 
 	switch resp.StatusCode {
-	case http.StatusTooManyRequests:
+	case http.StatusTooManyRequests, http.StatusServiceUnavailable:
 		// Always retry 429 responses - retryablehttp handles Retry-After header automatically
-		return true, nil
-
-	case http.StatusServiceUnavailable:
 		// Retry 503 responses - these indicate transient conditions such as a bucket
 		// deletion in progress that prevents creation of another bucket.
 		return true, nil

--- a/internal/generated/api/retry_http_client_test.go
+++ b/internal/generated/api/retry_http_client_test.go
@@ -62,6 +62,21 @@ func TestCustomRetryPolicyDirectly(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error for 429, got: %v", err)
 	}
+
+	// Test 503 case
+	resp = &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Body:       io.NopCloser(bytes.NewBufferString("service unavailable")),
+		Header:     make(http.Header),
+	}
+
+	shouldRetry, err = customRetryPolicy(context.Background(), resp, nil)
+	if !shouldRetry {
+		t.Error("expected retry for 503 case")
+	}
+	if err != nil {
+		t.Errorf("expected no error for 503, got: %v", err)
+	}
 }
 
 func TestCustomRetryPolicyJSONDecoder(t *testing.T) {
@@ -366,6 +381,40 @@ func Test429_RetryAfter_Respected(t *testing.T) {
 	}
 }
 
+func Test503_ServiceUnavailable_Retried(t *testing.T) {
+	var callCount int32
+
+	// Create test server that returns 503 on the first call, then success
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		if count == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte("service unavailable"))
+		} else {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("success"))
+		}
+	}))
+	defer server.Close()
+
+	client := NewRetryHTTPClient(context.Background(), 30*time.Second, false, WithFastBackoff())
+
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Should have retried once after 503
+	if atomic.LoadInt32(&callCount) != 2 {
+		t.Fatalf("expected 2 calls, got %d", atomic.LoadInt32(&callCount))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected successful status, got %d", resp.StatusCode)
+	}
+}
+
 func TestSuccessPassthrough(t *testing.T) {
 	var callCount int32
 
@@ -412,7 +461,6 @@ func TestDefaultCase_NoRetry(t *testing.T) {
 		{"NotFound", http.StatusNotFound, "not found"},
 		{"InternalServerError", http.StatusInternalServerError, "internal server error"},
 		{"BadGateway", http.StatusBadGateway, "bad gateway"},
-		{"ServiceUnavailable", http.StatusServiceUnavailable, "service unavailable"},
 	}
 
 	for _, tc := range testCases {

--- a/internal/generated/api/retry_http_client_test.go
+++ b/internal/generated/api/retry_http_client_test.go
@@ -389,10 +389,10 @@ func Test503_ServiceUnavailable_Retried(t *testing.T) {
 		count := atomic.AddInt32(&callCount, 1)
 		if count == 1 {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte("service unavailable"))
+			_, _ = w.Write([]byte("service unavailable"))
 		} else {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("success"))
+			_, _ = w.Write([]byte("success"))
 		}
 	}))
 	defer server.Close()
@@ -403,7 +403,7 @@ func Test503_ServiceUnavailable_Retried(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Should have retried once after 503
 	if atomic.LoadInt32(&callCount) != 2 {


### PR DESCRIPTION
## Jira

* AV-129960

## Description

Add retry logic for HTTP 503 (Service Unavailable)
Bucket creation can fail with "Cannot create bucket during the bucket deletion" (503) when another bucket on the same cluster is mid-deletion during parallel run of acceptance tests. This is a transient server-side condition that resolves once the deletion completes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments