### PR TITLE
[AV-135212] Only set eventing resource computed fields if known

### DIFF
--- a/internal/resources/eventing_function.go
+++ b/internal/resources/eventing_function.go
@@ -19,6 +19,7 @@ import (
 	eventingapi "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/eventingfunction"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -597,8 +598,8 @@ func keyspaceToAPI(k *providerschema.EventingFunctionKeyspace) eventingapi.Keysp
 	}
 	return eventingapi.Keyspace{
 		Bucket:     k.Bucket.ValueString(),
-		Scope:      k.Scope.ValueStringPointer(),
-		Collection: k.Collection.ValueStringPointer(),
+		Scope:      utils.StringPointerIfKnown(k.Scope),
+		Collection: utils.StringPointerIfKnown(k.Collection),
 	}
 }
 
@@ -612,7 +613,7 @@ func keyspaceToAPIPtr(k *providerschema.EventingFunctionKeyspace) *eventingapi.K
 }
 
 // eventingSettingsFromObject converts the settings object value into the concrete struct, returning
-// nil when the block was omitted (null/unknown). Unknown computed leaves are nulled so they are not
+// nil when the block was omitted (null/unknown). Unknown computed fields are nulled so they are not
 // sent to the API and do not register as user changes.
 func eventingSettingsFromObject(ctx context.Context, obj types.Object) (*providerschema.EventingFunctionSettings, diag.Diagnostics) {
 	if obj.IsNull() || obj.IsUnknown() {
@@ -631,14 +632,14 @@ func settingsToAPI(s *providerschema.EventingFunctionSettings) *eventingapi.Sett
 		return nil
 	}
 	return &eventingapi.Settings{
-		WorkerCount:           s.WorkerCount.ValueInt64Pointer(),
-		ScriptTimeout:         s.ScriptTimeout.ValueInt64Pointer(),
-		SqlConsistency:        s.SqlConsistency.ValueStringPointer(),
-		LanguageCompatibility: s.LanguageCompatibility.ValueStringPointer(),
-		FeedBoundary:          s.FeedBoundary.ValueStringPointer(),
-		MaxTimerContextSize:   s.MaxTimerContextSize.ValueInt64Pointer(),
-		AllowSyncDocuments:    s.AllowSyncDocuments.ValueBoolPointer(),
-		CursorAware:           s.CursorAware.ValueBoolPointer(),
+		WorkerCount:           utils.Int64PointerIfKnown(s.WorkerCount),
+		ScriptTimeout:         utils.Int64PointerIfKnown(s.ScriptTimeout),
+		SqlConsistency:        utils.StringPointerIfKnown(s.SqlConsistency),
+		LanguageCompatibility: utils.StringPointerIfKnown(s.LanguageCompatibility),
+		FeedBoundary:          utils.StringPointerIfKnown(s.FeedBoundary),
+		MaxTimerContextSize:   utils.Int64PointerIfKnown(s.MaxTimerContextSize),
+		AllowSyncDocuments:    utils.BoolPointerIfKnown(s.AllowSyncDocuments),
+		CursorAware:           utils.BoolPointerIfKnown(s.CursorAware),
 	}
 }
 
@@ -653,9 +654,9 @@ func bindingsToAPI(b *providerschema.EventingFunctionBindingsResource) *eventing
 		bindings.Buckets = append(bindings.Buckets, eventingapi.BucketBinding{
 			Alias:      bucket.Alias.ValueString(),
 			Bucket:     bucket.Bucket.ValueString(),
-			Scope:      bucket.Scope.ValueStringPointer(),
-			Collection: bucket.Collection.ValueStringPointer(),
-			Permission: bucket.Permission.ValueStringPointer(),
+			Scope:      utils.StringPointerIfKnown(bucket.Scope),
+			Collection: utils.StringPointerIfKnown(bucket.Collection),
+			Permission: utils.StringPointerIfKnown(bucket.Permission),
 		})
 	}
 
@@ -663,8 +664,8 @@ func bindingsToAPI(b *providerschema.EventingFunctionBindingsResource) *eventing
 		urlBinding := eventingapi.UrlBinding{
 			Alias:                  u.Alias.ValueString(),
 			Url:                    u.Url.ValueString(),
-			AllowCookies:           u.AllowCookies.ValueBoolPointer(),
-			ValidateTLSCertificate: u.ValidateTLSCertificate.ValueBoolPointer(),
+			AllowCookies:           utils.BoolPointerIfKnown(u.AllowCookies),
+			ValidateTLSCertificate: utils.BoolPointerIfKnown(u.ValidateTLSCertificate),
 		}
 		if u.Authentication != nil {
 			urlBinding.Authentication = &eventingapi.URLBindingAuthentication{

--- a/internal/utils/framework.go
+++ b/internal/utils/framework.go
@@ -1,0 +1,27 @@
+package utils
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+// BoolPointerIfKnown returns a pointer to the bool value when it is known and non-null, and nil otherwise.
+func BoolPointerIfKnown(v types.Bool) *bool {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	return v.ValueBoolPointer()
+}
+
+// StringPointerIfKnown returns a pointer to the string value when it is known and non-null, and nil otherwise.
+func StringPointerIfKnown(v types.String) *string {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	return v.ValueStringPointer()
+}
+
+// Int64PointerIfKnown returns a pointer to the int64 value when it is known and non-null, and nil otherwise.
+func Int64PointerIfKnown(v types.Int64) *int64 {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	return v.ValueInt64Pointer()
+}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-135212

## Description

- Only send computed fields values to the create eventing function API if they have been set in the plan

The objective of this PR is to fix `validate_tls_certificate` being set to false when the user hasn't set it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

TF Plan 

```
resource "couchbase-capella_eventing_function" "av135212" {
      organization_id = var.org_id
      project_id      = local.project_id
      cluster_id      = local.cluster_id

  name = "tf_av135212_unknowns"
  code = <<-EOT
      function OnUpdate(doc, meta) {
        log("updated", meta.id);
      }
    EOT

  event_source = {
    bucket = "travel-sample"
    scope = "inventory"
    collection = "airline"
  }

  event_metadata_storage = {
    bucket = "travel-sample"
    scope = "inventory"
    collection = "airport"
  }

  bindings = {
    buckets = [
      {
        alias  = "src"
        bucket = "travel-sample"
      }
    ]
    urls = [
      {
        alias = "api"
        url   = "https://example.com"
        authentication = {
          type = "none"
        }
      }
    ]
  }
}

output "validate_tls_certificate" {
  value = couchbase-capella_eventing_function.av135212.bindings.urls[0].validate_tls_certificate
}
output "settings" {
  value = couchbase-capella_eventing_function.av135212.settings
}
```

TF Apply shows `validate_tls_certificate` is true and settings use the defaults as expected

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_eventing_function.av135212 will be created
  + resource "couchbase-capella_eventing_function" "av135212" {
      + bindings               = {
          + buckets = [
              + {
                  + alias      = "src"
                  + bucket     = "travel-sample"
                  + collection = (known after apply)
                  + permission = (known after apply)
                  + scope      = (known after apply)
                },
            ]
          + urls    = [
              + {
                  + alias                    = "api"
                  + allow_cookies            = (known after apply)
                  + authentication           = {
                      + type = "none"
                    }
                  + url                      = "https://example.com"
                  + validate_tls_certificate = (known after apply)
                },
            ]
        }
      + cluster_id             = "c00c420c-047e-427d-8d73-5494217f9291"
      + code                   = (sensitive value)
      + event_metadata_storage = {
          + bucket     = "travel-sample"
          + collection = "airport"
          + scope      = "inventory"
        }
      + event_source           = {
          + bucket     = "travel-sample"
          + collection = "airline"
          + scope      = "inventory"
        }
      + name                   = "tf_av135212_unknowns"
      + organization_id        = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
      + project_id             = "c09035e8-3971-4b79-a6ec-bccd9056041f"
      + settings               = (known after apply)
      + state                  = "undeployed"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + settings                 = (known after apply)
  + validate_tls_certificate = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_eventing_function.av135212: Creating...
couchbase-capella_eventing_function.av135212: Creation complete after 1s [name=tf_av135212_unknowns]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

settings = {
  "allow_sync_documents" = true
  "cursor_aware" = false
  "feed_boundary" = "from_now"
  "language_compatibility" = "7.2.0"
  "max_timer_context_size" = 1024
  "script_timeout" = 60
  "sql_consistency" = "none"
  "worker_count" = 1
}
validate_tls_certificate = true
```
 
</details>

## Further comments