### PR TITLE
[AV-132169] Reject empty private endpoint endpoint_id at plan time

### DIFF
--- a/acceptance_tests/private_endpoint_acceptance_test.go
+++ b/acceptance_tests/private_endpoint_acceptance_test.go
@@ -2,6 +2,7 @@ package acceptance_tests
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -78,4 +79,34 @@ data "couchbase-capella_private_endpoints" "%[3]s" {
   depends_on = [couchbase-capella_private_endpoint_service.%[2]s]
 }
 `, globalProviderBlock, serviceResourceName, dataSourceName, globalOrgId, globalProjectId, globalClusterId)
+}
+
+// TestAccPrivateEndpointsInvalidEndpointID verifies that the private endpoints resource rejects
+// an empty endpoint_id at plan time. The LengthAtLeast(1) validator fires before any API call,
+// so dummy org/project/cluster IDs are sufficient.
+func TestAccPrivateEndpointsInvalidEndpointID(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_private_endpoints_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPrivateEndpointsInvalidEndpointIDConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)endpoint_id.*string length must be at least 1`),
+			},
+		},
+	})
+}
+
+func testAccPrivateEndpointsInvalidEndpointIDConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_private_endpoints" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  cluster_id      = "22222222-2222-2222-2222-222222222222"
+  endpoint_id     = ""
+}
+`, globalProviderBlock, resourceName)
 }

--- a/internal/resources/private_endpoints_schema.go
+++ b/internal/resources/private_endpoints_schema.go
@@ -1,7 +1,9 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
@@ -14,7 +16,10 @@ func PrivateEndpointsSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", privateEndpointsBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "project_id", privateEndpointsBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "cluster_id", privateEndpointsBuilder, requiredUUIDStringAttribute())
-	capellaschema.AddAttr(attrs, "endpoint_id", privateEndpointsBuilder, stringAttribute([]string{required, requiresReplace}))
+	capellaschema.AddAttr(attrs, "endpoint_id", privateEndpointsBuilder, stringAttribute(
+		[]string{required, requiresReplace},
+		validator.String(stringvalidator.LengthAtLeast(1)),
+	))
 	capellaschema.AddAttr(attrs, "status", privateEndpointsBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "service_name", privateEndpointsBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "private_endpoint_dns", privateEndpointsBuilder, stringAttribute([]string{computed}), "GetPrivateEndpointsResponse")


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-132169

## Description

 ### Problem                                                                                                                                                                                    
  `couchbase-capella_private_endpoints.endpoint_id` accepted an empty string (`endpoint_id = ""`) during `terraform validate`. The empty value then flowed straight into the associate API URL (`.../endpoints//associate`).                                                                                                                                                                  
                                                                                                                                                                                                 
  ### Root cause                                                                                                                                                                                 
  `endpoint_id` was defined as a plain required string in `private_endpoints_schema.go`. `required` only ensures the attribute is present, not non-empty, and the resource's own `validate()` (`private_endpoints.go`) only checks `IsNull()` — so an empty string was rejected by neither. The OpenAPI spec exposes no `minLength` for `endpointId`, so the auto-attach constraint mechanism couldn't help.                                                                                                                                                                                 
                                                                                                                                                                                                 
  ### Fix                                                                                                                                                                                        
  Add an explicit `stringvalidator.LengthAtLeast(1)` to `endpoint_id`. Empty values are now rejected at plan time, before any API call. (A provider-specific format validator like `vpce-*` was intentionally avoided — endpoint IDs differ across AWS/Azure/GCP, so a pattern would wrongly reject valid IDs.) 

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
Acceptance tested against production Capella. TestMain provisioned a cluster, bucket, app service, and app endpoint, the plan-time validation test ran, and all fixtures were torn down (verified 0 leftover clusters).

```
=== RUN   TestAccPrivateEndpointsInvalidEndpointID
--- PASS: TestAccPrivateEndpointsInvalidEndpointID (1.51s)
PASS
ok  github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests  850.349s
```

Asserts that `endpoint_id = ""` is rejected at plan time (before any API call):
`Attribute endpoint_id string length must be at least 1, got: 0`
</details>

## Further comments
