### PR TITLE
[AV-131920] Refactor network peer schema to enhance provider configuration attributes

### DIFF
--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -34,8 +34,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@e3d1f5e7861c36fe4a9c4dca3edec87b964b2bc4 #v5.0.0
+        uses: Factory-AI/droid-action@v3
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           allowed_bots: "factory-droid[bot]"
-          review_model: gpt-5.3-codex

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -34,7 +34,8 @@ jobs:
           fetch-depth: 1
 
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@v3
+        uses: Factory-AI/droid-action@e3d1f5e7861c36fe4a9c4dca3edec87b964b2bc4 #v5.0.0
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           allowed_bots: "factory-droid[bot]"
+          review_model: gpt-5.3-codex

--- a/internal/datasources/network_peer_schema.go
+++ b/internal/datasources/network_peer_schema.go
@@ -15,28 +15,49 @@ func NetworkPeerSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "project_id", networkPeerBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "cluster_id", networkPeerBuilder, requiredString())
 
-	commandAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(commandAttrs, "command", networkPeerBuilder, computedString())
+	awsConfigAttrs := make(map[string]schema.Attribute)
+	capellaschema.AddAttr(awsConfigAttrs, "account_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(awsConfigAttrs, "vpc_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(awsConfigAttrs, "region", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(awsConfigAttrs, "cidr", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(awsConfigAttrs, "provider_id", networkPeerBuilder, computedString())
 
-	commandsAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(commandsAttrs, "aws", networkPeerBuilder, &schema.SingleNestedAttribute{
+	gcpConfigAttrs := make(map[string]schema.Attribute)
+	capellaschema.AddAttr(gcpConfigAttrs, "cidr", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(gcpConfigAttrs, "network_name", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(gcpConfigAttrs, "project_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(gcpConfigAttrs, "service_account", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(gcpConfigAttrs, "provider_id", networkPeerBuilder, computedString())
+
+	azureConfigAttrs := make(map[string]schema.Attribute)
+	capellaschema.AddAttr(azureConfigAttrs, "tenant_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(azureConfigAttrs, "cidr", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(azureConfigAttrs, "resource_group", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(azureConfigAttrs, "subscription_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(azureConfigAttrs, "vnet_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(azureConfigAttrs, "provider_id", networkPeerBuilder, computedString())
+
+	providerConfigAttrs := make(map[string]schema.Attribute)
+	capellaschema.AddAttr(providerConfigAttrs, "aws_config", networkPeerBuilder, &schema.SingleNestedAttribute{
 		Computed:   true,
-		Attributes: commandAttrs,
+		Attributes: awsConfigAttrs,
 	})
-	capellaschema.AddAttr(commandsAttrs, "gcp", networkPeerBuilder, &schema.SingleNestedAttribute{
+	capellaschema.AddAttr(providerConfigAttrs, "gcp_config", networkPeerBuilder, &schema.SingleNestedAttribute{
 		Computed:   true,
-		Attributes: commandAttrs,
+		Attributes: gcpConfigAttrs,
 	})
-	capellaschema.AddAttr(commandsAttrs, "azure", networkPeerBuilder, &schema.SingleNestedAttribute{
+	capellaschema.AddAttr(providerConfigAttrs, "azure_config", networkPeerBuilder, &schema.SingleNestedAttribute{
 		Computed:   true,
-		Attributes: commandAttrs,
+		Attributes: azureConfigAttrs,
 	})
 
 	dataAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(dataAttrs, "id", networkPeerBuilder, computedString())
 	capellaschema.AddAttr(dataAttrs, "name", networkPeerBuilder, computedString())
-	capellaschema.AddAttr(dataAttrs, "provider_type", networkPeerBuilder, computedString())
-	capellaschema.AddAttr(dataAttrs, "provider_config", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(dataAttrs, "provider_config", networkPeerBuilder, &schema.SingleNestedAttribute{
+		Computed:   true,
+		Attributes: providerConfigAttrs,
+	})
 	capellaschema.AddAttr(dataAttrs, "audit", networkPeerBuilder, computedAudit())
 	capellaschema.AddAttr(dataAttrs, "status", networkPeerBuilder, &schema.SingleNestedAttribute{
 		Computed: true,
@@ -44,10 +65,6 @@ func NetworkPeerSchema() schema.Schema {
 			"state":     schema.StringAttribute{Computed: true},
 			"reasoning": schema.StringAttribute{Computed: true},
 		},
-	})
-	capellaschema.AddAttr(dataAttrs, "commands", networkPeerBuilder, &schema.SingleNestedAttribute{
-		Computed:   true,
-		Attributes: commandsAttrs,
 	})
 
 	capellaschema.AddAttr(attrs, "data", networkPeerBuilder, &schema.ListNestedAttribute{


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-131920

## Description

The `couchbase-capella_network_peers` data source failed at read time with a `Value Conversion Error`:
> Mismatch between struct and object type: Object defines fields not found in struct: `commands` and `provider_type`. Struct: `schema.NetworkPeerData`

The data source schema declared `provider_type` (string), `commands` (nested aws/gcp/azure), and a string `provider_config`, but the backing `schema.NetworkPeerData` struct only defines `id`, `name`, `provider_config`
(a structured `ProviderConfig`), `status`, and `audit`. Terraform could not convert the struct into the declared object type, so every read of the data source failed.

This is not a regression from AV-129893 — it is a pre-existing schema/model mismatch reproducible on `main`.

This PR aligns the data source schema with the struct:
- Removes the non-existent `provider_type` and `commands` attributes.
- Replaces the string `provider_config` with a nested object exposing `aws_config`, `gcp_config`, and `azure_config` (account/vpc/region/cidr/provider_id, etc.), matching the `ProviderConfig` model.
- Updates `examples/network_peer/` to reflect the corrected data source output shape.

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing


<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 2 53 20 PM" src="https://github.com/user-attachments/assets/dd30e816-bcd4-41a5-82fe-fcd22ea683f1" />

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 2 52 55 PM" src="https://github.com/user-attachments/assets/4a244a74-1a0e-40b3-8952-7d2fd02295c8" />
</details>

## Further comments