### PR TITLE
[AV-135236] Validate RFC3339 Format for start_time in Snapshot Backup Schedule Resource

### DIFF
--- a/acceptance_tests/snapshot_backup_schedule_acceptance_test.go
+++ b/acceptance_tests/snapshot_backup_schedule_acceptance_test.go
@@ -122,7 +122,7 @@ func TestAccSnapshotBackupScheduleResourceInvalidStartTime(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccSnapshotBackupScheduleResourceConfigWithCopyToRegions(resourceName, 12, 240, "invalid_time", "[]"),
-				ExpectError: regexp.MustCompile("There is an error during snapshot backup schedule creation"),
+				ExpectError: regexp.MustCompile("A string value was provided that is not valid RFC3339 string format"),
 			},
 		},
 	})

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.25.0 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect
 	github.com/hashicorp/terraform-plugin-docs v0.25.0 // indirect
+	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.5 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/hashicorp/terraform-plugin-docs v0.25.0 h1:qHs1V257NxVe8tv6HS4UQfNqja
 github.com/hashicorp/terraform-plugin-docs v0.25.0/go.mod h1:MQggCmY8zgP7R7E/cC0b0cmTvA9hSj3ZKyrrsDjRbLo=
 github.com/hashicorp/terraform-plugin-framework v1.15.0 h1:LQ2rsOfmDLxcn5EeIwdXFtr03FVsNktbbBci8cOKdb4=
 github.com/hashicorp/terraform-plugin-framework v1.15.0/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0 h1:v3DapR8gsp3EM8fKMh6up9cJUFQ2iRaFsYLP8UJnCco=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0/go.mod h1:c3PnGE9pHBDfdEVG9t1S1C9ia5LW+gkFR0CygXlM8ak=
 github.com/hashicorp/terraform-plugin-framework-validators v0.18.0 h1:OQnlOt98ua//rCw+QhBbSqfW3QbwtVrcdWeQN5gI3Hw=
 github.com/hashicorp/terraform-plugin-framework-validators v0.18.0/go.mod h1:lZvZvagw5hsJwuY7mAY6KUz45/U6fiDR0CzQAwWD0CA=
 github.com/hashicorp/terraform-plugin-go v0.27.0 h1:ujykws/fWIdsi6oTUT5Or4ukvEan4aN9lY+LOxVP8EE=

--- a/internal/datasources/attributes.go
+++ b/internal/datasources/attributes.go
@@ -3,6 +3,7 @@ package datasources
 import (
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -41,6 +42,13 @@ func requiredUUIDString() *schema.StringAttribute {
 func computedString() *schema.StringAttribute {
 	return &schema.StringAttribute{
 		Computed: true,
+	}
+}
+
+func computedRFC3339() *schema.StringAttribute {
+	return &schema.StringAttribute{
+		Computed:   true,
+		CustomType: timetypes.RFC3339Type{},
 	}
 }
 

--- a/internal/datasources/snapshot_backup_schedule_schema.go
+++ b/internal/datasources/snapshot_backup_schedule_schema.go
@@ -15,7 +15,7 @@ func SnapshotBackupScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "cluster_id", snapshotBackupScheduleBuilder, requiredStringWithValidator())
 	capellaschema.AddAttr(attrs, "interval", snapshotBackupScheduleBuilder, computedInt64())
 	capellaschema.AddAttr(attrs, "retention", snapshotBackupScheduleBuilder, computedInt64())
-	capellaschema.AddAttr(attrs, "start_time", snapshotBackupScheduleBuilder, computedString())
+	capellaschema.AddAttr(attrs, "start_time", snapshotBackupScheduleBuilder, computedRFC3339())
 	capellaschema.AddAttr(attrs, "copy_to_regions", snapshotBackupScheduleBuilder, computedStringSet())
 	return schema.Schema{
 		MarkdownDescription: "The snapshot backups data source retrieves the snapshot backup schedule for a cluster.",

--- a/internal/resources/attributes.go
+++ b/internal/resources/attributes.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -98,6 +99,22 @@ func requiredNonEmptyStringAttribute() *schema.StringAttribute {
 		[]string{required, requiresReplace},
 		validator.String(stringvalidator.LengthAtLeast(1)),
 	)
+}
+
+// rfc3339Attribute is a variadic function which returns a string attribute with the requested fields set to true
+// if the string satisfies the rfc3339 format, otherwise an error is returned.
+func rfc3339Attribute(fields ...string) *schema.StringAttribute {
+	attribute := stringAttribute(fields)
+	attribute.CustomType = timetypes.RFC3339Type{}
+	return attribute
+}
+
+// rfc3339DefaultAttribute sets the default values for a string field that should satisfy the rfc3339 format
+// and returns the string attribute.
+func rfc3339DefaultAttribute(defaultValue string, fields ...string) *schema.StringAttribute {
+	attribute := rfc3339Attribute(fields...)
+	attribute.Default = stringdefault.StaticString(defaultValue)
+	return attribute
 }
 
 // boolAttribute is a variadic function which sets the requested fields

--- a/internal/resources/snapshot_backup_schedule.go
+++ b/internal/resources/snapshot_backup_schedule.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -362,40 +361,7 @@ func (s *SnapshotBackupSchedule) getSnapshotBackupSchedule(ctx context.Context, 
 		return nil, err
 	}
 
-	snapshotBackupSchedule.StartTime, err = s.getStartTime(ctx, startTimeString, &snapshotBackupSchedule)
-	if err != nil {
-		return nil, err
-	}
-
 	return &snapshotBackupSchedule, nil
-}
-
-// getStartTime compares the start time of the current state with the start time of the actual resource, and returns the resource's start time only if it is different.
-// This ensures that the resource storing an equivalent start time does not cause the state to be unnecessarily updated.
-func (s *SnapshotBackupSchedule) getStartTime(ctx context.Context, currentStartTimeString string, snapshotBackupSchedule *snapshot_backup_schedule.SnapshotBackupSchedule) (string, error) {
-	newStartTime, err := time.Parse(time.RFC3339, snapshotBackupSchedule.StartTime)
-	if err != nil {
-		tflog.Debug(ctx, "Error parsing updated start time", map[string]interface{}{
-			"snapshotBackupSchedule.StartTime": snapshotBackupSchedule.StartTime,
-			"err":                              err,
-		})
-		return "", err
-	}
-	if currentStartTimeString == "" {
-		return newStartTime.Format(time.RFC3339), nil
-	}
-	currentStartTime, err := time.Parse(time.RFC3339, currentStartTimeString)
-	if err != nil {
-		tflog.Debug(ctx, "Error parsing current start time", map[string]interface{}{
-			"currentStartTimeString": currentStartTimeString,
-			"err":                    err,
-		})
-		return "", err
-	}
-	if currentStartTime.Equal(newStartTime) {
-		return currentStartTimeString, nil
-	}
-	return newStartTime.Format(time.RFC3339), nil
 }
 
 func (s *SnapshotBackupSchedule) convertCopyToRegions(ctx context.Context, copyToRegionsSet types.Set) ([]string, error) {

--- a/internal/resources/snapshot_backup_schedule.go
+++ b/internal/resources/snapshot_backup_schedule.go
@@ -94,7 +94,7 @@ func (s *SnapshotBackupSchedule) Create(ctx context.Context, req resource.Create
 	}
 
 	var refreshedState *providerschema.SnapshotBackupSchedule
-	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan.StartTime.ValueString())
+	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId)
 	if err != nil {
 		tflog.Debug(ctx, "Error getting snapshot backup schedule after upsert", map[string]interface{}{
 			"organizationId": organizationId,
@@ -153,7 +153,7 @@ func (s *SnapshotBackupSchedule) Read(ctx context.Context, req resource.ReadRequ
 		clusterId      = IDs[providerschema.ClusterId]
 	)
 
-	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, state.StartTime.ValueString())
+	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Getting Snapshot Backup Schedule in Capella",
@@ -213,7 +213,7 @@ func (s *SnapshotBackupSchedule) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan.StartTime.ValueString())
+	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId)
 	if err != nil {
 		tflog.Debug(ctx, "Error getting snapshot backup schedule after upsert", map[string]interface{}{
 			"organizationId": organizationId,
@@ -330,7 +330,7 @@ func (s *SnapshotBackupSchedule) upsertSnapshotBackupSchedule(ctx context.Contex
 }
 
 // getSnapshotBackupSchedule retrieves the snapshot backup schedule for a cluster.
-func (s *SnapshotBackupSchedule) getSnapshotBackupSchedule(ctx context.Context, organizationId, projectId, clusterId string, startTimeString string) (*snapshot_backup_schedule.SnapshotBackupSchedule, error) {
+func (s *SnapshotBackupSchedule) getSnapshotBackupSchedule(ctx context.Context, organizationId, projectId, clusterId string) (*snapshot_backup_schedule.SnapshotBackupSchedule, error) {
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/cloudsnapshotbackupschedule", s.HostURL, organizationId, projectId, clusterId)
 	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
 	backupScheduleResp, err := s.ClientV1.ExecuteWithRetry(

--- a/internal/resources/snapshot_backup_schedule_schema.go
+++ b/internal/resources/snapshot_backup_schedule_schema.go
@@ -19,7 +19,7 @@ func SnapshotBackupScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "cluster_id", snapshotBackupScheduleBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "interval", snapshotBackupScheduleBuilder, int64Attribute(required))
 	capellaschema.AddAttr(attrs, "retention", snapshotBackupScheduleBuilder, int64Attribute(required))
-	capellaschema.AddAttr(attrs, "start_time", snapshotBackupScheduleBuilder, stringDefaultAttribute(time.Now().Truncate(time.Hour).Format(time.RFC3339), optional, computed))
+	capellaschema.AddAttr(attrs, "start_time", snapshotBackupScheduleBuilder, rfc3339DefaultAttribute(time.Now().Truncate(time.Hour).Format(time.RFC3339), optional, computed))
 	capellaschema.AddAttr(attrs, "copy_to_regions", snapshotBackupScheduleBuilder, stringSetAttribute(optional))
 
 	return schema.Schema{

--- a/internal/schema/snapshot_backup_schedule.go
+++ b/internal/schema/snapshot_backup_schedule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -13,13 +14,13 @@ import (
 )
 
 type SnapshotBackupSchedule struct {
-	OrganizationID types.String `tfsdk:"organization_id"`
-	ProjectID      types.String `tfsdk:"project_id"`
-	ClusterID      types.String `tfsdk:"cluster_id"`
-	Interval       types.Int64  `tfsdk:"interval"`
-	Retention      types.Int64  `tfsdk:"retention"`
-	StartTime      types.String `tfsdk:"start_time"`
-	CopyToRegions  types.Set    `tfsdk:"copy_to_regions"`
+	OrganizationID types.String      `tfsdk:"organization_id"`
+	ProjectID      types.String      `tfsdk:"project_id"`
+	ClusterID      types.String      `tfsdk:"cluster_id"`
+	Interval       types.Int64       `tfsdk:"interval"`
+	Retention      types.Int64       `tfsdk:"retention"`
+	StartTime      timetypes.RFC3339 `tfsdk:"start_time"`
+	CopyToRegions  types.Set         `tfsdk:"copy_to_regions"`
 }
 
 func (s SnapshotBackupSchedule) AttributeTypes() map[string]attr.Type {
@@ -29,12 +30,17 @@ func (s SnapshotBackupSchedule) AttributeTypes() map[string]attr.Type {
 		"cluster_id":      types.StringType,
 		"interval":        types.Int64Type,
 		"retention":       types.Int64Type,
-		"start_time":      types.StringType,
+		"start_time":      timetypes.RFC3339Type{},
 		"copy_to_regions": types.SetType{ElemType: types.StringType},
 	}
 }
 
 func NewSnapshotBackupSchedule(ctx context.Context, scheduleResp snapshot_backup_schedule.SnapshotBackupSchedule, organizationID, projectID, clusterID string) (*SnapshotBackupSchedule, error) {
+	startTime, diags := timetypes.NewRFC3339PointerValue(&scheduleResp.StartTime)
+	if diags.HasError() {
+		return nil, fmt.Errorf("error converting startTime: %s", diags.Errors())
+	}
+
 	copyToRegions, diags := types.SetValueFrom(ctx, types.StringType, scheduleResp.CopyToRegions)
 	if diags.HasError() {
 		return nil, fmt.Errorf("copyToRegions set error")
@@ -46,7 +52,7 @@ func NewSnapshotBackupSchedule(ctx context.Context, scheduleResp snapshot_backup
 		ClusterID:      types.StringValue(clusterID),
 		Interval:       types.Int64Value(scheduleResp.Interval),
 		Retention:      types.Int64Value(scheduleResp.Retention),
-		StartTime:      types.StringValue(scheduleResp.StartTime),
+		StartTime:      startTime,
 		CopyToRegions:  copyToRegions,
 	}
 	return &snapshotBackupSchedule, nil


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-135236

## Description

Ensures an error is returned when running `terraform plan`, if `start_time` for a Snapshot Backup Schedule resource is not in the RFC3339 format, as this would cause an API error, and `terraform apply` would fail.

Removes the `getStartTime` function, which ensured that a `start_time` that was returned from the API during a `Read`, which was an equivalent RFC3339 time but a different string to the one in the config file, did not trigger the snapshot backup schedule being upserted again. This is no longer necessary as using the custom type `timetypes.RFC3339Type` means that an `Update` won't be triggered in this situation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

**Resource**

*Incorrect Format*

Running `terraform plan` with

```
cloud_snapshot_backup_schedule = {
    interval = 12
    retention = 168
    start_time = "00:00:00Z"
}
```

returns the error 

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Invalid RFC3339 String Value
│ 
│   with couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule,
│   on create_snapshot_backup_schedule.tf line 12, in resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule":
│   12:   start_time = var.cloud_snapshot_backup_schedule.start_time
│ 
│ A string value was provided that is not valid RFC3339 string format.
│ 
│ Given Value: 00:00:00Z
│ Error: parsing time "00:00:00Z" as "2006-01-02T15:04:05Z07:00": cannot parse "00:00:00Z" as "2006"
╵
```

*Day Out of Range*
Running `terraform plan` with

```
cloud_snapshot_backup_schedule = {
    interval = 12
    retention = 168
    start_time = "2026-07-40T16:00:00+00:00"
}
```

returns the error 

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Invalid RFC3339 String Value
│ 
│   with couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule,
│   on create_snapshot_backup_schedule.tf line 12, in resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule":
│   12:   start_time = var.cloud_snapshot_backup_schedule.start_time
│ 
│ A string value was provided that is not valid RFC3339 string format.
│ 
│ Given Value: 2026-07-40T16:00:00+00:00
│ Error: parsing time "2026-07-40T16:00:00+00:00": day out of range
╵
```

*Valid*

Running `terraform plan` with

```
cloud_snapshot_backup_schedule = {
    interval = 12
    retention = 168
    start_time = "2026-07-24T16:00:00+00:00"
}
```

successfully creates the plan 

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be created
  + resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + interval        = 12
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-07-24T16:00:00+00:00"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + new_cloud_snapshot_backup_schedule = {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = null
      + interval        = 12
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-07-24T16:00:00+00:00"
    }
```

Running `terraform apply` successfully applies the plan.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be created
  + resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + interval        = 12
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-07-24T16:00:00+00:00"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + new_cloud_snapshot_backup_schedule = {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = null
      + interval        = 12
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-07-24T16:00:00+00:00"
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Creating...
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Creation complete after 0s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

new_cloud_snapshot_backup_schedule = {
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "copy_to_regions" = toset(null) /* of string */
  "interval" = 12
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "retention" = 168
  "start_time" = "2026-07-24T16:00:00+00:00"
}
```

<img width="1416" height="440" alt="Screenshot 2026-06-25 at 10 09 25" src="https://github.com/user-attachments/assets/ac83b1cb-fd3c-4057-8481-49db8a728f6d" />

*Removing getStartTime*

When `start_time` is just a standard `StringAttribute`, subsequently running `terraform plan` creates the following plan

```
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule will be updated in-place
  ~ resource "couchbase-capella_cloud_snapshot_backup_schedule" "new_cloud_snapshot_backup_schedule" {
      ~ start_time      = "2026-07-24T16:00:00Z" -> "2026-07-24T16:00:00+00:00"
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

where it will attempt to change the `start_time` from "2026-07-24T16:00:00Z", which is returned by the API, to "2026-07-24T16:00:00+00:00", which is in the config file. This is despite this times being equivalent in the RFC3339 format.

When `start_time` is the custom type `timetypes.RFC3339Type`, subsequently running `terraform plan` creates the following plan

```
couchbase-capella_cloud_snapshot_backup_schedule.new_cloud_snapshot_backup_schedule: Refreshing state...

No changes. Your infrastructure matches the configuration.
```

which recognises that the times are equivalent.

**Data Source**

Running `terraform plan` creates the plan

```
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Reading...
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Read complete after 0s

Changes to Outputs:
  + existing_cloud_snapshot_backup_schedule = {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = null
      + interval        = 12
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-07-24T16:00:00Z"
    }
```

Running `terraform apply` successfully applies the plan

```
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Reading...
data.couchbase-capella_cloud_snapshot_backup_schedule.existing_cloud_snapshot_backup_schedule: Read complete after 0s

Changes to Outputs:
  + existing_cloud_snapshot_backup_schedule = {
      + cluster_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + copy_to_regions = null
      + interval        = 12
      + organization_id = "ffffffff-aaaa-1414-eeee-000000000000"
      + project_id      = "ffffffff-aaaa-1414-eeee-000000000000"
      + retention       = 168
      + start_time      = "2026-07-24T16:00:00Z"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes


Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

existing_cloud_snapshot_backup_schedule = {
  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "copy_to_regions" = toset(null) /* of string */
  "interval" = 12
  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
  "retention" = 168
  "start_time" = "2026-07-24T16:00:00Z"
}
```

</details>

## Further comments