### PR TITLE
[AV-132167] Reject short private endpoint command VPC IDs at plan time

### DIFF
--- a/acceptance_tests/private_endpoint_acceptance_test.go
+++ b/acceptance_tests/private_endpoint_acceptance_test.go
@@ -2,6 +2,7 @@ package acceptance_tests
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -42,6 +43,100 @@ func TestAccPrivateEndpointServiceEnableDisable(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccAWSPrivateEndpointCommandInvalidVPCID verifies that the AWS private endpoint
+// command data source rejects a vpc_id shorter than the OpenAPI minimum length at plan
+// time. The generated LengthBetween(12, 21) validator fires before any API call, so dummy
+// org/project/cluster IDs are sufficient.
+func TestAccAWSPrivateEndpointCommandInvalidVPCID(t *testing.T) {
+	dataSourceName := randomStringWithPrefix("tf_acc_aws_pe_command_invalid_")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSPrivateEndpointCommandInvalidVPCIDConfig(dataSourceName),
+				ExpectError: regexp.MustCompile(`(?s)Attribute vpc_id string length must be between 12 and 21`),
+			},
+		},
+	})
+}
+
+func testAccAWSPrivateEndpointCommandInvalidVPCIDConfig(dataSourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_aws_private_endpoint_command" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  cluster_id      = "22222222-2222-2222-2222-222222222222"
+  vpc_id          = "vpc-short"
+  subnet_ids      = ["subnet-1234567890abcdef0"]
+}
+`, globalProviderBlock, dataSourceName)
+}
+
+// TestAccAzurePrivateEndpointCommandInvalidVirtualNetwork verifies that the Azure private
+// endpoint command data source rejects a virtual_network shorter than the OpenAPI minimum
+// length at plan time. The generated LengthBetween(2, 64) validator fires before any API call.
+func TestAccAzurePrivateEndpointCommandInvalidVirtualNetwork(t *testing.T) {
+	dataSourceName := randomStringWithPrefix("tf_acc_azure_pe_command_invalid_")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAzurePrivateEndpointCommandInvalidVirtualNetworkConfig(dataSourceName),
+				ExpectError: regexp.MustCompile(`(?s)Attribute virtual_network string length must be between 2 and 64`),
+			},
+		},
+	})
+}
+
+func testAccAzurePrivateEndpointCommandInvalidVirtualNetworkConfig(dataSourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_azure_private_endpoint_command" "%[2]s" {
+  organization_id     = "00000000-0000-0000-0000-000000000000"
+  project_id          = "11111111-1111-1111-1111-111111111111"
+  cluster_id          = "22222222-2222-2222-2222-222222222222"
+  resource_group_name = "my-resource-group"
+  virtual_network     = "a"
+}
+`, globalProviderBlock, dataSourceName)
+}
+
+// TestAccGCPPrivateEndpointCommandInvalidVPCNetworkID verifies that the GCP private endpoint
+// command data source rejects a vpc_network_id shorter than the OpenAPI minimum length at
+// plan time. The generated LengthBetween(12, 21) validator fires before any API call.
+func TestAccGCPPrivateEndpointCommandInvalidVPCNetworkID(t *testing.T) {
+	dataSourceName := randomStringWithPrefix("tf_acc_gcp_pe_command_invalid_")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccGCPPrivateEndpointCommandInvalidVPCNetworkIDConfig(dataSourceName),
+				ExpectError: regexp.MustCompile(`(?s)Attribute vpc_network_id string length must be between 12 and 21`),
+			},
+		},
+	})
+}
+
+func testAccGCPPrivateEndpointCommandInvalidVPCNetworkIDConfig(dataSourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_gcp_private_endpoint_command" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  cluster_id      = "22222222-2222-2222-2222-222222222222"
+  vpc_network_id  = "vpc-short"
+  subnet_ids      = ["subnet-1234567890abcdef0"]
+}
+`, globalProviderBlock, dataSourceName)
 }
 
 // testAccPrivateEndpointServiceEnableConfig returns terraform config for enabling/disabling private endpoint service

--- a/acceptance_tests/private_endpoint_acceptance_test.go
+++ b/acceptance_tests/private_endpoint_acceptance_test.go
@@ -52,12 +52,12 @@ func TestAccPrivateEndpointServiceEnableDisable(t *testing.T) {
 func TestAccAWSPrivateEndpointCommandInvalidVPCID(t *testing.T) {
 	dataSourceName := randomStringWithPrefix("tf_acc_aws_pe_command_invalid_")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSPrivateEndpointCommandInvalidVPCIDConfig(dataSourceName),
-				ExpectError: regexp.MustCompile(`(?s)Attribute vpc_id string length must be between 12 and 21`),
+				ExpectError: regexp.MustCompile(`(?s)vpc_id.*string length must be between 12 and 21`),
 			},
 		},
 	})
@@ -83,12 +83,12 @@ data "couchbase-capella_aws_private_endpoint_command" "%[2]s" {
 func TestAccAzurePrivateEndpointCommandInvalidVirtualNetwork(t *testing.T) {
 	dataSourceName := randomStringWithPrefix("tf_acc_azure_pe_command_invalid_")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAzurePrivateEndpointCommandInvalidVirtualNetworkConfig(dataSourceName),
-				ExpectError: regexp.MustCompile(`(?s)Attribute virtual_network string length must be between 2 and 64`),
+				ExpectError: regexp.MustCompile(`(?s)virtual_network.*string length must be between 2 and 64`),
 			},
 		},
 	})
@@ -114,12 +114,12 @@ data "couchbase-capella_azure_private_endpoint_command" "%[2]s" {
 func TestAccGCPPrivateEndpointCommandInvalidVPCNetworkID(t *testing.T) {
 	dataSourceName := randomStringWithPrefix("tf_acc_gcp_pe_command_invalid_")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccGCPPrivateEndpointCommandInvalidVPCNetworkIDConfig(dataSourceName),
-				ExpectError: regexp.MustCompile(`(?s)Attribute vpc_network_id string length must be between 12 and 21`),
+				ExpectError: regexp.MustCompile(`(?s)vpc_network_id.*string length must be between 12 and 21`),
 			},
 		},
 	})

--- a/internal/datasources/aws_private_endpoint_command_schema.go
+++ b/internal/datasources/aws_private_endpoint_command_schema.go
@@ -16,7 +16,7 @@ func AwsPrivateEndpointCommandSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", awsPrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "project_id", awsPrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "cluster_id", awsPrivateEndpointCommandBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "vpc_id", awsPrivateEndpointCommandBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "vpc_id", awsPrivateEndpointCommandBuilder, requiredString(), "CreateVPCEndpointCommandRequest")
 	capellaschema.AddAttr(attrs, "subnet_ids", awsPrivateEndpointCommandBuilder, &schema.SetAttribute{
 		Required:    true,
 		ElementType: types.StringType,

--- a/internal/datasources/azure_private_endpoint_command_schema.go
+++ b/internal/datasources/azure_private_endpoint_command_schema.go
@@ -15,8 +15,8 @@ func AzurePrivateEndpointCommandSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", azurePrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "project_id", azurePrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "cluster_id", azurePrivateEndpointCommandBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "resource_group_name", azurePrivateEndpointCommandBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "virtual_network", azurePrivateEndpointCommandBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "resource_group_name", azurePrivateEndpointCommandBuilder, requiredString(), "CreateAzurePrivateEndpointCommandRequest")
+	capellaschema.AddAttr(attrs, "virtual_network", azurePrivateEndpointCommandBuilder, requiredString(), "CreateAzurePrivateEndpointCommandRequest")
 	capellaschema.AddAttr(attrs, "command", azurePrivateEndpointCommandBuilder, computedString())
 
 	return schema.Schema{

--- a/internal/datasources/gcp_private_endpoint_command_schema.go
+++ b/internal/datasources/gcp_private_endpoint_command_schema.go
@@ -16,7 +16,7 @@ func GcpPrivateEndpointCommandSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", gcpPrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "project_id", gcpPrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "cluster_id", gcpPrivateEndpointCommandBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "vpc_network_id", gcpPrivateEndpointCommandBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "vpc_network_id", gcpPrivateEndpointCommandBuilder, requiredString(), "CreateGCPPrivateEndpointCommandRequest")
 	capellaschema.AddAttr(attrs, "subnet_ids", gcpPrivateEndpointCommandBuilder, &schema.SetAttribute{
 		Required:    true,
 		ElementType: types.StringType,


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-132167

## Description

### Problem
The `aws_private_endpoint_command`, `azure_private_endpoint_command`, and `gcp_private_endpoint_command` data sources accepted invalid VPC ID / network values during `terraform validate`.

 ### Root cause                                                                                                                                                                                 
  These fields were plain required strings. The generated length constraints exist under OpenAPI request schemas (e.g. `CreateVPCEndpointCommandRequest.vpcID`), but the builders use schema names like `awsPrivateEndpointCommand`, so `ConstraintLookup` never matched and no validator attached.

### Fix
Pass the relevant request schema as `alternateSchemas` to `AddAttr` so the generated length validators resolve for aws `vpc_id` (12–21), azure `resource_group_name` (1–90), azure `virtual_network` (2–64), and gcp `vpc_network_id` (12–21). These are now rejected at plan time, before any API call.

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [X] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
Acceptance tested against production Capella. TestMain provisioned a cluster, bucket, app service, and app endpoint, the three new plan-time validation tests ran, and all fixtures were torn down (verified 0 leftover clusters).

```
=== RUN   TestAccAWSPrivateEndpointCommandInvalidVPCID
--- PASS: TestAccAWSPrivateEndpointCommandInvalidVPCID (1.72s)
=== RUN   TestAccAzurePrivateEndpointCommandInvalidVirtualNetwork
--- PASS: TestAccAzurePrivateEndpointCommandInvalidVirtualNetwork (0.55s)
=== RUN   TestAccGCPPrivateEndpointCommandInvalidVPCNetworkID
--- PASS: TestAccGCPPrivateEndpointCommandInvalidVPCNetworkID (0.16s)
PASS
ok  github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests  855.882s
```

Each test asserts that a too-short value is rejected at plan time (before any API call):
- aws `vpc_id = "vpc-short"`           -> `Attribute vpc_id string length must be between 12 and 21, got: 9`
- azure `virtual_network = "a"`        -> `Attribute virtual_network string length must be between 2 and 64, got: 1`
- gcp `vpc_network_id = "vpc-short"`   -> `Attribute vpc_network_id string length must be between 12 and 21, got: 9`
</details>

## Further comments
