### PR TITLE
[AV-135975] Generate client side validation from specs

### DIFF
--- a/internal/datasources/eventing_function_schema.go
+++ b/internal/datasources/eventing_function_schema.go
@@ -116,7 +116,7 @@ func EventingFunctionSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", eventingFunctionBuilder, requiredUUIDString())
 	capellaschema.AddAttr(attrs, "project_id", eventingFunctionBuilder, requiredUUIDString())
 	capellaschema.AddAttr(attrs, "cluster_id", eventingFunctionBuilder, requiredUUIDString())
-	capellaschema.AddAttr(attrs, "name", eventingFunctionBuilder, requiredStringWithValidator())
+	capellaschema.AddAttr(attrs, "name", eventingFunctionBuilder, requiredString())
 
 	// export omits the read-only status field from the response so the result can be reused as a
 	// create payload. It maps to the export query parameter on the get eventing function endpoint.

--- a/internal/generated/enums/enums.gen.go
+++ b/internal/generated/enums/enums.gen.go
@@ -35,6 +35,9 @@ var enumTable = map[string]map[string]EnumDef{
 	"Caching": {
 		"defaultCache": {Type: "string", Values: []string{"standard", "semantic"}},
 	},
+	"Channel": {
+		"type": {Type: "string", Values: []string{"public", "private"}},
+	},
 	"CloudConfig": {
 		"compute.cpu":       {Type: "integer", Values: []string{"4", "32"}},
 		"compute.gpuMemory": {Type: "integer", Values: []string{"24", "48", "192"}},
@@ -61,7 +64,10 @@ var enumTable = map[string]map[string]EnumDef{
 		"logLevel": {Type: "string", Values: []string{"info", "warn", "error"}},
 	},
 	"CreateAlertRequest": {
-		"kind": {Type: "string", Values: []string{"webhook"}},
+		"kind": {Type: "string", Values: []string{"webhook", "slack", "teams"}},
+	},
+	"CreateBedrockConfigurationRequest": {
+		"region": {Type: "string", Values: []string{"us-east-1", "us-west-2", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-central-2", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1"}},
 	},
 	"CreateBucketRequest": {
 		"vbuckets": {Type: "integer", Values: []string{"128", "1024"}},
@@ -118,11 +124,22 @@ var enumTable = map[string]map[string]EnumDef{
 	"EnableCMEKAzureRequest": {
 		"cloudProvider": {Type: "string", Values: []string{"azure"}},
 	},
+	"EventingFunctionBucketBinding": {
+		"permission": {Type: "string", Values: []string{"read", "readWrite"}},
+	},
+	"EventingFunctionSettings": {
+		"feedBoundary":          {Type: "string", Values: []string{"everything", "from_now"}},
+		"languageCompatibility": {Type: "string", Values: []string{"6.0.0", "6.5.0", "6.6.2", "7.2.0"}},
+		"sqlConsistency":        {Type: "string", Values: []string{"none", "request"}},
+	},
+	"ExternalEmbeddingModel": {
+		"provider": {Type: "string", Values: []string{"openAI", "awsBedrock"}},
+	},
 	"ExternalModel": {
 		"external.modelName": {Type: "string", Values: []string{"text-embedding-3-small", "text-embedding-3-large", "text-embedding-ada-002"}},
 	},
 	"GetAlertResponse": {
-		"kind": {Type: "string", Values: []string{"webhook"}},
+		"kind": {Type: "string", Values: []string{"webhook", "slack", "teams"}},
 	},
 	"GetAppServicePrivateEndpointStateResponse": {
 		"state":       {Type: "string", Values: []string{"enabled", "enabling", "disabled", "disabling", "failed"}},
@@ -150,6 +167,9 @@ var enumTable = map[string]map[string]EnumDef{
 	},
 	"GetPrivateEndpointServiceResponse": {
 		"status": {Type: "string", Values: []string{"idle", "unknown", "enabling", "enabled", "enableFailed", "disabling", "disabled", "disableFailed"}},
+	},
+	"GetPrivateEndpointServiceStatusResponse": {
+		"status": {Type: "string", Values: []string{"idle", "enabling", "enabled", "enableFailed", "disabling", "disabled", "disableFailed", "unknown"}},
 	},
 	"GetReplicationJobResponse": {
 		"state": {Type: "string", Values: []string{"pending", "processing", "complete", "failed", "skipped", "killed", "notfound", "unknown"}},
@@ -210,6 +230,27 @@ var enumTable = map[string]map[string]EnumDef{
 	},
 	"ResyncStatus": {
 		"state": {Type: "string", Values: []string{"running", "completed", "stopping", "stopped", "error"}},
+	},
+	"SetFunctionStateRequest": {
+		"state": {Type: "string", Values: []string{"deploy", "undeploy", "pause", "resume"}},
+	},
+	"URLBindingAuthBasic": {
+		"type": {Type: "string", Values: []string{"basic"}},
+	},
+	"URLBindingAuthBearer": {
+		"type": {Type: "string", Values: []string{"bearer"}},
+	},
+	"URLBindingAuthDigest": {
+		"type": {Type: "string", Values: []string{"digest"}},
+	},
+	"URLBindingAuthNone": {
+		"type": {Type: "string", Values: []string{"none"}},
+	},
+	"UpdateAlertRequest": {
+		"kind": {Type: "string", Values: []string{"webhook", "slack", "teams"}},
+	},
+	"UpdateBedrockConfigurationRequest": {
+		"region": {Type: "string", Values: []string{"us-east-1", "us-west-2", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-central-2", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1"}},
 	},
 	"UpdateBucketRequest": {
 		"durabilityLevel": {Type: "string", Values: []string{"none", "majority", "majorityAndPersistActive", "persistToMajority"}},
@@ -299,9 +340,6 @@ var compositionTable = map[string]map[string]CompositionDef{
 	},
 	"UpdateProviderRequest": {
 		"configuration": {Kind: "oneOf", Branches: []string{"UpdateS3ConfigurationRequest", "UpdateOpenAIConfigurationRequest", "UpdateBedrockConfigurationRequest"}},
-	},
-	"VectorizationConfig": {
-		"embeddingModel": {Kind: "oneOf", Branches: []string{"ExternalModel", "CapellaHostedModel"}},
 	},
 }
 
@@ -403,6 +441,9 @@ var requiredTable = map[string]map[string]RequiredDef{
 	},
 	"CategorizedBillingResponse": {
 		"data": {},
+	},
+	"Channel": {
+		"name": {},
 	},
 	"CloudAccounts": {
 		"aws-capella-account":        {},
@@ -506,10 +547,6 @@ var requiredTable = map[string]map[string]RequiredDef{
 		"resourceGroupName": {},
 		"virtualNetwork":    {},
 	},
-	"CreateBedrockConfigurationRequest": {
-		"accessKeyId":     {},
-		"secretAccessKey": {},
-	},
 	"CreateBucketRequest": {
 		"name": {},
 	},
@@ -577,6 +614,11 @@ var requiredTable = map[string]map[string]RequiredDef{
 	"CreateDatabaseCredentialResponse": {
 		"id":       {},
 		"password": {},
+	},
+	"CreateEventingFunctionRequest": {
+		"eventMetadataStorage": {},
+		"eventSource":          {},
+		"name":                 {},
 	},
 	"CreateFreeTierAppServiceRequest": {
 		"name": {},
@@ -745,6 +787,10 @@ var requiredTable = map[string]map[string]RequiredDef{
 	"EditColumnarAnalyticsBackupRetentionRequest": {
 		"retention": {},
 	},
+	"EmbeddingDimensions": {
+		"default":   {},
+		"supported": {},
+	},
 	"EnableCMEKAzureRequest": {
 		"cloudProvider": {},
 	},
@@ -753,6 +799,32 @@ var requiredTable = map[string]map[string]RequiredDef{
 		"hint":           {},
 		"httpStatusCode": {},
 		"message":        {},
+	},
+	"EventingFunction": {
+		"eventMetadataStorage": {},
+		"eventSource":          {},
+		"name":                 {},
+	},
+	"EventingFunctionBucketBinding": {
+		"alias":  {},
+		"bucket": {},
+	},
+	"EventingFunctionConstantBinding": {
+		"alias": {},
+		"value": {},
+	},
+	"EventingFunctionKeyspace": {
+		"bucket": {},
+	},
+	"EventingFunctionUrlBinding": {
+		"alias": {},
+		"url":   {},
+	},
+	"ExternalEmbeddingModel": {
+		"contextWindowSize": {},
+		"dimensions":        {},
+		"name":              {},
+		"provider":          {},
 	},
 	"ExternalModel": {
 		"external": {},
@@ -943,18 +1015,19 @@ var requiredTable = map[string]map[string]RequiredDef{
 		"timezone":         {},
 	},
 	"GetClusterResponse": {
-		"audit":             {},
-		"availability":      {},
-		"cloudProvider":     {},
-		"configurationType": {},
-		"connectionString":  {},
-		"couchbaseServer":   {},
-		"currentState":      {},
-		"description":       {},
-		"id":                {},
-		"name":              {},
-		"serviceGroups":     {},
-		"support":           {},
+		"audit":              {},
+		"availability":       {},
+		"cloudProvider":      {},
+		"configurationType":  {},
+		"connectionString":   {},
+		"couchbaseServer":    {},
+		"currentState":       {},
+		"deletionProtection": {},
+		"description":        {},
+		"id":                 {},
+		"name":               {},
+		"serviceGroups":      {},
+		"support":            {},
 	},
 	"GetClusterSupport": {
 		"plan":     {},
@@ -1005,6 +1078,10 @@ var requiredTable = map[string]map[string]RequiredDef{
 		"severity":  {},
 		"source":    {},
 		"timestamp": {},
+	},
+	"GetEventingFunctionsResponse": {
+		"cursor": {},
+		"data":   {},
 	},
 	"GetEventsResponse": {
 		"cursor": {},
@@ -1087,6 +1164,10 @@ var requiredTable = map[string]map[string]RequiredDef{
 		"structuredDataProcessingConfig": {},
 		"targetCouchbaseKeyspace":        {},
 		"vectorizationConfig":            {},
+	},
+	"GetSupportedExternalEmbeddingModelsResponse": {
+		"cursor": {},
+		"data":   {},
 	},
 	"GetUnstructuredWorkflowResponse": {
 		"source":                           {},
@@ -1182,6 +1263,13 @@ var requiredTable = map[string]map[string]RequiredDef{
 	},
 	"ListBackupsResponse": {
 		"data": {},
+	},
+	"ListChannelsRequest": {
+		"botToken":      {},
+		"integrationId": {},
+	},
+	"ListChannelsResponse": {
+		"channels": {},
 	},
 	"ListCloudSnapshotBackupsResponse": {
 		"cursor": {},
@@ -1320,7 +1408,17 @@ var requiredTable = map[string]map[string]RequiredDef{
 		"createdBy": {},
 	},
 	"RequestConfig": {
+		"slack":   {},
+		"teams":   {},
 		"webhook": {},
+	},
+	"RequestSlack": {
+		"botToken":                  {},
+		"channel":                   {},
+		"channelWebhookUrlMappings": {},
+	},
+	"RequestTeams": {
+		"webhookUrlMappings": {},
 	},
 	"RequestWebhook": {
 		"method": {},
@@ -1337,6 +1435,8 @@ var requiredTable = map[string]map[string]RequiredDef{
 		"name": {},
 	},
 	"ResponseConfig": {
+		"slack":   {},
+		"teams":   {},
 		"webhook": {},
 	},
 	"ResponseWebhook": {
@@ -1372,6 +1472,12 @@ var requiredTable = map[string]map[string]RequiredDef{
 	"ScopeConfig": {
 		"collections": {},
 	},
+	"SetFunctionStateRequest": {
+		"state": {},
+	},
+	"SlackCustomPayload": {
+		"payload": {},
+	},
 	"Stats": {
 		"diskUsedInMib":   {},
 		"itemCount":       {},
@@ -1381,8 +1487,33 @@ var requiredTable = map[string]map[string]RequiredDef{
 	"Support": {
 		"plan": {},
 	},
-	"UpdateAlertRequest": {
-		"config": {},
+	"TeamsCustomPayload": {
+		"payload": {},
+	},
+	"TestRequestConfig": {
+		"slack":   {},
+		"teams":   {},
+		"webhook": {},
+	},
+	"TestRequestTeams": {
+		"url": {},
+	},
+	"URLBindingAuthBasic": {
+		"password": {},
+		"type":     {},
+		"username": {},
+	},
+	"URLBindingAuthBearer": {
+		"bearerToken": {},
+		"type":        {},
+	},
+	"URLBindingAuthDigest": {
+		"password": {},
+		"type":     {},
+		"username": {},
+	},
+	"URLBindingAuthNone": {
+		"type": {},
 	},
 	"UpdateAppEndpointRequest": {
 		"bucket":               {},
@@ -1464,6 +1595,11 @@ var requiredTable = map[string]map[string]RequiredDef{
 	},
 	"UpdateProviderRequest": {
 		"configuration": {},
+	},
+	"UpdateRequestConfig": {
+		"slack":   {},
+		"teams":   {},
+		"webhook": {},
 	},
 	"UpsertColumnarAnalyticsBackupScheduleRequest": {
 		"interval":  {},
@@ -1586,6 +1722,9 @@ var constraintTable = map[string]map[string]ConstraintDef{
 		"name":     {MinLength: ptrInt64(2), MaxLength: ptrInt64(128)},
 		"password": {MinLength: ptrInt64(8)},
 	},
+	"CreateEventingFunctionRequest": {
+		"name": {MinLength: ptrInt64(1), MaxLength: ptrInt64(100)},
+	},
 	"CreateFreeTierAppServiceRequest": {
 		"description": {MaxLength: ptrInt64(256)},
 		"name":        {MaxLength: ptrInt64(256)},
@@ -1629,6 +1768,28 @@ var constraintTable = map[string]map[string]ConstraintDef{
 	"DiskGCP": {
 		"storage": {Minimum: ptrFloat64(50)},
 	},
+	"EventingFunction": {
+		"name": {MinLength: ptrInt64(1), MaxLength: ptrInt64(100)},
+	},
+	"EventingFunctionBucketBinding": {
+		"alias":  {MinLength: ptrInt64(1), MaxLength: ptrInt64(64)},
+		"bucket": {MinLength: ptrInt64(1), MaxLength: ptrInt64(100)},
+	},
+	"EventingFunctionConstantBinding": {
+		"alias": {MinLength: ptrInt64(1), MaxLength: ptrInt64(64)},
+		"value": {MinLength: ptrInt64(1)},
+	},
+	"EventingFunctionKeyspace": {
+		"bucket": {MinLength: ptrInt64(1), MaxLength: ptrInt64(100)},
+	},
+	"EventingFunctionSettings": {
+		"maxTimerContextSize": {Minimum: ptrFloat64(20), Maximum: ptrFloat64(2.097152e+07)},
+		"scriptTimeout":       {Minimum: ptrFloat64(1)},
+		"workerCount":         {Minimum: ptrFloat64(1), Maximum: ptrFloat64(64)},
+	},
+	"EventingFunctionUrlBinding": {
+		"alias": {MinLength: ptrInt64(1), MaxLength: ptrInt64(64)},
+	},
 	"GetAlertResponse": {
 		"name": {MaxLength: ptrInt64(1024)},
 	},
@@ -1665,6 +1826,17 @@ var constraintTable = map[string]map[string]ConstraintDef{
 	"ServiceGroup": {
 		"services": {MinItems: ptrInt64(1)},
 	},
+	"URLBindingAuthBasic": {
+		"password": {MinLength: ptrInt64(1)},
+		"username": {MinLength: ptrInt64(1)},
+	},
+	"URLBindingAuthBearer": {
+		"bearerToken": {MinLength: ptrInt64(1)},
+	},
+	"URLBindingAuthDigest": {
+		"password": {MinLength: ptrInt64(1)},
+		"username": {MinLength: ptrInt64(1)},
+	},
 	"UpdateAlertRequest": {
 		"name": {MaxLength: ptrInt64(1024)},
 	},
@@ -1697,5 +1869,11 @@ var constraintTable = map[string]map[string]ConstraintDef{
 	"UpdateProjectRequest": {
 		"description": {MaxLength: ptrInt64(256)},
 		"name":        {MaxLength: ptrInt64(128)},
+	},
+	"VectorizationConfig": {
+		"embeddingModel.external.dimensions": {Minimum: ptrFloat64(1)},
+	},
+	"VectorizationConfigCreation": {
+		"embeddingModel.external.dimensions": {Minimum: ptrFloat64(1)},
 	},
 }

--- a/internal/resources/eventing_function_schema.go
+++ b/internal/resources/eventing_function_schema.go
@@ -27,7 +27,7 @@ func EventingFunctionSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", eventingFunctionBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "project_id", eventingFunctionBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "cluster_id", eventingFunctionBuilder, requiredUUIDStringAttribute())
-	capellaschema.AddAttr(attrs, "name", eventingFunctionBuilder, requiredNonEmptyStringAttribute())
+	capellaschema.AddAttr(attrs, "name", eventingFunctionBuilder, stringAttribute([]string{required, requiresReplace}))
 	capellaschema.AddAttr(attrs, "description", eventingFunctionBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(attrs, "code", eventingFunctionBuilder, stringAttribute([]string{required, sensitive}))
 	capellaschema.AddAttr(
@@ -77,7 +77,7 @@ func EventingFunctionSchema() schema.Schema {
 
 func keyspaceAttributes() map[string]schema.Attribute {
 	attrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(attrs, "bucket", eventingFunctionBuilder, requiredStringAttributeNoReplace(), "EventingFunctionKeyspace")
+	capellaschema.AddAttr(attrs, "bucket", eventingFunctionBuilder, stringAttribute([]string{required}), "EventingFunctionKeyspace")
 	capellaschema.AddAttr(attrs, "scope", eventingFunctionBuilder, stringAttribute([]string{optional, computed}), "EventingFunctionKeyspace")
 	capellaschema.AddAttr(attrs, "collection", eventingFunctionBuilder, stringAttribute([]string{optional, computed}), "EventingFunctionKeyspace")
 	return attrs
@@ -88,14 +88,11 @@ func settingsAttributes() map[string]schema.Attribute {
 	capellaschema.AddAttr(attrs, "worker_count", eventingFunctionBuilder, int64Attribute(optional, computed, useStateForUnknown), "EventingFunctionSettings")
 	capellaschema.AddAttr(attrs, "script_timeout", eventingFunctionBuilder, int64Attribute(optional, computed, useStateForUnknown), "EventingFunctionSettings")
 
-	capellaschema.AddAttr(attrs, "sql_consistency", eventingFunctionBuilder, stringAttribute(
-		[]string{optional, computed, useStateForUnknown}, validator.String(stringvalidator.OneOf("none", "request"))), "EventingFunctionSettings")
+	capellaschema.AddAttr(attrs, "sql_consistency", eventingFunctionBuilder, stringAttribute([]string{optional, computed, useStateForUnknown}), "EventingFunctionSettings")
 
-	capellaschema.AddAttr(attrs, "language_compatibility", eventingFunctionBuilder, stringAttribute(
-		[]string{optional, computed, useStateForUnknown}, validator.String(stringvalidator.OneOf("6.0.0", "6.5.0", "6.6.2", "7.2.0"))), "EventingFunctionSettings")
+	capellaschema.AddAttr(attrs, "language_compatibility", eventingFunctionBuilder, stringAttribute([]string{optional, computed, useStateForUnknown}), "EventingFunctionSettings")
 
-	capellaschema.AddAttr(attrs, "feed_boundary", eventingFunctionBuilder, stringAttribute(
-		[]string{optional, computed, useStateForUnknown}, validator.String(stringvalidator.OneOf("everything", "from_now"))), "EventingFunctionSettings")
+	capellaschema.AddAttr(attrs, "feed_boundary", eventingFunctionBuilder, stringAttribute([]string{optional, computed, useStateForUnknown}), "EventingFunctionSettings")
 
 	capellaschema.AddAttr(attrs, "max_timer_context_size", eventingFunctionBuilder, int64Attribute(optional, computed, useStateForUnknown), "EventingFunctionSettings")
 	capellaschema.AddAttr(attrs, "allow_sync_documents", eventingFunctionBuilder, boolAttribute(optional, computed, useStateForUnknown), "EventingFunctionSettings")
@@ -107,12 +104,11 @@ func bindingsAttributes() map[string]schema.Attribute {
 	attrs := make(map[string]schema.Attribute)
 
 	bucketAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(bucketAttrs, "alias", eventingFunctionBuilder, requiredStringAttributeNoReplace(), "EventingFunctionBucketBinding")
-	capellaschema.AddAttr(bucketAttrs, "bucket", eventingFunctionBuilder, requiredStringAttributeNoReplace(), "EventingFunctionBucketBinding")
+	capellaschema.AddAttr(bucketAttrs, "alias", eventingFunctionBuilder, stringAttribute([]string{required}), "EventingFunctionBucketBinding")
+	capellaschema.AddAttr(bucketAttrs, "bucket", eventingFunctionBuilder, stringAttribute([]string{required}), "EventingFunctionBucketBinding")
 	capellaschema.AddAttr(bucketAttrs, "scope", eventingFunctionBuilder, stringAttribute([]string{optional, computed}), "EventingFunctionBucketBinding")
 	capellaschema.AddAttr(bucketAttrs, "collection", eventingFunctionBuilder, stringAttribute([]string{optional, computed}), "EventingFunctionBucketBinding")
-	capellaschema.AddAttr(bucketAttrs, "permission", eventingFunctionBuilder, stringAttribute(
-		[]string{optional, computed}, validator.String(stringvalidator.OneOf("read", "readWrite"))), "EventingFunctionBucketBinding")
+	capellaschema.AddAttr(bucketAttrs, "permission", eventingFunctionBuilder, stringAttribute([]string{optional, computed}), "EventingFunctionBucketBinding")
 
 	capellaschema.AddAttr(attrs, "buckets", eventingFunctionBuilder, &schema.ListNestedAttribute{
 		Optional: true,
@@ -129,7 +125,7 @@ func bindingsAttributes() map[string]schema.Attribute {
 	capellaschema.AddAttr(authAttrs, "bearer_token", eventingFunctionBuilder, stringAttribute([]string{optional, sensitive}))
 
 	urlAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(urlAttrs, "alias", eventingFunctionBuilder, requiredStringAttributeNoReplace(), "EventingFunctionUrlBinding")
+	capellaschema.AddAttr(urlAttrs, "alias", eventingFunctionBuilder, stringAttribute([]string{required}), "EventingFunctionUrlBinding")
 	capellaschema.AddAttr(urlAttrs, "url", eventingFunctionBuilder, requiredStringAttributeNoReplace(), "EventingFunctionUrlBinding")
 	capellaschema.AddAttr(urlAttrs, "allow_cookies", eventingFunctionBuilder, boolAttribute(optional, computed), "EventingFunctionUrlBinding")
 	capellaschema.AddAttr(urlAttrs, "validate_tls_certificate", eventingFunctionBuilder, boolAttribute(optional, computed), "EventingFunctionUrlBinding")
@@ -146,8 +142,8 @@ func bindingsAttributes() map[string]schema.Attribute {
 	})
 
 	constantAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(constantAttrs, "alias", eventingFunctionBuilder, requiredStringAttributeNoReplace(), "EventingFunctionConstantBinding")
-	capellaschema.AddAttr(constantAttrs, "value", eventingFunctionBuilder, requiredStringAttributeNoReplace(), "EventingFunctionConstantBinding")
+	capellaschema.AddAttr(constantAttrs, "alias", eventingFunctionBuilder, stringAttribute([]string{required}), "EventingFunctionConstantBinding")
+	capellaschema.AddAttr(constantAttrs, "value", eventingFunctionBuilder, stringAttribute([]string{required}), "EventingFunctionConstantBinding")
 
 	capellaschema.AddAttr(attrs, "constants", eventingFunctionBuilder, &schema.ListNestedAttribute{
 		Optional: true,


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-135975

## Description

- Generate enum validation using `make gen-enums` so we have more client side validation now that the eventing APIs have GA'ed

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
worker count set to 0
tf plan

```
│ Error: Invalid Attribute Value
│
│   with couchbase-capella_eventing_function.validate_test,
│   on terraform.tf line 28, in resource "couchbase-capella_eventing_function" "validate_test":
│   28: resource "couchbase-capella_eventing_function" "validate_test" {
│
│ Attribute settings.worker_count value must be between 1 and 64, got: 0
```

bad enum for feed boundary 

```
│ Error: Invalid Attribute Value Match
│
│   with couchbase-capella_eventing_function.validate_test,
│   on terraform.tf line 28, in resource "couchbase-capella_eventing_function" "validate_test":
│   28: resource "couchbase-capella_eventing_function" "validate_test" {
│
│ Attribute settings.feed_boundary value must be one of: ["everything" "from_now"], got: "test"
```

</details>

## Further comments