### PR TITLE
[AV-131920] Update network peer documentation to reflect changes in provider configuration attributes

### DIFF
--- a/docs/data-sources/network_peers.md
+++ b/docs/data-sources/network_peers.md
@@ -39,11 +39,9 @@ data "couchbase-capella_network_peers" "existing_network_peers" {
 Read-Only:
 
 - `audit` (Attributes) Couchbase audit data. (see [below for nested schema](#nestedatt--data--audit))
-- `commands` (Attributes) (see [below for nested schema](#nestedatt--data--commands))
 - `id` (String)
 - `name` (String)
-- `provider_config` (String)
-- `provider_type` (String) Type of provider to filter on. By default all providers are returned.
+- `provider_config` (Attributes) (see [below for nested schema](#nestedatt--data--provider_config))
 - `status` (Attributes) (see [below for nested schema](#nestedatt--data--status))
 
 <a id="nestedatt--data--audit"></a>
@@ -60,37 +58,50 @@ Read-Only:
 - `version` (Number) - The version of the document. This value is incremented each time the resource is modified.
 
 
-<a id="nestedatt--data--commands"></a>
-### Nested Schema for `data.commands`
+<a id="nestedatt--data--provider_config"></a>
+### Nested Schema for `data.provider_config`
 
 Read-Only:
 
-- `aws` (Attributes) (see [below for nested schema](#nestedatt--data--commands--aws))
-- `azure` (Attributes) (see [below for nested schema](#nestedatt--data--commands--azure))
-- `gcp` (Attributes) (see [below for nested schema](#nestedatt--data--commands--gcp))
+- `aws_config` (Attributes) (see [below for nested schema](#nestedatt--data--provider_config--aws_config))
+- `azure_config` (Attributes) (see [below for nested schema](#nestedatt--data--provider_config--azure_config))
+- `gcp_config` (Attributes) (see [below for nested schema](#nestedatt--data--provider_config--gcp_config))
 
-<a id="nestedatt--data--commands--aws"></a>
-### Nested Schema for `data.commands.aws`
-
-Read-Only:
-
-- `command` (String)
-
-
-<a id="nestedatt--data--commands--azure"></a>
-### Nested Schema for `data.commands.azure`
+<a id="nestedatt--data--provider_config--aws_config"></a>
+### Nested Schema for `data.provider_config.aws_config`
 
 Read-Only:
 
-- `command` (String)
+- `account_id` (String)
+- `cidr` (String)
+- `provider_id` (String) The unique identifier of the provider.
+- `region` (String)
+- `vpc_id` (String)
 
 
-<a id="nestedatt--data--commands--gcp"></a>
-### Nested Schema for `data.commands.gcp`
+<a id="nestedatt--data--provider_config--azure_config"></a>
+### Nested Schema for `data.provider_config.azure_config`
 
 Read-Only:
 
-- `command` (String)
+- `cidr` (String)
+- `provider_id` (String) The unique identifier of the provider.
+- `resource_group` (String)
+- `subscription_id` (String)
+- `tenant_id` (String)
+- `vnet_id` (String)
+
+
+<a id="nestedatt--data--provider_config--gcp_config"></a>
+### Nested Schema for `data.provider_config.gcp_config`
+
+Read-Only:
+
+- `cidr` (String)
+- `network_name` (String)
+- `project_id` (String) The GUID4 ID of the project.
+- `provider_id` (String) The unique identifier of the provider.
+- `service_account` (String)
 
 
 

--- a/examples/network_peer/README.md
+++ b/examples/network_peer/README.md
@@ -485,9 +485,9 @@ network_peers_list = {
           "region" = "us-east-1"
           "vpc_id" = "vpc-141f0fffff141aa00ff"
         }
+        "azure_config" = null /* object */
         "gcp_config" = null /* object */
       }
-      "provider_type" = ""
       "status" = {
         "reasoning" = ""
         "state" = "complete"
@@ -618,9 +618,9 @@ Changes to Outputs:
                       - region      = "us-east-1"
                       - vpc_id      = "vpc-12345678912345678"
                     }
+                  - azure_config = null
                   - gcp_config = null
                 }
-              - provider_type   = ""
               - status          = {
                   - reasoning = ""
                   - state     = "complete"
@@ -1114,6 +1114,7 @@ Changes to Outputs:
               - name            = "VPCPeerTFTestGCP"
               - provider_config = {
                   - aws_config = null
+                  - azure_config = null
                   - gcp_config = {
                       - cidr            = "10.0.4.0/23"
                       - network_name    = "cc-ffffffff-aaaa-1414-eeee-000000000000"
@@ -1297,6 +1298,7 @@ Changes to Outputs:
               - name            = "VPCPeerTFTestGCP"
               - provider_config = {
                   - aws_config = null
+                  - azure_config = null
                   - gcp_config = {
                       - cidr            = "10.0.4.0/23"
                       - network_name    = "cc-ffffffff-aaaa-1414-eeee-000000000000"


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-131920

## Description

PR #666 (AV-131920) refactored the `couchbase-capella_network_peers` data sourceschema in `internal/datasources/network_peer_schema.go` — it removed `commands` and `provider_type`, and changed `provider_config` from a flat string into a nested object exposing `aws_config` / `gcp_config` / `azure_config`. The
auto-generated docs and the hand-captured example output were not updated, so they still describe the old, now-incorrect schema.

This PR brings the documentation back in sync with the schema:

- **`docs/data-sources/network_peers.md`** — regenerated from the schema via `make build-docs`. It now documents `provider_config` as a nested object with `aws_config` / `gcp_config` / `azure_config` (each with its provider-specific fields) and drops the removed `commands` and `provider_type` attributes.
- **`examples/network_peer/README.md`** — the hand-captured data-source (`network_peers_list`) sample output is not auto-generated, so it was fixed by hand: removed the stale `provider_type` attribute and added the missing `azure_config` key to `provider_config` in the AWS and GCP sections. The Azure section was already captured against the new schema and needed no change. Resource (`new_network_peer`) outputs legitimately still carry `provider_type` and were left untouched.

No functional/code changes — documentation only.

<!-- What does this change do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [x] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
 Ran `make build-docs` and confirmed `docs/data-sources/network_peers.md`
  regenerates with no further diff
</details>

## Further comments