### PR TITLE
[AV-134866] Fix flaky app_endpoint tests by sharing bucket via collections

### DIFF
--- a/acceptance_tests/app_endpoint_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_acceptance_test.go
@@ -10,31 +10,33 @@ import (
 )
 
 func TestAccAppEndpoint(t *testing.T) {
-	ensureFixtureBucketByName(t, globalEPBucketName)
+	ensureFixtureCollection(t, globalEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointResourceConfig(resourceName, epName, globalEPBucketName, "syncFnXattr", true),
+				Config: testAccAppEndpointResourceConfig(resourceName, epName, globalEPCollectionName, "syncFnXattr", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
 					resource.TestCheckResourceAttr(resourceReference, "cluster_id", appEndpointClusterId),
 					resource.TestCheckResourceAttr(resourceReference, "app_service_id", appEndpointAppServiceId),
-					resource.TestCheckResourceAttr(resourceReference, "bucket", globalEPBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "bucket", appEndpointBucketName),
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
 					resource.TestCheckResourceAttr(resourceReference, "delta_sync_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceReference, "user_xattr_key", "syncFnXattr"),
 				),
 			},
 			{
-				Config: testAccAppEndpointResourceConfig(resourceName, epName, globalEPBucketName, "new_xattr", false),
+				Config: testAccAppEndpointResourceConfig(resourceName, epName, globalEPCollectionName, "new_xattr", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "delta_sync_enabled", "false"),
@@ -82,7 +84,9 @@ func TestAccAppEndpointInexistentCollection(t *testing.T) {
 		appEndpointBucketName,
 		epName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
@@ -93,7 +97,7 @@ func TestAccAppEndpointInexistentCollection(t *testing.T) {
 	})
 }
 
-func testAccAppEndpointResourceConfig(resourceName, endpointName, bucketName, userXattr string, deltaSync bool) string {
+func testAccAppEndpointResourceConfig(resourceName, endpointName, collectionName, userXattr string, deltaSync bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -102,7 +106,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id         = "%[4]s"
 	cluster_id         = "%[5]s"
 	app_service_id     = "%[6]s"
-	bucket             = "%[7]s"
+	bucket             = "`+appEndpointBucketName+`"
 	name               = "%[8]s"
 	user_xattr_key     = "%[9]s"
 	delta_sync_enabled = %[10]t
@@ -119,7 +123,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 		  collections = {
-			"_default" = {}
+			"%[7]s" = {}
 		  }
 		}
 	}
@@ -131,7 +135,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 		userXattr,
 		deltaSync,
@@ -141,15 +145,17 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // TestAccAppEndpointNoCors verifies that creating an app endpoint without a
 // cors block does not produce perpetual state drift on subsequent plans.
 func TestAccAppEndpointNoCors(t *testing.T) {
-	ensureFixtureBucketByName(t, globalNoCorsEPBucketName)
+	ensureFixtureCollection(t, globalNoCorsEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_ep_nocors_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_ep_nocors_")
 
-	cfg := testAccAppEndpointNoCorsConfig(resourceName, epName, globalNoCorsEPBucketName)
+	cfg := testAccAppEndpointNoCorsConfig(resourceName, epName, globalNoCorsEPCollectionName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
@@ -170,7 +176,7 @@ func TestAccAppEndpointNoCors(t *testing.T) {
 	})
 }
 
-func testAccAppEndpointNoCorsConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointNoCorsConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -179,12 +185,12 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 	scopes = {
 		"_default" = {
 		  collections = {
-			"_default" = {}
+			"%[7]s" = {}
 		  }
 		}
 	}
@@ -196,7 +202,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -230,25 +236,27 @@ func testAccAppEndpointComputedAttrs(resourceReference string) resource.TestChec
 // The API rejects empty/missing origin when a cors block is present.
 // Provider schema must reject this before issuing the API request.
 func TestAccAppEndpointCorsDisabledFalseNoOrigin(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsDisabledFalseEPBucketName)
+	ensureFixtureCollection(t, globalCorsDisabledFalseEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
+				Config:      testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, epName, globalCorsDisabledFalseEPCollectionName),
 				ExpectError: re.MustCompile(`(?s).*cors\.origin.*at least 1 value.*`),
 			},
 			{
-				Config:      testAccAppEndpointCorsEmptyOriginResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
+				Config:      testAccAppEndpointCorsEmptyOriginResourceConfig(resourceName, epName, globalCorsDisabledFalseEPCollectionName),
 				ExpectError: re.MustCompile(`(?s).*cors\.origin.*at least 1 value.*`),
 			},
 			{
-				Config: testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
+				Config: testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, epName, globalCorsDisabledFalseEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "cors.disabled", "true"),
@@ -260,17 +268,19 @@ func TestAccAppEndpointCorsDisabledFalseNoOrigin(t *testing.T) {
 
 // ── S6: Full cors config (all fields) — happy path (also covers I2 import) ───
 func TestAccAppEndpointCorsFullConfig(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsFullEPBucketName)
+	ensureFixtureCollection(t, globalCorsFullEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalCorsFullEPBucketName),
+				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalCorsFullEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "cors.disabled", "false"),
@@ -298,16 +308,18 @@ func TestAccAppEndpointCorsFullConfig(t *testing.T) {
 // supplied. Single-provider creation (S17/S18) works correctly.
 func TestAccAppEndpointMultipleOIDC(t *testing.T) {
 	t.Skip("AV-128222: multiple OIDC providers cause a 500 Internal Server Error; unskip once the bug is fixed")
-	ensureFixtureBucketByName(t, globalMultipleOIDCEPBucketName)
+	ensureFixtureCollection(t, globalMultipleOIDCEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointMultipleOIDCResourceConfig(resourceName, epName, globalMultipleOIDCEPBucketName),
+				Config: testAccAppEndpointMultipleOIDCResourceConfig(resourceName, epName, globalMultipleOIDCEPCollectionName),
 			},
 		},
 	})
@@ -315,17 +327,19 @@ func TestAccAppEndpointMultipleOIDC(t *testing.T) {
 
 // ── S20: cors with specific (non-wildcard) origins — happy path ───────────────
 func TestAccAppEndpointCorsSpecificOrigins(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsSpecificEPBucketName)
+	ensureFixtureCollection(t, globalCorsSpecificEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, epName, globalCorsSpecificEPBucketName),
+				Config: testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, epName, globalCorsSpecificEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "cors.origin.#", "2"),
@@ -345,17 +359,19 @@ func TestAccAppEndpointCorsSpecificOrigins(t *testing.T) {
 // default). Users cannot set max_age=0 — the value is always silently replaced.
 func TestAccAppEndpointCorsMaxAgeZeroSilentDrift(t *testing.T) {
 	t.Skip("AV-128218: cors.max_age=0 is silently omitted by the API request model; unskip once zero values round-trip correctly")
-	ensureFixtureBucketByName(t, globalCorsMaxAge0EPBucketName)
+	ensureFixtureCollection(t, globalCorsMaxAge0EPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, epName, globalCorsMaxAge0EPBucketName),
+				Config: testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, epName, globalCorsMaxAge0EPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "cors.max_age", "0"),
 					// https://jira.issues.couchbase.com/browse/AV-128218
@@ -367,17 +383,19 @@ func TestAccAppEndpointCorsMaxAgeZeroSilentDrift(t *testing.T) {
 
 // ── S18: OIDC with all optional fields — happy path ───────────────────────────
 func TestAccAppEndpointOIDCFullFields(t *testing.T) {
-	ensureFixtureBucketByName(t, globalOIDCFullEPBucketName)
+	ensureFixtureCollection(t, globalOIDCFullEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointOIDCAllFieldsResourceConfig(resourceName, epName, globalOIDCFullEPBucketName),
+				Config: testAccAppEndpointOIDCAllFieldsResourceConfig(resourceName, epName, globalOIDCFullEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "oidc.#", "1"),
@@ -397,17 +415,19 @@ func TestAccAppEndpointOIDCFullFields(t *testing.T) {
 
 // ── S22: OIDC with discovery_url — happy path ─────────────────────────────────
 func TestAccAppEndpointOIDCDiscoveryURL(t *testing.T) {
-	ensureFixtureBucketByName(t, globalOIDCDiscEPBucketName)
+	ensureFixtureCollection(t, globalOIDCDiscEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointOIDCDiscoveryURLResourceConfig(resourceName, epName, globalOIDCDiscEPBucketName),
+				Config: testAccAppEndpointOIDCDiscoveryURLResourceConfig(resourceName, epName, globalOIDCDiscEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "oidc.#", "1"),
@@ -422,30 +442,32 @@ func TestAccAppEndpointOIDCDiscoveryURL(t *testing.T) {
 
 // ── U1: Expand cors from minimal (origin only) to full (all fields) — happy path ──
 func TestAccAppEndpointUpdateCorsExpand(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsExpandEPBucketName)
+	ensureFixtureCollection(t, globalCorsExpandEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsExpandEPBucketName),
+				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsExpandEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
 					resource.TestCheckResourceAttr(resourceReference, "cluster_id", appEndpointClusterId),
 					resource.TestCheckResourceAttr(resourceReference, "app_service_id", appEndpointAppServiceId),
-					resource.TestCheckResourceAttr(resourceReference, "bucket", globalCorsExpandEPBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "bucket", appEndpointBucketName),
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
 					resource.TestCheckTypeSetElemAttr(resourceReference, "cors.origin.*", "*"),
 				),
 			},
 			{
-				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalCorsExpandEPBucketName),
+				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalCorsExpandEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "cors.disabled", "false"),
@@ -463,19 +485,21 @@ func TestAccAppEndpointUpdateCorsExpand(t *testing.T) {
 // cors is effectively write-once via Terraform.
 func TestAccAppEndpointUpdateRemoveCors(t *testing.T) {
 	t.Skip("AV-128229 / AV-128217: removing the cors block after it is set should succeed once the bugs are fixed")
-	ensureFixtureBucketByName(t, globalRemoveCorsEPBucketName)
+	ensureFixtureCollection(t, globalRemoveCorsEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalRemoveCorsEPBucketName),
+				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalRemoveCorsEPCollectionName),
 			},
 			{
-				Config: testAccAppEndpointNoCorsResourceConfig(resourceName, epName, globalRemoveCorsEPBucketName),
+				Config: testAccAppEndpointNoCorsResourceConfig(resourceName, epName, globalRemoveCorsEPCollectionName),
 			},
 		},
 	})
@@ -485,19 +509,21 @@ func TestAccAppEndpointUpdateRemoveCors(t *testing.T) {
 // The API rejects disabling CORS when other cors fields (origin etc.) are also set.
 func TestAccAppEndpointUpdateCorsDisableToggle(t *testing.T) {
 	t.Skip("AV-128229: toggling cors.disabled=true while other CORS fields are set should succeed once the bug is fixed")
-	ensureFixtureBucketByName(t, globalCorsDisableToggleEPBucketName)
+	ensureFixtureCollection(t, globalCorsDisableToggleEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsDisableToggleEPBucketName),
+				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsDisableToggleEPCollectionName),
 			},
 			{
-				Config: testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, epName, globalCorsDisableToggleEPBucketName),
+				Config: testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, epName, globalCorsDisableToggleEPCollectionName),
 			},
 		},
 	})
@@ -505,23 +531,25 @@ func TestAccAppEndpointUpdateCorsDisableToggle(t *testing.T) {
 
 // ── U5: cors origin wildcard → specific URLs — happy path ────────────────────
 func TestAccAppEndpointUpdateCorsOriginWildcardToSpecific(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsWildEPBucketName)
+	ensureFixtureCollection(t, globalCorsWildEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsWildEPBucketName),
+				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsWildEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckTypeSetElemAttr(resourceReference, "cors.origin.*", "*"),
 				),
 			},
 			{
-				Config: testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, epName, globalCorsWildEPBucketName),
+				Config: testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, epName, globalCorsWildEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "cors.origin.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceReference, "cors.origin.*", "https://app.example.com"),
@@ -534,20 +562,22 @@ func TestAccAppEndpointUpdateCorsOriginWildcardToSpecific(t *testing.T) {
 
 // ── U7: Add OIDC block to existing endpoint — happy path ─────────────────────
 func TestAccAppEndpointUpdateAddOIDC(t *testing.T) {
-	ensureFixtureBucketByName(t, globalAddOIDCEPBucketName)
+	ensureFixtureCollection(t, globalAddOIDCEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalAddOIDCEPBucketName),
+				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalAddOIDCEPCollectionName),
 			},
 			{
-				Config: testAccAppEndpointWithOIDCResourceConfig(resourceName, epName, globalAddOIDCEPBucketName),
+				Config: testAccAppEndpointWithOIDCResourceConfig(resourceName, epName, globalAddOIDCEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "oidc.#", "1"),
 					resource.TestCheckResourceAttr(resourceReference, "oidc.0.issuer", "https://accounts.google.com"),
@@ -565,19 +595,21 @@ func TestAccAppEndpointUpdateAddOIDC(t *testing.T) {
 // from the GET response, and Terraform detects the plan/state mismatch.
 func TestAccAppEndpointUpdateRemoveOIDC(t *testing.T) {
 	t.Skip("AV-128167: removing the oidc block should succeed once the bug is fixed")
-	ensureFixtureBucketByName(t, globalRemoveOIDCEPBucketName)
+	ensureFixtureCollection(t, globalRemoveOIDCEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointWithOIDCResourceConfig(resourceName, epName, globalRemoveOIDCEPBucketName),
+				Config: testAccAppEndpointWithOIDCResourceConfig(resourceName, epName, globalRemoveOIDCEPCollectionName),
 			},
 			{
-				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalRemoveOIDCEPBucketName),
+				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalRemoveOIDCEPCollectionName),
 			},
 		},
 	})
@@ -585,7 +617,7 @@ func TestAccAppEndpointUpdateRemoveOIDC(t *testing.T) {
 
 // ── U9: Update access_control_function body — happy path ─────────────────────
 func TestAccAppEndpointUpdateACF(t *testing.T) {
-	ensureFixtureBucketByName(t, globalACFUpdateEPBucketName)
+	ensureFixtureCollection(t, globalACFUpdateEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
@@ -594,17 +626,19 @@ func TestAccAppEndpointUpdateACF(t *testing.T) {
 	initialACF := "function(doc, oldDoc, meta) { channel(doc.channels); }"
 	updatedACF := "function(doc, oldDoc, meta) { channel(doc.type); }"
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointACFResourceConfig(resourceName, epName, globalACFUpdateEPBucketName, initialACF),
+				Config: testAccAppEndpointACFResourceConfig(resourceName, epName, globalACFUpdateEPCollectionName, initialACF),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
 				),
 			},
 			{
-				Config: testAccAppEndpointACFResourceConfig(resourceName, epName, globalACFUpdateEPBucketName, updatedACF),
+				Config: testAccAppEndpointACFResourceConfig(resourceName, epName, globalACFUpdateEPCollectionName, updatedACF),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
 				),
@@ -619,19 +653,21 @@ func TestAccAppEndpointUpdateACF(t *testing.T) {
 // Terraform detects plan=0 vs state=3600 and raises inconsistency error.
 func TestAccAppEndpointUpdateCorsMaxAgeToZero(t *testing.T) {
 	t.Skip("AV-128218: updating cors.max_age to 0 currently produces inconsistent state; unskip once zero values round-trip correctly")
-	ensureFixtureBucketByName(t, globalCorsMaxAgeZeroEPBucketName)
+	ensureFixtureCollection(t, globalCorsMaxAgeZeroEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeZeroEPBucketName, 3600),
+				Config: testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeZeroEPCollectionName, 3600),
 			},
 			{
-				Config:      testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeZeroEPBucketName, 0),
+				Config:      testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeZeroEPCollectionName, 0),
 				ExpectError: re.MustCompile("Provider produced inconsistent result after apply"),
 				// https://jira.issues.couchbase.com/browse/AV-128218
 			},
@@ -644,23 +680,25 @@ func TestAccAppEndpointUpdateCorsMaxAgeToZero(t *testing.T) {
 // non-zero value recovers the drift. The non-zero value is not omitted by
 // omitempty and is applied correctly by the API.
 func TestAccAppEndpointUpdateCorsMaxAgeFromZero(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsMaxAgeFromZeroEPBucketName)
+	ensureFixtureCollection(t, globalCorsMaxAgeFromZeroEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, epName, globalCorsMaxAgeFromZeroEPBucketName),
+				Config: testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, epName, globalCorsMaxAgeFromZeroEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "cors.max_age", "0"),
 				),
 			},
 			{
-				Config: testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeFromZeroEPBucketName, 3600),
+				Config: testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeFromZeroEPCollectionName, 3600),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "cors.max_age", "3600"),
 				),
@@ -680,7 +718,7 @@ func TestAccAppEndpointUpdateCorsMaxAgeFromZero(t *testing.T) {
 
 // testAccAppEndpointNoCorsResourceConfig creates an endpoint with no cors block.
 // Used by: TestAccAppEndpointUpdateRemoveCors (U2 phase 2, skipped).
-func testAccAppEndpointNoCorsResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointNoCorsResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -689,13 +727,13 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -707,14 +745,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointCorsDisabledFalseResourceConfig creates an endpoint with
 // cors { disabled=false } and no origin field. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin.
-func testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -723,7 +761,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -733,7 +771,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -745,14 +783,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig creates an endpoint with
 // cors { disabled=true } and no origin field. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin.
-func testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -761,7 +799,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -771,7 +809,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -783,14 +821,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointCorsEmptyOriginResourceConfig creates an endpoint with
 // cors { disabled=false, origin=[] }. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin.
-func testAccAppEndpointCorsEmptyOriginResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsEmptyOriginResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -799,7 +837,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -810,7 +848,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -822,7 +860,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -830,7 +868,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // testAccAppEndpointCorsMaxAgeZeroResourceConfig creates an endpoint with
 // cors.max_age=0. Used by: TestAccAppEndpointCorsMaxAgeZeroSilentDrift (S21),
 // TestAccAppEndpointUpdateCorsMaxAgeFromZero (U11 phase 1).
-func testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -839,7 +877,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -851,7 +889,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -863,14 +901,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointMultipleOIDCResourceConfig creates an endpoint with two OIDC
 // providers. Used by: TestAccAppEndpointMultipleOIDC (S19, skipped).
-func testAccAppEndpointMultipleOIDCResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointMultipleOIDCResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -879,7 +917,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -901,7 +939,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -913,7 +951,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -921,7 +959,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // testAccAppEndpointCorsAllFieldsResourceConfig creates an endpoint with all
 // cors fields set. Used by: TestAccAppEndpointCorsFullConfig (S6),
 // TestAccAppEndpointUpdateCorsExpand (U1 phase 2), TestAccAppEndpointUpdateRemoveCors (U2 phase 1, skipped).
-func testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -930,7 +968,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -944,7 +982,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -956,7 +994,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -964,7 +1002,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // testAccAppEndpointCorsSpecificOriginsResourceConfig creates an endpoint with
 // specific (non-wildcard) cors origins. Used by: TestAccAppEndpointCorsSpecificOrigins (S20),
 // TestAccAppEndpointUpdateCorsOriginWildcardToSpecific (U5 phase 2).
-func testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -973,7 +1011,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -987,7 +1025,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -999,14 +1037,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointOIDCAllFieldsResourceConfig creates an endpoint with an OIDC
 // provider using all optional fields. Used by: TestAccAppEndpointOIDCFullFields (S18).
-func testAccAppEndpointOIDCAllFieldsResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointOIDCAllFieldsResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1015,7 +1053,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1036,7 +1074,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1048,14 +1086,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointOIDCDiscoveryURLResourceConfig creates an endpoint with an OIDC
 // provider that includes a discovery_url. Used by: TestAccAppEndpointOIDCDiscoveryURL (S22).
-func testAccAppEndpointOIDCDiscoveryURLResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointOIDCDiscoveryURLResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1064,7 +1102,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1082,7 +1120,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1094,7 +1132,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -1104,7 +1142,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // TestAccAppEndpointUpdateCorsDisableToggle (U3 phase 1, skipped),
 // TestAccAppEndpointUpdateCorsOriginWildcardToSpecific (U5 phase 1),
 // TestAccAppEndpointUpdateAddOIDC (U7 phase 1), TestAccAppEndpointUpdateRemoveOIDC (U8 phase 2, skipped).
-func testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1113,7 +1151,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1123,7 +1161,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1135,14 +1173,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointCorsDisabledTrueResourceConfig creates an endpoint with
 // cors.disabled=true. Used by: TestAccAppEndpointUpdateCorsDisableToggle (U3 phase 2, skipped).
-func testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1151,7 +1189,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1162,7 +1200,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1174,7 +1212,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -1182,7 +1220,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // testAccAppEndpointCorsMaxAgeResourceConfig creates an endpoint with a
 // parameterised cors.max_age. Used by: TestAccAppEndpointUpdateCorsMaxAgeToZero (U10),
 // TestAccAppEndpointUpdateCorsMaxAgeFromZero (U11 phase 2).
-func testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, endpointName, bucketName string, maxAge int) string {
+func testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, endpointName, collectionName string, maxAge int) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1191,7 +1229,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1202,7 +1240,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1214,7 +1252,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 		maxAge,
 	)
@@ -1223,7 +1261,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // testAccAppEndpointWithOIDCResourceConfig creates an endpoint with cors and a
 // minimal OIDC provider. Used by: TestAccAppEndpointUpdateAddOIDC (U7 phase 2),
 // TestAccAppEndpointUpdateRemoveOIDC (U8 phase 1, skipped).
-func testAccAppEndpointWithOIDCResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointWithOIDCResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1232,7 +1270,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1249,7 +1287,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1261,14 +1299,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointACFResourceConfig creates an endpoint with a parameterised
 // access_control_function body. Used by: TestAccAppEndpointUpdateACF (U9).
-func testAccAppEndpointACFResourceConfig(resourceName, endpointName, bucketName, acfBody string) string {
+func testAccAppEndpointACFResourceConfig(resourceName, endpointName, collectionName, acfBody string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1277,7 +1315,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1287,7 +1325,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {
+				"%[7]s" = {
 					access_control_function = "%[9]s"
 				}
 			}
@@ -1301,7 +1339,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 		acfBody,
 	)

--- a/acceptance_tests/app_endpoint_deleted_externally_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_deleted_externally_acceptance_test.go
@@ -16,15 +16,17 @@ import (
 // This tests the 403 → List check → remove-from-state flow implemented in
 // checkAppEndpointDeletedOrForbidden.
 func TestAccAppEndpointDeletedExternally(t *testing.T) {
-	ensureFixtureBucketByName(t, globalDeletedExternallyEPBucketName)
+	ensureFixtureCollection(t, globalDeletedExternallyEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_ep_del_ext_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_ep_del_ext_")
 
-	cfg := testAccAppEndpointDeletedExternallyConfig(resourceName, epName, globalDeletedExternallyEPBucketName)
+	cfg := testAccAppEndpointDeletedExternallyConfig(resourceName, epName, globalDeletedExternallyEPCollectionName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			// Step 1: Create the App Endpoint via Terraform.
@@ -37,7 +39,7 @@ func TestAccAppEndpointDeletedExternally(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cluster_id", appEndpointClusterId),
 					resource.TestCheckResourceAttr(resourceReference, "app_service_id", appEndpointAppServiceId),
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
-					resource.TestCheckResourceAttr(resourceReference, "bucket", globalDeletedExternallyEPBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "bucket", appEndpointBucketName),
 				),
 			},
 			// Step 2: Delete the App Endpoint externally, then re-apply the same config.
@@ -62,7 +64,7 @@ func TestAccAppEndpointDeletedExternally(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
-					resource.TestCheckResourceAttr(resourceReference, "bucket", globalDeletedExternallyEPBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "bucket", appEndpointBucketName),
 				),
 			},
 		},
@@ -73,7 +75,7 @@ func TestAccAppEndpointDeletedExternally(t *testing.T) {
 // an App Endpoint is deleted outside of Terraform, the access_control_function
 // resource attached to it is gracefully removed from state during Read.
 func TestAccAppEndpointAccessControlFunctionDeletedExternally(t *testing.T) {
-	ensureFixtureBucketByName(t, globalACFDeletedExtEPBucketName)
+	ensureFixtureCollection(t, globalACFDeletedExtEPCollectionName)
 
 	epResourceName := randomStringWithPrefix("tf_acc_ep_acf_del_")
 	epReference := "couchbase-capella_app_endpoint." + epResourceName
@@ -85,12 +87,14 @@ func TestAccAppEndpointAccessControlFunctionDeletedExternally(t *testing.T) {
 	acfBody := "function(doc, oldDoc, meta) { channel(doc.channels); }"
 
 	cfgWithACF := testAccAppEndpointWithACFDeletedExternallyConfig(
-		epResourceName, epName, globalACFDeletedExtEPBucketName,
+		epResourceName, epName, globalACFDeletedExtEPCollectionName,
 		acfResourceName, acfBody,
 	)
-	cfgEndpointOnly := testAccAppEndpointDeletedExternallyConfig(epResourceName, epName, globalACFDeletedExtEPBucketName)
+	cfgEndpointOnly := testAccAppEndpointDeletedExternallyConfig(epResourceName, epName, globalACFDeletedExtEPCollectionName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			// Step 1: Create App Endpoint + ACF resource.
@@ -134,7 +138,7 @@ func TestAccAppEndpointAccessControlFunctionDeletedExternally(t *testing.T) {
 // Config helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-func testAccAppEndpointDeletedExternallyConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointDeletedExternallyConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -143,13 +147,13 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -161,13 +165,13 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 func testAccAppEndpointWithACFDeletedExternallyConfig(
-	epResourceName, endpointName, bucketName string,
+	epResourceName, endpointName, collectionName string,
 	acfResourceName, acfBody string,
 ) string {
 	return fmt.Sprintf(`
@@ -178,13 +182,13 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -196,6 +200,8 @@ resource "couchbase-capella_app_endpoint_access_control_function" "%[9]s" {
 	cluster_id              = "%[5]s"
 	app_service_id          = "%[6]s"
 	app_endpoint_name       = couchbase-capella_app_endpoint.%[2]s.name
+	scope                   = "_default"
+	collection              = "%[7]s"
 	access_control_function = "%[10]s"
 }
 `,
@@ -205,7 +211,7 @@ resource "couchbase-capella_app_endpoint_access_control_function" "%[9]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 		acfResourceName,
 		acfBody,

--- a/acceptance_tests/app_endpoint_environment.go
+++ b/acceptance_tests/app_endpoint_environment.go
@@ -24,6 +24,28 @@ var appEndpointEnvironmentOnce struct {
 	err error
 }
 
+// appEndpointCRUDConcurrency bounds how many app_endpoint resource tests run
+// endpoint create/update/delete at once. Every app-endpoint test shares a
+// single app service, and each endpoint mutation forces a Sync Gateway
+// reconfiguration; running too many concurrently triggers transient HTTP 500s
+// ("internal server error", code 10000) on update/list. Bounding concurrency
+// keeps the suite mostly parallel while avoiding that contention. Tune if the
+// 500s persist (lower) or the suite is too slow (raise).
+const appEndpointCRUDConcurrency = 3
+
+var appEndpointCRUDSem = make(chan struct{}, appEndpointCRUDConcurrency)
+
+// acquireAppEndpointCRUDSlot blocks until an endpoint-CRUD slot is free and
+// returns a release function. Call it after t.Parallel() and after fixture
+// provisioning, deferring the returned release for the test body:
+//
+//	t.Parallel()
+//	defer acquireAppEndpointCRUDSlot()()
+func acquireAppEndpointCRUDSlot() func() {
+	appEndpointCRUDSem <- struct{}{}
+	return func() { <-appEndpointCRUDSem }
+}
+
 func ensureAppEndpointTestEnvironment(t *testing.T) {
 	t.Helper()
 

--- a/acceptance_tests/app_service.go
+++ b/acceptance_tests/app_service.go
@@ -21,8 +21,7 @@ func createAppService(ctx context.Context, client *api.Client) error {
 			Cpu: 2,
 			Ram: 4,
 		},
-		Nodes:   &n,
-		Version: &version,
+		Nodes:   &n,		
 	}
 
 	url := fmt.Sprintf(

--- a/acceptance_tests/app_service.go
+++ b/acceptance_tests/app_service.go
@@ -15,13 +15,15 @@ import (
 
 func createAppService(ctx context.Context, client *api.Client) error {
 	var n int64 = 2
+	version := "4.0"
 	appServiceRequest := appservice.CreateAppServiceRequest{
 		Name: globalAppServiceName,
 		Compute: appservice.AppServiceCompute{
 			Cpu: 2,
 			Ram: 4,
 		},
-		Nodes: &n,
+		Nodes:   &n,
+		Version: &version,
 	}
 
 	url := fmt.Sprintf(

--- a/acceptance_tests/app_service.go
+++ b/acceptance_tests/app_service.go
@@ -14,8 +14,7 @@ import (
 )
 
 func createAppService(ctx context.Context, client *api.Client) error {
-	var n int64 = 2
-	version := "4.0"
+	var n int64 = 2	
 	appServiceRequest := appservice.CreateAppServiceRequest{
 		Name: globalAppServiceName,
 		Compute: appservice.AppServiceCompute{

--- a/acceptance_tests/audit_log_settings_acceptance_test.go
+++ b/acceptance_tests/audit_log_settings_acceptance_test.go
@@ -26,7 +26,7 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 	clusterReference := "couchbase-capella_cluster." + clusterResourceName
 	resourceReference := "couchbase-capella_audit_log_settings." + resourceName
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{

--- a/acceptance_tests/audit_log_settings_acceptance_test.go
+++ b/acceptance_tests/audit_log_settings_acceptance_test.go
@@ -26,7 +26,7 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 	clusterReference := "couchbase-capella_cluster." + clusterResourceName
 	resourceReference := "couchbase-capella_audit_log_settings." + resourceName
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{

--- a/acceptance_tests/endpoint_setup.go
+++ b/acceptance_tests/endpoint_setup.go
@@ -16,48 +16,49 @@ import (
 	bucketapi "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/bucket"
 )
 
-// fixtBucketState holds a once-and-error pair for a single pre-created bucket.
-type fixtBucketState struct {
-	once    sync.Once
-	err     error
-	created bool // true only if this test process created the bucket
+// fixtCollectionState holds a once-and-error pair for a single pre-created
+// collection in the shared app-endpoint bucket.
+type fixtCollectionState struct {
+	once sync.Once
+	err  error
 }
 
 var (
-	fixtBucketMu     sync.Mutex
-	fixtBucketStates = map[string]*fixtBucketState{}
+	fixtCollectionMu     sync.Mutex
+	fixtCollectionStates = map[string]*fixtCollectionState{}
 )
 
-// ensureFixtureBucketByName creates the named bucket exactly once per test
-// process. Safe to call from parallel tests.
-func ensureFixtureBucketByName(t *testing.T, name string) {
+// ensureFixtureCollection creates the named collection in the shared
+// app-endpoint bucket's _default scope exactly once per test process. App
+// endpoint resource tests use one collection each instead of a dedicated
+// bucket: Capella allows only one endpoint per bucket/scope/collection, and a
+// cluster's bucket cap (1 per 0.2 cores) is far smaller than its collection
+// cap. Sharing the bucket keeps parallel tests well under the bucket limit that
+// previously caused flaky "maximum number of buckets reached" failures.
+//
+// The collection lives in the shared bucket and is torn down with it at the end
+// of the suite, so no per-test cleanup is registered. Safe to call from
+// parallel tests.
+func ensureFixtureCollection(t *testing.T, name string) {
 	t.Helper()
 	ensureAppEndpointTestEnvironment(t)
-	fixtBucketMu.Lock()
-	state, ok := fixtBucketStates[name]
+	fixtCollectionMu.Lock()
+	state, ok := fixtCollectionStates[name]
 	if !ok {
-		state = &fixtBucketState{}
-		fixtBucketStates[name] = state
+		state = &fixtCollectionState{}
+		fixtCollectionStates[name] = state
 	}
-	// Unlock immediately — the mutex only guards the map. Bucket creation is
-	// serialised per-name by state.once (sync.Once), so parallel tests for
-	// different buckets are not blocked behind each other.
-	fixtBucketMu.Unlock()
+	// Unlock immediately — the mutex only guards the map. Collection creation is
+	// serialised per-name by state.once, so parallel tests for different
+	// collections are not blocked behind each other.
+	fixtCollectionMu.Unlock()
 
 	state.once.Do(func() {
 		ctx := context.Background()
-		state.created, state.err = createFixtureBucket(ctx, globalClient, name)
+		state.err = createFixtureCollection(ctx, globalClient, appEndpointBucketId, globalScopeName, name)
 	})
 	if state.err != nil {
-		t.Fatalf("failed to provision test bucket %s: %v", name, state.err)
-	}
-
-	if state.created {
-		t.Cleanup(func() {
-			if err := deleteAppEndpointFixtureBucket(context.Background(), globalClient, globalProjectId, appEndpointClusterId, name); err != nil {
-				t.Logf("warning: failed to delete fixture bucket %q: %v", name, err)
-			}
-		})
+		t.Fatalf("failed to provision test collection %s: %v", name, state.err)
 	}
 }
 
@@ -156,6 +157,76 @@ func createFixtureBucket(ctx context.Context, client *api.Client, name string) (
 	}
 
 	return true, waitForFixtureBucket(ctx, client, bucketResp.Id)
+}
+
+// createFixtureCollection creates the named collection in the given scope of the
+// shared bucket if it does not already exist, then waits until it is listable.
+func createFixtureCollection(ctx context.Context, client *api.Client, bucketID, scope, name string) error {
+	collectionsUrl := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/buckets/%s/scopes/%s/collections",
+		globalHost, globalOrgId, globalProjectId, appEndpointClusterId, bucketID, scope)
+
+	exists, err := fixtureCollectionExists(ctx, client, collectionsUrl, name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		log.Printf("fixture collection %q already exists", name)
+		return nil
+	}
+
+	createCfg := api.EndpointCfg{Url: collectionsUrl, Method: http.MethodPost, SuccessStatus: http.StatusCreated}
+	if _, err = client.ExecuteWithRetry(ctx, createCfg, api.CreateCollectionRequest{Name: name}, globalToken, nil); err != nil {
+		return fmt.Errorf("creating fixture collection %q: %w", name, err)
+	}
+
+	return waitForFixtureCollection(ctx, client, collectionsUrl, name)
+}
+
+// fixtureCollectionExists reports whether a collection with the given name is
+// present at the collections list endpoint.
+func fixtureCollectionExists(ctx context.Context, client *api.Client, collectionsUrl, name string) (bool, error) {
+	listCfg := api.EndpointCfg{Url: collectionsUrl, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := client.ExecuteWithRetry(ctx, listCfg, nil, globalToken, nil)
+	if err != nil {
+		return false, fmt.Errorf("listing collections for %q: %w", name, err)
+	}
+
+	var collections api.GetCollectionsResponse
+	if err = json.Unmarshal(response.Body, &collections); err != nil {
+		return false, fmt.Errorf("unmarshalling collections list for %q: %w", name, err)
+	}
+	for _, c := range collections.Data {
+		if c.Name != nil && *c.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// waitForFixtureCollection polls until the collection is listable. App endpoint
+// creation rejects a collection that is not yet visible ("Collection Not
+// Found"), so fixtures wait for it before pointing endpoints at it.
+func waitForFixtureCollection(ctx context.Context, client *api.Client, collectionsUrl, name string) error {
+	const maxWait = 2 * time.Minute
+	deadline := time.Now().Add(maxWait)
+
+	for {
+		exists, err := fixtureCollectionExists(ctx, client, collectionsUrl, name)
+		if err == nil && exists {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return fmt.Errorf("timeout waiting for fixture collection %q: %w", name, err)
+			}
+			return fmt.Errorf("timeout waiting for fixture collection %q to become listable", name)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context done waiting for fixture collection %q: %w", name, ctx.Err())
+		case <-time.After(5 * time.Second):
+		}
+	}
 }
 
 // deleteBucketWithRetry retries the bucket DELETE on 412 (App Service not yet

--- a/acceptance_tests/globals.go
+++ b/acceptance_tests/globals.go
@@ -79,35 +79,39 @@ var (
 	appEndpointLoggingEndpointName    = "tf_acc_test_logging_endpoint"
 	appEndpointLoggingBucketName      = "tf_acc_logging_bkt"
 
-	// Fixture buckets for app_endpoint resource tests. Each test gets its
-	// own bucket because Capella only permits one endpoint per bucket/scope/collection.
-	// These buckets are not created or managed by Terraform; instead, test helpers
-	// manage their lifecycle through the API during test runs, including cleanup
-	// when needed.
-	globalEPBucketName                   = "tf_acc_ep_bkt"
-	globalNoCorsEPBucketName             = "tf_acc_ep_nocors_bkt"
-	globalCorsFullEPBucketName           = "tf_acc_ep_cors_full_bkt"
-	globalCorsSpecificEPBucketName       = "tf_acc_ep_cors_spec_bkt"
-	globalCorsMaxAge0EPBucketName        = "tf_acc_ep_cors_ma0_bkt"
-	globalOIDCFullEPBucketName           = "tf_acc_ep_oidc_full_bkt"
-	globalOIDCDiscEPBucketName           = "tf_acc_ep_oidc_disc_bkt"
-	globalCorsExpandEPBucketName         = "tf_acc_ep_cors_exp_bkt"
-	globalCorsWildEPBucketName           = "tf_acc_ep_cors_wld_bkt"
-	globalAddOIDCEPBucketName            = "tf_acc_ep_add_oidc_bkt"
-	globalACFUpdateEPBucketName          = "tf_acc_ep_acf_bkt"
-	globalCorsMaxAgeZeroEPBucketName     = "tf_acc_ep_maz_bkt"
-	globalCorsMaxAgeFromZeroEPBucketName = "tf_acc_ep_mafz_bkt"
-	// Buckets for "deleted externally" tests — validates the 403 → List fallback
+	// Fixture collections for app_endpoint resource tests. Each test gets its
+	// own collection in the shared appEndpointBucketName bucket (under the
+	// _default scope) rather than a dedicated bucket: Capella permits only one
+	// endpoint per bucket/scope/collection, and a cluster's bucket cap (1 per
+	// 0.2 cores, so 20 here) is far smaller than its collection cap. Sharing the
+	// bucket keeps parallel runs well under the bucket limit that previously
+	// caused flaky "maximum number of buckets reached" failures. These
+	// collections are created via the API by ensureFixtureCollection and torn
+	// down with the shared bucket at the end of the suite.
+	globalEPCollectionName                   = "tf_acc_ep_col"
+	globalNoCorsEPCollectionName             = "tf_acc_ep_nocors_col"
+	globalCorsFullEPCollectionName           = "tf_acc_ep_cors_full_col"
+	globalCorsSpecificEPCollectionName       = "tf_acc_ep_cors_spec_col"
+	globalCorsMaxAge0EPCollectionName        = "tf_acc_ep_cors_ma0_col"
+	globalOIDCFullEPCollectionName           = "tf_acc_ep_oidc_full_col"
+	globalOIDCDiscEPCollectionName           = "tf_acc_ep_oidc_disc_col"
+	globalCorsExpandEPCollectionName         = "tf_acc_ep_cors_exp_col"
+	globalCorsWildEPCollectionName           = "tf_acc_ep_cors_wld_col"
+	globalAddOIDCEPCollectionName            = "tf_acc_ep_add_oidc_col"
+	globalACFUpdateEPCollectionName          = "tf_acc_ep_acf_col"
+	globalCorsMaxAgeZeroEPCollectionName     = "tf_acc_ep_maz_col"
+	globalCorsMaxAgeFromZeroEPCollectionName = "tf_acc_ep_mafz_col"
+	// Collections for "deleted externally" tests — validates the 403 → List fallback
 	// that removes resources from state when the App Endpoint is deleted outside TF.
-	globalDeletedExternallyEPBucketName = "tf_acc_ep_del_ext_bkt"
-	globalACFDeletedExtEPBucketName     = "tf_acc_ep_acf_dex_bkt"
-	// Buckets for currently-skipped tests — not provisioned while skipped, but
+	globalDeletedExternallyEPCollectionName = "tf_acc_ep_del_ext_col"
+	globalACFDeletedExtEPCollectionName     = "tf_acc_ep_acf_dex_col"
+	// Collections for currently-skipped tests — not provisioned while skipped, but
 	// named so the tests are ready to run once the underlying bugs are fixed.
-	globalCorsDisabledFalseEPBucketName = "tf_acc_ep_cors_df_bkt"
-	globalMultipleOIDCEPBucketName      = "tf_acc_ep_moidc_bkt"
-	globalRemoveCorsEPBucketName        = "tf_acc_ep_rmcors_bkt"
-	globalCorsDisableToggleEPBucketName = "tf_acc_ep_cdtgl_bkt"
-	globalRemoveOIDCEPBucketName        = "tf_acc_ep_rmoidc_bkt"
+	globalCorsDisabledFalseEPCollectionName = "tf_acc_ep_cors_df_col"
+	globalMultipleOIDCEPCollectionName      = "tf_acc_ep_moidc_col"
+	globalRemoveCorsEPCollectionName        = "tf_acc_ep_rmcors_col"
+	globalCorsDisableToggleEPCollectionName = "tf_acc_ep_cdtgl_col"
+	globalRemoveOIDCEPCollectionName        = "tf_acc_ep_rmoidc_col"
 	// TestAccAppEndpointInexistentCollection reuses globalBucketName: it tries
 	// _default/INVALID_COLLECTION which does not conflict with the common
 	// endpoint on _default/_default, so no dedicated bucket is needed.

--- a/acceptance_tests/globals.go
+++ b/acceptance_tests/globals.go
@@ -106,7 +106,7 @@ var (
 	globalDeletedExternallyEPCollectionName = "tf_acc_ep_del_ext_col"
 	globalACFDeletedExtEPCollectionName     = "tf_acc_ep_acf_dex_col"
 	// Collections for currently-skipped tests — not provisioned while skipped, but
-	// named so the tests are ready to run once the underlying bugs are fixed.
+	// named so the tests are ready to run once the underlying bugs are fixed. 
 	globalCorsDisabledFalseEPCollectionName = "tf_acc_ep_cors_df_col"
 	globalMultipleOIDCEPCollectionName      = "tf_acc_ep_moidc_col"
 	globalRemoveCorsEPCollectionName        = "tf_acc_ep_rmcors_col"


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-134866](https://jira.issues.couchbase.com/browse/AV-134866)

## Description

**Summary**

Fixes flaky app_endpoint acceptance tests that intermittently failed in setup with:

> The maximum number of buckets allowed for this Couchbase Capella cluster
> is (20) buckets. That maximum has been reached.

**Root cause**
Every app_endpoint resource test provisioned its own dedicated bucket. Capella caps buckets at 1 per 0.2 cores (20 on the test cluster). With the suite running in parallel, ~23 fixture buckets were live simultaneously and overflowed the cap — non-deterministically, depending on scheduling.

**Fix**
Share one bucket; isolate tests by collection instead. Each resource test now creates its own collection in the existing default bucket's _default scope and points its endpoint there. This is valid because Capella's constraint is one endpoint per bucket/scope/collection, and the per-cluster collection limit is far larger than the bucket limit.

Peak bucket usage drops from ~23 -> ~9, comfortably under the cap.

The sub-resource fixture endpoints (ACF, import filter, resync) intentionally keep dedicated buckets — they assert _default/_default defaulting behavior, which needs a free _default/_default keyspace per bucket.

**Secondary fix: throttle endpoint CRUD**
While validating, two tests hit transient code 10000 HTTP 500s on update/list. All app-endpoint tests share a single app service, and unbounded concurrent endpoint reconfiguration overloads Sync Gateway. Added a bounded semaphore (appEndpointCRUDConcurrency = 3): tests keep t.Parallel() but gate the create/update/delete body, mirroring the existing cloudSnapshotRestoreMu precedent. The limit is a tunable const.

**Changes**
- **globals.go** — rename *EPBucketName -> *EPCollectionName; update comments.
- **endpoint_setup.go** — add ensureFixtureCollection + createFixtureCollection (idempotent, waits until the collection is listable); remove the now-unused ensureFixtureBucketByName and dead bucket-fixture state.
- **app_endpoint_environment.go** — add the bounded-concurrency semaphore helper.
- **app_endpoint_acceptance_test.go / app_endpoint_deleted_externally_acceptance_test.go** — configs target the shared bucket + per-test collection; the deleted-externally ACF sub-resource targets the endpoint's collection; throttle endpoint CRUD.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments

[AV-134866]: https://couchbasecloud.atlassian.net/browse/AV-134866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ