### PR TITLE
[AV-135219] Add validation for eventing function URL bindings auth

### DIFF
--- a/internal/resources/eventing_function.go
+++ b/internal/resources/eventing_function.go
@@ -24,9 +24,10 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = (*EventingFunction)(nil)
-	_ resource.ResourceWithConfigure   = (*EventingFunction)(nil)
-	_ resource.ResourceWithImportState = (*EventingFunction)(nil)
+	_ resource.Resource                   = (*EventingFunction)(nil)
+	_ resource.ResourceWithConfigure      = (*EventingFunction)(nil)
+	_ resource.ResourceWithImportState    = (*EventingFunction)(nil)
+	_ resource.ResourceWithValidateConfig = (*EventingFunction)(nil)
 )
 
 // EventingFunction is the eventing function resource implementation.
@@ -47,6 +48,89 @@ func (e *EventingFunction) Metadata(_ context.Context, req resource.MetadataRequ
 // Schema defines the schema for the eventing function resource.
 func (e *EventingFunction) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = EventingFunctionSchema()
+}
+
+// ValidateConfig is used to reject URL binding authentication blocks whose credential fields do not match the
+// chosen type. For example, a "basic" type must set username and password but not a bearer token, etc.
+func (e *EventingFunction) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config providerschema.EventingFunctionResource
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() || config.Bindings == nil {
+		return
+	}
+
+	for i := range config.Bindings.Urls {
+		auth := config.Bindings.Urls[i].Authentication
+		if auth == nil || auth.Type.IsNull() || auth.Type.IsUnknown() {
+			continue
+		}
+
+		authPath := path.Root("bindings").AtName("urls").AtListIndex(i).AtName("authentication")
+		validateURLBindingAuth(*auth, authPath, resp)
+	}
+}
+
+// validateURLBindingAuth checks a single URL binding authentication block against the credential
+// requirements of its type and records an attribute error for any mismatch.
+func validateURLBindingAuth(auth providerschema.EventingFunctionURLBindingAuthentication, authPath path.Path, resp *resource.ValidateConfigResponse) {
+	const summary = "Invalid URL Binding Authentication"
+
+	authType := auth.Type.ValueString()
+	switch authType {
+	case eventingURLAuthNone:
+		if credentialSet(auth.Username) || credentialSet(auth.Password) || credentialSet(auth.BearerToken) {
+			resp.Diagnostics.AddAttributeError(
+				authPath,
+				summary,
+				fmt.Sprintf("Authentication type %q must not set username, password or bearer_token.", authType),
+			)
+		}
+	case eventingURLAuthBasic, eventingURLAuthDigest:
+		if !credentialSet(auth.Username) || !credentialSet(auth.Password) {
+			resp.Diagnostics.AddAttributeError(
+				authPath,
+				summary,
+				fmt.Sprintf("Authentication type %q requires username and password.", authType),
+			)
+		}
+		if credentialSet(auth.BearerToken) {
+			resp.Diagnostics.AddAttributeError(
+				authPath.AtName("bearer_token"),
+				summary,
+				fmt.Sprintf("Authentication type %q must not set bearer_token.", authType),
+			)
+		}
+	case eventingURLAuthBearer:
+		if !credentialSet(auth.BearerToken) {
+			resp.Diagnostics.AddAttributeError(
+				authPath.AtName("bearer_token"),
+				summary,
+				fmt.Sprintf("Authentication type %q requires bearer_token.", authType),
+			)
+		}
+		if credentialSet(auth.Username) || credentialSet(auth.Password) {
+			resp.Diagnostics.AddAttributeError(
+				authPath,
+				summary,
+				fmt.Sprintf("Authentication type %q must not set username or password.", authType),
+			)
+		}
+	}
+}
+
+// credentialSet reports whether a URL binding authentication credential is configured
+func credentialSet(v types.String) bool {
+	// Null counts as unset
+	if v.IsNull() {
+		return false
+	}
+
+	// Unknown counts as set because it resolves to a concrete value at apply time
+	if v.IsUnknown() {
+		return true
+	}
+
+	return v.ValueString() != ""
 }
 
 // Create creates a new eventing function. The function is created in the undeployed state; if the

--- a/internal/resources/eventing_function_schema.go
+++ b/internal/resources/eventing_function_schema.go
@@ -18,6 +18,15 @@ const (
 	eventingStateResumed    = "resumed"
 )
 
+// URL binding authentication types accepted by the eventing API. Each type selects which credential
+// fields of a URL binding authentication block must be set and which must be absent.
+const (
+	eventingURLAuthNone   = "none"
+	eventingURLAuthBasic  = "basic"
+	eventingURLAuthBearer = "bearer"
+	eventingURLAuthDigest = "digest"
+)
+
 var eventingFunctionBuilder = capellaschema.NewSchemaBuilder("eventingFunction")
 
 // EventingFunctionSchema defines the schema for the eventing function resource.
@@ -123,7 +132,16 @@ func bindingsAttributes() map[string]schema.Attribute {
 
 	authAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(authAttrs, "type", eventingFunctionBuilder, stringAttribute(
-		[]string{required}, validator.String(stringvalidator.OneOf("none", "basic", "bearer", "digest"))))
+		[]string{required},
+		validator.String(
+			stringvalidator.OneOf(
+				eventingURLAuthNone,
+				eventingURLAuthBasic,
+				eventingURLAuthBearer,
+				eventingURLAuthDigest,
+			),
+		),
+	))
 	capellaschema.AddAttr(authAttrs, "username", eventingFunctionBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(authAttrs, "password", eventingFunctionBuilder, stringAttribute([]string{optional, sensitive}))
 	capellaschema.AddAttr(authAttrs, "bearer_token", eventingFunctionBuilder, stringAttribute([]string{optional, sensitive}))

--- a/internal/resources/eventing_function_test.go
+++ b/internal/resources/eventing_function_test.go
@@ -1,0 +1,195 @@
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+func Test_validateURLBindingAuth(t *testing.T) {
+	authPath := path.Root("bindings").AtName("urls").AtListIndex(0).AtName("authentication")
+
+	tests := []struct {
+		name           string
+		auth           providerschema.EventingFunctionURLBindingAuthentication
+		wantErrorCount int
+		wantSubstr     string
+	}{
+		{
+			name: "none with no credentials is valid",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthNone),
+				Username:    types.StringNull(),
+				Password:    types.StringNull(),
+				BearerToken: types.StringNull(),
+			},
+		},
+		{
+			name: "none with a username is rejected",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthNone),
+				Username:    types.StringValue("user"),
+				Password:    types.StringNull(),
+				BearerToken: types.StringNull(),
+			},
+			wantErrorCount: 1,
+			wantSubstr:     "must not set username, password or bearer_token",
+		},
+		{
+			name: "none with an unknown bearer token is rejected",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthNone),
+				Username:    types.StringNull(),
+				Password:    types.StringNull(),
+				BearerToken: types.StringUnknown(),
+			},
+			wantErrorCount: 1,
+		},
+		{
+			name: "basic with username and password is valid",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthBasic),
+				Username:    types.StringValue("user"),
+				Password:    types.StringValue("pass"),
+				BearerToken: types.StringNull(),
+			},
+		},
+		{
+			name: "basic with username but no password is rejected",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthBasic),
+				Username:    types.StringValue("userOnly"),
+				Password:    types.StringNull(),
+				BearerToken: types.StringNull(),
+			},
+			wantErrorCount: 1,
+			wantSubstr:     `type "basic" requires username and password`,
+		},
+		{
+			name: "basic with an empty password is rejected",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthBasic),
+				Username:    types.StringValue("user"),
+				Password:    types.StringValue(""),
+				BearerToken: types.StringNull(),
+			},
+			wantErrorCount: 1,
+		},
+		{
+			name: "basic with an unknown password defers validation",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthBasic),
+				Username:    types.StringValue("user"),
+				Password:    types.StringUnknown(),
+				BearerToken: types.StringNull(),
+			},
+		},
+		{
+			name: "basic with a bearer token is rejected",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthBasic),
+				Username:    types.StringValue("user"),
+				Password:    types.StringValue("pass"),
+				BearerToken: types.StringValue("token"),
+			},
+			wantErrorCount: 1,
+			wantSubstr:     `type "basic" must not set bearer_token`,
+		},
+		{
+			name: "basic missing password and setting a bearer token yields two errors",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthBasic),
+				Username:    types.StringValue("user"),
+				Password:    types.StringNull(),
+				BearerToken: types.StringValue("token"),
+			},
+			wantErrorCount: 2,
+		},
+		{
+			name: "digest with username and password is valid",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthDigest),
+				Username:    types.StringValue("user"),
+				Password:    types.StringValue("pass"),
+				BearerToken: types.StringNull(),
+			},
+		},
+		{
+			name: "digest with no password is rejected",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthDigest),
+				Username:    types.StringValue("user"),
+				Password:    types.StringNull(),
+				BearerToken: types.StringNull(),
+			},
+			wantErrorCount: 1,
+			wantSubstr:     `type "digest" requires username and password`,
+		},
+		{
+			name: "bearer with a token is valid",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthBearer),
+				Username:    types.StringNull(),
+				Password:    types.StringNull(),
+				BearerToken: types.StringValue("token"),
+			},
+		},
+		{
+			name: "bearer with no token is rejected",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthBearer),
+				Username:    types.StringNull(),
+				Password:    types.StringNull(),
+				BearerToken: types.StringNull(),
+			},
+			wantErrorCount: 1,
+			wantSubstr:     `type "bearer" requires bearer_token`,
+		},
+		{
+			name: "bearer with a username is rejected",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthBearer),
+				Username:    types.StringValue("user"),
+				Password:    types.StringNull(),
+				BearerToken: types.StringValue("token"),
+			},
+			wantErrorCount: 1,
+			wantSubstr:     `type "bearer" must not set username or password`,
+		},
+		{
+			name: "bearer missing token and setting a username yields two errors",
+			auth: providerschema.EventingFunctionURLBindingAuthentication{
+				Type:        types.StringValue(eventingURLAuthBearer),
+				Username:    types.StringValue("user"),
+				Password:    types.StringNull(),
+				BearerToken: types.StringNull(),
+			},
+			wantErrorCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &resource.ValidateConfigResponse{}
+			validateURLBindingAuth(tt.auth, authPath, resp)
+
+			assert.Len(t, resp.Diagnostics, tt.wantErrorCount)
+			if tt.wantSubstr != "" {
+				var matched bool
+				for _, d := range resp.Diagnostics {
+					if strings.Contains(d.Detail(), tt.wantSubstr) {
+						matched = true
+						break
+					}
+				}
+				assert.Truef(t, matched, "expected a diagnostic containing %q, got %v", tt.wantSubstr, resp.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-135219

## Description

- Add enum validation for eventing function URL bindings authentication block
- Make sure the correct fields are provided for the authentication block based on the `type`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

Initial TF success

```
resource "couchbase-capella_eventing_function" "validate_test" {
  organization_id = var.org_id
  project_id      = local.project_id
  cluster_id      = local.cluster_id

  name  = "tf_validate_test"
  code  = "function OnUpdate(doc, meta) {}"
  state = "undeployed"

  event_source = {
    bucket     = "travel-sample"
    scope      = "_default"
    collection = "_default"
  }

  event_metadata_storage = {
    bucket     = "travel-sample"
    scope      = "inventory"
    collection = "airline"
  }

  bindings = {
    urls = [
      {
        alias = "myEndpoint"
        url   = "https://example.com"

        authentication = {
          type     = "basic"
          username = "user"
          password = "pass"
        }
      }
    ]
  }
}
```

Remove username line and TF apply

```
        authentication = {
          type     = "basic"
          # username = "user"
          password = "pass"
        }

│ Error: Invalid URL Binding Authentication
│
│   with couchbase-capella_eventing_function.validate_test,
│   on terraform.tf line 28, in resource "couchbase-capella_eventing_function" "validate_test":
│   28: resource "couchbase-capella_eventing_function" "validate_test" {
│
│ Authentication type "basic" requires username and password.
```

Type bearer and try to set password, and not token
```
        authentication = {
          type     = "bearer"
          username = "user"
          # password = "pass"
        }

│ Error: Invalid URL Binding Authentication
│
│   with couchbase-capella_eventing_function.validate_test,
│   on terraform.tf line 28, in resource "couchbase-capella_eventing_function" "validate_test":
│   28: resource "couchbase-capella_eventing_function" "validate_test" {
│
│ Authentication type "bearer" requires bearer_token.
╵
╷
│ Error: Invalid URL Binding Authentication
│
│   with couchbase-capella_eventing_function.validate_test,
│   on terraform.tf line 28, in resource "couchbase-capella_eventing_function" "validate_test":
│   28: resource "couchbase-capella_eventing_function" "validate_test" {
│
│ Authentication type "bearer" must not set username or password.
╵
```

and more


</details>

## Further comments