### PR TITLE
[AV-129812] List eventing function data source implementation

### DIFF
--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // Cursor represents pagination metadata for navigating through large data sets.
@@ -82,8 +83,14 @@ func GetPaginated[DataSchema ~[]T, T any](
 		baseUrl   = cfg.Url
 	)
 
+	// Keep any query parameters that may have been supplied in the base URL
+	separator := "?"
+	if strings.Contains(baseUrl, "?") {
+		separator = "&"
+	}
+
 	for {
-		cfg.Url = baseUrl + fmt.Sprintf("?page=%d&perPage=%d", page, perPage)
+		cfg.Url = baseUrl + fmt.Sprintf("%spage=%d&perPage=%d", separator, page, perPage)
 		if string(sortBy) != "" {
 			cfg.Url += fmt.Sprintf("&sortBy=%s", string(sortBy))
 		}

--- a/internal/datasources/eventing_functions.go
+++ b/internal/datasources/eventing_functions.go
@@ -1,0 +1,115 @@
+package datasources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/eventing_function"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = (*EventingFunctions)(nil)
+	_ datasource.DataSourceWithConfigure = (*EventingFunctions)(nil)
+)
+
+// EventingFunctions is the list eventing functions data source implementation.
+type EventingFunctions struct {
+	*providerschema.Data
+}
+
+// NewEventingFunctions is a helper function to simplify the provider implementation.
+func NewEventingFunctions() datasource.DataSource {
+	return &EventingFunctions{}
+}
+
+// Metadata returns the eventing functions data source type name.
+func (d *EventingFunctions) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_eventing_functions"
+}
+
+// Schema defines the schema for the eventing functions data source.
+func (d *EventingFunctions) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = EventingFunctionsSchema()
+}
+
+// Read refreshes the Terraform state with the latest list of eventing functions.
+func (d *EventingFunctions) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state providerschema.EventingFunctions
+	diags := req.Config.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var (
+		organizationId = state.OrganizationId.ValueString()
+		projectId      = state.ProjectId.ValueString()
+		clusterId      = state.ClusterId.ValueString()
+	)
+
+	requestUrl := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/eventingFunctions",
+		d.HostURL, organizationId, projectId, clusterId,
+	)
+
+	// The list endpoint filters by state server-side via a comma-separated status query parameter.
+	if !state.Status.IsNull() {
+		var statuses []string
+		diags := state.Status.ElementsAs(ctx, &statuses, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if len(statuses) > 0 {
+			requestUrl += "?status=" + strings.Join(statuses, ",")
+		}
+	}
+
+	cfg := api.EndpointCfg{Url: requestUrl, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	functions, err := api.GetPaginated[[]eventing_function.EventingFunction](ctx, d.ClientV1, d.Token, cfg, api.SortByName)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Capella Eventing Functions",
+			fmt.Sprintf("Could not read eventing functions in cluster %s, unexpected error: %s", clusterId, api.ParseError(err)),
+		)
+		return
+	}
+
+	state.EventingFunctions = make([]providerschema.OneEventingFunction, 0, len(functions))
+	for _, function := range functions {
+		model, diags := providerschema.NewOneEventingFunction(ctx, function)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.EventingFunctions = append(state.EventingFunctions, model)
+	}
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Configure adds the provider configured client to the eventing functions data source.
+func (d *EventingFunctions) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	data, ok := req.ProviderData.(*providerschema.Data)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *providerschema.Data, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+	d.Data = data
+}

--- a/internal/datasources/eventing_functions.go
+++ b/internal/datasources/eventing_functions.go
@@ -60,7 +60,7 @@ func (d *EventingFunctions) Read(ctx context.Context, req datasource.ReadRequest
 	)
 
 	// The list endpoint filters by state server-side via a comma-separated status query parameter.
-	if !state.Status.IsNull() {
+	if !state.Status.IsNull() && !state.Status.IsUnknown() {
 		var statuses []string
 		diags := state.Status.ElementsAs(ctx, &statuses, false)
 		resp.Diagnostics.Append(diags...)

--- a/internal/datasources/eventing_functions_schema.go
+++ b/internal/datasources/eventing_functions_schema.go
@@ -1,0 +1,85 @@
+package datasources
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+// eventingFunctionStatuses are the states an eventing function can be in. They double as the
+// accepted values for the status filter on the list eventing functions data source.
+var eventingFunctionStatuses = []string{
+	"deployed",
+	"deploying",
+	"undeployed",
+	"undeploying",
+	"paused",
+	"pausing",
+}
+
+// getOneEventingFunctionAttrs returns the computed attributes describing a single eventing function
+// entry in the list data source. The nested object attributes are shared with the single eventing
+// function data source.
+func getOneEventingFunctionAttrs() map[string]schema.Attribute {
+	attrs := make(map[string]schema.Attribute)
+	capellaschema.AddAttr(attrs, "name", eventingFunctionBuilder, computedString())
+	capellaschema.AddAttr(attrs, "description", eventingFunctionBuilder, computedString())
+	capellaschema.AddAttr(attrs, "status", eventingFunctionBuilder, computedString())
+	capellaschema.AddAttr(attrs, "code", eventingFunctionBuilder, &schema.StringAttribute{
+		Computed:  true,
+		Sensitive: true,
+	})
+
+	capellaschema.AddAttr(attrs, "event_source", eventingFunctionBuilder, &schema.SingleNestedAttribute{
+		Computed:   true,
+		Attributes: getEventingFunctionKeyspaceAttrs(),
+	})
+	capellaschema.AddAttr(attrs, "event_metadata_storage", eventingFunctionBuilder, &schema.SingleNestedAttribute{
+		Computed:   true,
+		Attributes: getEventingFunctionKeyspaceAttrs(),
+	})
+	capellaschema.AddAttr(attrs, "settings", eventingFunctionBuilder, &schema.SingleNestedAttribute{
+		Computed:   true,
+		Attributes: getEventingFunctionSettingsAttrs(),
+	})
+	capellaschema.AddAttr(attrs, "bindings", eventingFunctionBuilder, &schema.SingleNestedAttribute{
+		Computed:   true,
+		Attributes: getEventingFunctionBindingsAttrs(),
+	})
+	return attrs
+}
+
+// EventingFunctionsSchema returns the schema for the list eventing functions data source.
+func EventingFunctionsSchema() schema.Schema {
+	attrs := make(map[string]schema.Attribute)
+	capellaschema.AddAttr(attrs, "organization_id", eventingFunctionBuilder, requiredUUIDString())
+	capellaschema.AddAttr(attrs, "project_id", eventingFunctionBuilder, requiredUUIDString())
+	capellaschema.AddAttr(attrs, "cluster_id", eventingFunctionBuilder, requiredUUIDString())
+
+	// status is an optional filter passed through to the list endpoint's status query parameter.
+	// When omitted, eventing functions in every state are returned.
+	capellaschema.AddAttr(attrs, "status", eventingFunctionBuilder, &schema.SetAttribute{
+		Optional:    true,
+		ElementType: types.StringType,
+		Validators: []validator.Set{
+			setvalidator.SizeAtLeast(1),
+			setvalidator.ValueStringsAre(stringvalidator.OneOf(eventingFunctionStatuses...)),
+		},
+	})
+
+	capellaschema.AddAttr(attrs, "eventing_functions", eventingFunctionBuilder, &schema.ListNestedAttribute{
+		Computed: true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: getOneEventingFunctionAttrs(),
+		},
+	})
+
+	return schema.Schema{
+		MarkdownDescription: "The eventing functions data source retrieves the eventing functions in a cluster, optionally filtered by one or more states.",
+		Attributes:          attrs,
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -288,6 +288,7 @@ func (p *capellaProvider) DataSources(_ context.Context) []func() datasource.Dat
 		datasources.NewAppEndpointLoggingConfig,
 		datasources.NewAppServiceLogStreaming,
 		datasources.NewEventingFunction,
+		datasources.NewEventingFunctions,
 	}
 }
 

--- a/internal/schema/eventing_function.go
+++ b/internal/schema/eventing_function.go
@@ -12,18 +12,35 @@ import (
 
 // EventingFunction is the Terraform data source model for a single eventing function.
 type EventingFunction struct {
+	OneEventingFunction
+	OrganizationId types.String `tfsdk:"organization_id"`
+	ProjectId      types.String `tfsdk:"project_id"`
+	ClusterId      types.String `tfsdk:"cluster_id"`
+	Export         types.Bool   `tfsdk:"export"`
+}
+
+// EventingFunctions is the Terraform data source model for listing eventing functions in a cluster.
+// Status is an optional filter that maps to the status query parameter on the list endpoint.
+type EventingFunctions struct {
+	OrganizationId    types.String          `tfsdk:"organization_id"`
+	ProjectId         types.String          `tfsdk:"project_id"`
+	ClusterId         types.String          `tfsdk:"cluster_id"`
+	Status            types.Set             `tfsdk:"status"`
+	EventingFunctions []OneEventingFunction `tfsdk:"eventing_functions"`
+}
+
+// OneEventingFunction is a single eventing function entry returned by the list eventing functions
+// data source. It mirrors the per-function fields of EventingFunction without the request-scoped
+// identifiers and export flag, which live on the parent EventingFunctions model.
+type OneEventingFunction struct {
 	Description          types.String `tfsdk:"description"`
 	Status               types.String `tfsdk:"status"`
 	Code                 types.String `tfsdk:"code"`
-	OrganizationId       types.String `tfsdk:"organization_id"`
-	ProjectId            types.String `tfsdk:"project_id"`
-	ClusterId            types.String `tfsdk:"cluster_id"`
 	Name                 types.String `tfsdk:"name"`
 	EventSource          types.Object `tfsdk:"event_source"`
 	EventMetadataStorage types.Object `tfsdk:"event_metadata_storage"`
 	Settings             types.Object `tfsdk:"settings"`
 	Bindings             types.Object `tfsdk:"bindings"`
-	Export               types.Bool   `tfsdk:"export"`
 }
 
 // EventingFunctionKeyspace identifies the bucket, scope and collection of an event source or
@@ -160,19 +177,30 @@ func NewEventingFunction(
 	organizationId, projectId, clusterId, name string,
 	export types.Bool,
 ) (EventingFunction, diag.Diagnostics) {
+	one, diags := NewOneEventingFunction(ctx, function)
+
+	model := EventingFunction{
+		OneEventingFunction: one,
+		OrganizationId:      types.StringValue(organizationId),
+		ProjectId:           types.StringValue(projectId),
+		ClusterId:           types.StringValue(clusterId),
+		Export:              export,
+	}
+
+	return model, diags
+}
+
+// NewOneEventingFunction converts a single eventing function API response into its Terraform model.
+// It is shared by the single and list eventing function data sources to build the per-function
+// fields and their nested objects.
+func NewOneEventingFunction(ctx context.Context, function eventing_function.EventingFunction) (OneEventingFunction, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	// name is echoed from the configured value, not the API response, so the required attribute
-	// always matches config in the read result.
-	model := EventingFunction{
-		OrganizationId: types.StringValue(organizationId),
-		ProjectId:      types.StringValue(projectId),
-		ClusterId:      types.StringValue(clusterId),
-		Name:           types.StringValue(name),
-		Export:         export,
-		Description:    types.StringPointerValue(function.Description),
-		Status:         types.StringPointerValue(function.Status),
-		Code:           types.StringPointerValue(function.Code),
+	model := OneEventingFunction{
+		Name:        types.StringValue(function.Name),
+		Description: types.StringPointerValue(function.Description),
+		Status:      types.StringPointerValue(function.Status),
+		Code:        types.StringPointerValue(function.Code),
 	}
 
 	eventSource, d := newEventingFunctionKeyspaceObject(ctx, function.EventSource)


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-129812

## Description

<!-- What does this change do? Why is it needed? -->

Implementation for the list eventing function data source

Acceptance testing to be done in a later ticket.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

### 3 eventing functions to test with
<img width="2443" height="291" alt="image" src="https://github.com/user-attachments/assets/9bda6f01-6f80-4ec1-a39d-40c4ed9a2800" />

### Run TF apply on
```
data "couchbase-capella_eventing_functions" "existing_functions" {
  organization_id = var.org_id
  project_id      = local.project_id
  cluster_id      = local.cluster_id
}

output "eventing_functions" {
  value = data.couchbase-capella_eventing_functions.existing_functions
  sensitive = true
}
```

output:

```
{
  "cluster_id" = "f28e9f64-fa5b-48fb-a156-61c9fef25fcf"
  "eventing_functions" = tolist([
    {
      "bindings" = {
        "buckets" = tolist([])
        "constants" = tolist([])
        "urls" = tolist([])
      }
      "code" = <<-EOT
      function OnUpdate(doc, meta, xattrs) {
         log("Doc created/updated", meta.id);
      }

      function OnDelete(meta, options) {
         log("Doc deleted/expired", meta.id);
      }
      EOT
      "description" = "aaa"
      "event_metadata_storage" = {
        "bucket" = "travel-sample"
        "collection" = "hotel"
        "scope" = "inventory"
      }
      "event_source" = {
        "bucket" = "travel-sample"
        "collection" = "airline"
        "scope" = "inventory"
      }
      "name" = "aaa"
      "settings" = {
        "allow_sync_documents" = true
        "cursor_aware" = false
        "feed_boundary" = "everything"
        "language_compatibility" = "7.2.0"
        "max_timer_context_size" = 1024
        "script_timeout" = 60
        "sql_consistency" = "none"
        "worker_count" = 1
      }
      "status" = "undeployed"
    },
    {
      "bindings" = {
        "buckets" = tolist([
          {
            "alias" = "src"
            "bucket" = "travel-sample"
            "collection" = "_default"
            "permission" = "readWrite"
            "scope" = "_default"
          },
        ])
        "constants" = tolist([
          {
            "alias" = "maxRetries"
            "value" = "3"
          },
        ])
        "urls" = tolist([
          {
            "alias" = "api"
            "allow_cookies" = false
            "authentication" = {
              "bearer_token" = tostring(null)
              "password" = "*****"
              "type" = "basic"
              "username" = "user"
            }
            "url" = "https://api.example.com/path"
            "validate_tls_certificate" = true
          },
        ])
      }
      "code" = <<-EOT
      function OnUpdate(doc, meta, xattrs) {
        log("Doc created/updated", meta.id);
      }

      function OnDelete(meta, options) {
        log("Doc deleted/expired", meta.id);
      }

      EOT
      "description" = "Replicates document mutations to a downstream collection."
      "event_metadata_storage" = {
        "bucket" = "travel-sample"
        "collection" = "_default"
        "scope" = "_default"
      }
      "event_source" = {
        "bucket" = "travel-sample"
        "collection" = "airline"
        "scope" = "inventory"
      }
      "name" = "my_function"
      "settings" = {
        "allow_sync_documents" = true
        "cursor_aware" = false
        "feed_boundary" = "from_now"
        "language_compatibility" = "7.2.0"
        "max_timer_context_size" = 1024
        "script_timeout" = 60
        "sql_consistency" = "none"
        "worker_count" = 1
      }
      "status" = "paused"
    },
    {
      "bindings" = {
        "buckets" = tolist([
          {
            "alias" = "src"
            "bucket" = "travel-sample"
            "collection" = "_default"
            "permission" = "readWrite"
            "scope" = "_default"
          },
        ])
        "constants" = tolist([
          {
            "alias" = "maxRetries"
            "value" = "3"
          },
        ])
        "urls" = tolist([
          {
            "alias" = "api"
            "allow_cookies" = false
            "authentication" = {
              "bearer_token" = tostring(null)
              "password" = "*****"
              "type" = "basic"
              "username" = "user"
            }
            "url" = "https://api.example.com/path"
            "validate_tls_certificate" = true
          },
        ])
      }
      "code" = <<-EOT
      function OnUpdate(doc, meta, xattrs) {
        log("Doc created/updated", meta.id);
      }

      function OnDelete(meta, options) {
        log("Doc deleted/expired", meta.id);
      }

      EOT
      "description" = "Replicates document mutations to a downstream collection."
      "event_metadata_storage" = {
        "bucket" = "travel-sample"
        "collection" = "_default"
        "scope" = "_default"
      }
      "event_source" = {
        "bucket" = "travel-sample"
        "collection" = "airline"
        "scope" = "inventory"
      }
      "name" = "my_function2"
      "settings" = {
        "allow_sync_documents" = true
        "cursor_aware" = false
        "feed_boundary" = "from_now"
        "language_compatibility" = "7.2.0"
        "max_timer_context_size" = 1024
        "script_timeout" = 60
        "sql_consistency" = "none"
        "worker_count" = 1
      }
      "status" = "deployed"
    },
  ])
  "organization_id" = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
  "project_id" = "c09035e8-3971-4b79-a6ec-bccd9056041f"
  "status" = toset(null) /* of string */
}
```


### List with status filtering

TF

```
data "couchbase-capella_eventing_functions" "eventing_functions" {
  organization_id = var.org_id
  project_id      = local.project_id
  cluster_id      = local.cluster_id
  status = ["deployed", "paused"]
}
```

output:

```
{
  "cluster_id" = "f28e9f64-fa5b-48fb-a156-61c9fef25fcf"
  "eventing_functions" = tolist([
    {
...
      "status" = "paused"
    },
    {
....
      "status" = "deployed"
    },
  ])
  "organization_id" = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
  "project_id" = "c09035e8-3971-4b79-a6ec-bccd9056041f"
  "status" = toset([
    "deployed",
    "paused",
  ])
}
```

### status filter with empty output:

```
data "couchbase-capella_eventing_functions" "eventing_functions" {
  organization_id = var.org_id
  project_id      = local.project_id
  cluster_id      = local.cluster_id
  status = ["deploying"]
}
```

```
$ terraform output eventing_functions
{
  "cluster_id" = "f28e9f64-fa5b-48fb-a156-61c9fef25fcf"
  "eventing_functions" = tolist([])
  "organization_id" = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
  "project_id" = "c09035e8-3971-4b79-a6ec-bccd9056041f"
  "status" = toset([
    "deploying",
  ])
}
```
</details>

## Further comments