### PR TITLE
[AV-135369] Allow App Service to be deployed with a specific version

### DIFF
--- a/acceptance_tests/appservice_acceptance_test.go
+++ b/acceptance_tests/appservice_acceptance_test.go
@@ -47,11 +47,12 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 	appServiceName := randomStringWithPrefix("tf_acc_app_svc_")
 	description := "terraform app service optional fields acceptance test"
 
+	const version = "4.0"
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, 2, 2, 4),
+				Config: testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, version, 2, 2, 4),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
@@ -61,10 +62,10 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.cpu", "2"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.ram", "4"),
+					resource.TestCheckResourceAttr(resourceReference, "version", version),
 					resource.TestCheckResourceAttrSet(resourceReference, "id"),
 					resource.TestCheckResourceAttrSet(resourceReference, "cluster_id"),
 					resource.TestCheckResourceAttrSet(resourceReference, "current_state"),
-					resource.TestCheckResourceAttrSet(resourceReference, "version"),
 					resource.TestCheckResourceAttrSet(resourceReference, "etag"),
 					resource.TestCheckResourceAttrSet(resourceReference, "audit.created_at"),
 					resource.TestCheckResourceAttrSet(resourceReference, "audit.modified_at"),
@@ -78,7 +79,7 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, 3, 4, 8),
+				Config: testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, version, 3, 4, 8),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
@@ -88,15 +89,20 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.ram", "8"),
+					resource.TestCheckResourceAttr(resourceReference, "version", version),
 					resource.TestCheckResourceAttrSet(resourceReference, "id"),
 					resource.TestCheckResourceAttrSet(resourceReference, "cluster_id"),
 					resource.TestCheckResourceAttrSet(resourceReference, "current_state"),
-					resource.TestCheckResourceAttrSet(resourceReference, "version"),
 					resource.TestCheckResourceAttrSet(resourceReference, "etag"),
 					resource.TestCheckResourceAttrSet(resourceReference, "audit.created_at"),
 					resource.TestCheckResourceAttrSet(resourceReference, "audit.modified_at"),
 					resource.TestCheckResourceAttrSet(resourceReference, "audit.version"),
 				),
+			},
+			{
+				// Changing the major.minor version is not supported and must be rejected at apply time.
+				Config:      testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, "1.0", 3, 4, 8),
+				ExpectError: regexp.MustCompile(`(?s)version as this is not supported`),
 			},
 		},
 	})
@@ -207,7 +213,7 @@ resource "couchbase-capella_app_service" "%[4]s" {
 `, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, cidr)
 }
 
-func testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description string, nodes, cpu, ram int) string {
+func testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, version string, nodes, cpu, ram int) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -252,13 +258,14 @@ resource "couchbase-capella_app_service" "%[4]s" {
 	cluster_id      = couchbase-capella_cluster.%[5]s.id
 	name            = "%[7]s"
 	description     = "%[8]s"
+	version         = "%[12]s"
 	nodes           = %[9]d
 	compute = {
 		cpu = %[10]d
 		ram = %[11]d
 	}
 }
-`, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, cidr, appServiceName, description, nodes, cpu, ram)
+`, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, cidr, appServiceName, description, nodes, cpu, ram, version)
 }
 
 func testAccAppServiceResourceNameTooLongConfig(resourceName string) string {

--- a/examples/resources/couchbase-capella_app_service/resource.tf
+++ b/examples/resources/couchbase-capella_app_service/resource.tf
@@ -4,6 +4,7 @@ resource "couchbase-capella_app_service" "new_app_service" {
   cluster_id      = "<cluster_id>"
   name            = "MyAppSyncService"
   description     = "My app sync service."
+  version         = "4.0"
   nodes           = 2
   compute = {
     cpu = 2

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -257,7 +257,7 @@ func (a *AppService) Update(ctx context.Context, req resource.UpdateRequest, res
 		return
 	}
 
-	if !plan.Version.Equal(state.Version) {
+	if !plan.Version.IsNull() && !plan.Version.IsUnknown() && !plan.Version.Equal(state.Version) {
 		resp.Diagnostics.AddError(
 			"Error updating app service",
 			"Could not update app service ID "+state.Id.String()+" version as this is not supported. "+

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -5,13 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/appservice"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
-
-	"time"
-
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -255,6 +253,17 @@ func (a *AppService) Update(ctx context.Context, req resource.UpdateRequest, res
 		resp.Diagnostics.AddError(
 			"Error updating app service",
 			"Could not update app service id "+state.Id.String()+" unexpected error: "+errors.ErrUnableToUpdateAppServiceName.Error(),
+		)
+		return
+	}
+
+	if !plan.Version.Equal(state.Version) {
+		resp.Diagnostics.AddError(
+			"Error updating app service",
+			"Could not update app service ID "+state.Id.String()+" version as this is not supported. "+
+				"To fix, destroy the App Service and create a new one with the desired version, "+
+				"update the version in the plan to the current version ("+state.Version.ValueString()+"), "+
+				"or omit version from the plan completely.",
 		)
 		return
 	}

--- a/internal/resources/appservice_schema.go
+++ b/internal/resources/appservice_schema.go
@@ -27,7 +27,7 @@ func AppServiceSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "nodes", appServiceBuilder, int64Attribute(optional, computed))
 	capellaschema.AddAttr(attrs, "cloud_provider", appServiceBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "current_state", appServiceBuilder, stringAttribute([]string{computed}))
-	capellaschema.AddAttr(attrs, "version", appServiceBuilder, stringAttribute([]string{computed}))
+	capellaschema.AddAttr(attrs, "version", appServiceBuilder, stringAttribute([]string{optional, computed}))
 	capellaschema.AddAttr(attrs, "audit", appServiceBuilder, computedAuditAttribute())
 	capellaschema.AddAttr(attrs, "if_match", appServiceBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(attrs, "etag", appServiceBuilder, stringAttribute([]string{computed}))

--- a/internal/schema/appservice.go
+++ b/internal/schema/appservice.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 
@@ -97,11 +98,20 @@ func NewAppService(
 		},
 		ClusterId:    types.StringValue(appService.ClusterId),
 		CurrentState: types.StringValue(string(appService.CurrentState)),
-		Version:      types.StringValue(appService.Version),
+		Version:      types.StringValue(truncateToMajorMinor(appService.Version)),
 		Audit:        auditObject,
 		Etag:         types.StringValue(appService.Etag),
 	}
 	return &newAppService
+}
+
+// truncateToMajorMinor reduces a fully-expanded app service version such as "4.0.5-1.0.0" to its major.minor form ("4.0")
+func truncateToMajorMinor(version string) string {
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) < 2 {
+		return version
+	}
+	return parts[0] + "." + parts[1]
 }
 
 // Validate is used to verify that IDs have been properly imported.


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-135369

## Description

- Allow an App Service to be deployed with a specific version
- Do not allow App Service version to be modified once deployed (reject instead of requires replace to prevent accidental downgrading)
- Only show major.minor version in the `version` field to prevent state inconsistancies

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
Deploy 3.3

```
resource "couchbase-capella_app_service" "new_app_service" {
  organization_id = var.org_id
  project_id      = local.project_id
  cluster_id      = "4eb62ff4-962e-4007-9385-e53a23a2d272"
  name            = "tf-app-service-33"
  description     = "App service deployed on version 3.3"
  nodes           = 1
  version         = "3.3"
  compute = {
    cpu = 2
    ram = 4
  }
}
```

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # couchbase-capella_app_service.new_app_service will be created
  + resource "couchbase-capella_app_service" "new_app_service" {
      + audit           = (known after apply)
      + cloud_provider  = (known after apply)
      + cluster_id      = "4eb62ff4-962e-4007-9385-e53a23a2d272"
      + compute         = {
          + cpu = 2
          + ram = 4
        }
      + current_state   = (known after apply)
      + description     = "App service deployed on version 3.3"
      + etag            = (known after apply)
      + id              = (known after apply)
      + name            = "tf-app-service-33"
      + nodes           = 1
      + organization_id = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
      + project_id      = "c09035e8-3971-4b79-a6ec-bccd9056041f"
      + version         = "3.3"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Update to 4.0

```
...
  version         = "4.0"
...
```

Errors as expected

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # couchbase-capella_app_service.new_app_service will be updated in-place
  ~ resource "couchbase-capella_app_service" "new_app_service" {
      ~ audit           = {
          ~ created_at  = "2026-06-26 16:56:09.832173167 +0000 UTC" -> (known after apply)
          ~ created_by  = "B9bj6JJAwdVyPG7AaP2DKJH0X3bbZiek" -> (known after apply)
          ~ modified_at = "2026-06-26 17:01:02.375765802 +0000 UTC" -> (known after apply)
          ~ modified_by = "apikey-B9bj6JJAwdVyPG7AaP2DKJH0X3bbZiek" -> (known after apply)
          ~ version     = 7 -> (known after apply)
        } -> (known after apply)
      ~ cloud_provider  = "AWS" -> (known after apply)
      ~ current_state   = "healthy" -> (known after apply)
      ~ etag            = "Version: 7" -> (known after apply)
        id              = "fce09e7b-fd57-40c0-a206-621793763ebc"
        name            = "tf-app-service-33"
      ~ version         = "3.3" -> "4.0"
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_app_service.new_app_service: Modifying... [id=fce09e7b-fd57-40c0-a206-621793763ebc]
╷
│ Error: Error updating app service
│
│   with couchbase-capella_app_service.new_app_service,
│   on terraform.tf line 109, in resource "couchbase-capella_app_service" "new_app_service":
│  109: resource "couchbase-capella_app_service" "new_app_service" {
│
│ Could not update app service ID "fce09e7b-fd57-40c0-a206-621793763ebc" version as this is not supported. To fix, destroy the App Service and create a new one with the desired version, update the
│ version in the plan to the current version (3.3), or omit version from the plan completely.
╵
```

Omit version from update now and make sure no changes

```
resource "couchbase-capella_app_service" "new_app_service" {
  organization_id = var.org_id
  project_id      = local.project_id
  cluster_id      = "4eb62ff4-962e-4007-9385-e53a23a2d272"
  name            = "tf-app-service-33"
  description     = "App service deployed on version 3.3"
  nodes           = 1
  
  compute = {
    cpu = 2
    ram = 4
  }
}

$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - couchbasecloud/couchbase-capella in /Users/isaaclambat/dev/terraform/providers
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
couchbase-capella_app_service.new_app_service: Refreshing state... [id=fce09e7b-fd57-40c0-a206-621793763ebc]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```


</details>

## Further comments