### PR TITLE
[AV-132168] Reject unsupported network peer provider_type

### DIFF
--- a/acceptance_tests/network_peer_acceptance_test.go
+++ b/acceptance_tests/network_peer_acceptance_test.go
@@ -1,0 +1,48 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccNetworkPeerInvalidProviderType verifies that the network peer resource rejects an
+// unsupported provider_type at plan time. The OneOf("aws", "gcp", "azure") validator fires
+// before any API call, so dummy org/project/cluster IDs are sufficient.
+func TestAccNetworkPeerInvalidProviderType(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_network_peer_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNetworkPeerInvalidProviderTypeConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)provider_type.*value must be one of.*aws.*gcp.*azure`),
+			},
+		},
+	})
+}
+
+func testAccNetworkPeerInvalidProviderTypeConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_network_peer" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  cluster_id      = "22222222-2222-2222-2222-222222222222"
+  name            = "qe-invalid-provider-type"
+  provider_type   = "ibm"
+  provider_config = {
+    aws_config = {
+      account_id = "123456789012"
+      vpc_id     = "vpc-1234567890abcdef0"
+      cidr       = "10.10.0.0/16"
+      region     = "us-east-1"
+    }
+  }
+}
+`, globalProviderBlock, resourceName)
+}

--- a/internal/resources/network_peer_schema.go
+++ b/internal/resources/network_peer_schema.go
@@ -1,10 +1,12 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
@@ -25,7 +27,10 @@ func NetworkPeerSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "project_id", networkPeerBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "cluster_id", networkPeerBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "name", networkPeerBuilder, stringAttribute([]string{required, requiresReplace}))
-	capellaschema.AddAttr(attrs, "provider_type", networkPeerBuilder, stringAttribute([]string{required, requiresReplace}))
+	capellaschema.AddAttr(attrs, "provider_type", networkPeerBuilder, stringAttribute(
+		[]string{required, requiresReplace},
+		validator.String(stringvalidator.OneOf("aws", "gcp", "azure")),
+	))
 	capellaschema.AddAttr(attrs, "audit", networkPeerBuilder, computedAuditAttribute())
 	capellaschema.AddAttr(attrs, "commands", networkPeerBuilder, &schema.SetAttribute{
 		Computed:    true,


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-132168

## Description

 ### Problem                                                                                                                                                                                    
  `couchbase-capella_network_peer.provider_type` accepted unsupported values (e.g. `provider_type = "ibm"`) during `terraform validate`. The error only surfaced later during create, when the API rejected it.                                                                                                                                                                               
                                                                                                                                                                                                 
  ### Root cause                                                                                                                                                                                 
  `provider_type` was defined as a plain required string in `network_peer_schema.go`. Unlike other fields, the auto-attach mechanism can't help here: the generated enum table has no `providerType` entry because the OpenAPI spec (`CreateNetworkPeeringRequest.providerType`) doesn't expose it as an enum, so no `OneOf` validator gets attached.                                
                                                                                                                                                                                                 
  ### Fix                                                                                                                                                                                        
  Add an explicit `stringvalidator.OneOf("aws", "gcp", "azure")` to `provider_type`, matching the supported values documented in the schema model (`internal/schema/network_peer.go`) and the resource examples. Invalid values are now rejected at plan time, before any API call.  

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [X] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
Acceptance tested against production Capella. TestMain provisioned a cluster, bucket, app service, and app endpoint, the plan-time validation test ran, and all fixtures were torn down (verified 0 leftover clusters).

```
=== RUN   TestAccNetworkPeerInvalidProviderType
--- PASS: TestAccNetworkPeerInvalidProviderType (1.54s)
PASS
ok  github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests  851.216s
```

Asserts that `provider_type = "ibm"` is rejected at plan time (before any API call):
`Attribute provider_type value must be one of: ["aws" "gcp" "azure"], got: "ibm"`
</details>

## Further comments
