### PR TITLE
[AV-136056] Merge 'main' into feature/AV-128959-eventing-functions

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,7 +1,7 @@
 user=couchbasecloud
 project=terraform-provider-couchbase-capella
-future-release=v1.9.0
-since-tag=v1.8.1
+future-release=v1.9.1
+since-tag=v1.9.0
 exclude-labels=no-changelog-needed,dependencies
 enhancement-labels=enhancement,feature
 bug-labels=bug,bugfix,fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [v1.9.1](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/tree/v1.9.1) (2026-06-30)
+
+[Full Changelog](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/compare/v1.9.0...v1.9.1)
+
+**Implemented enhancements:**
+
+- \[AV-134634\] Fix - Fail fast and auto-recover from private endpoint service failed states [\#647](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/647) ([cloudy-vishnu](https://github.com/cloudy-vishnu))
+- \[AV-128971\] Add certificate datasource tests; provision DM cluster lazily [\#637](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/637) ([panigrahisubhrajit](https://github.com/panigrahisubhrajit))
+- \[AV-127227\] Handle app endpoint deletion and forbidden errors in various resource operations [\#634](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/634) ([stanleefdz](https://github.com/stanleefdz))
+- \[AV-128970\] Add acceptance tests for query index datasources [\#625](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/625) ([panigrahisubhrajit](https://github.com/panigrahisubhrajit))
+- \[AV-128954\] Add acceptance tests for events datasources [\#624](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/624) ([panigrahisubhrajit](https://github.com/panigrahisubhrajit))
+
+**Fixed bugs:**
+
+- \[AV-131920\] Refactor network peer schema to enhance provider configuration attributes [\#666](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/666) ([akhilravuri-cb](https://github.com/akhilravuri-cb))
+- \[AV-135236\] Validate RFC3339 Format for start\_time in Snapshot Backup Schedule Resource [\#665](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/665) ([SophieWegmann](https://github.com/SophieWegmann))
+- \[AV-132169\] Reject empty private endpoint endpoint\_id at plan time [\#663](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/663) ([PaulomeeCb](https://github.com/PaulomeeCb))
+- \[AV-132168\] Reject unsupported network peer provider\_type [\#660](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/660) ([PaulomeeCb](https://github.com/PaulomeeCb))
+- \[AV-132167\] Reject short private endpoint command VPC IDs at plan time [\#659](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/659) ([PaulomeeCb](https://github.com/PaulomeeCb))
+- \[AV-134866\] Fix flaky app\_endpoint tests by sharing bucket via collections [\#655](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/655) ([nimiyajoseph](https://github.com/nimiyajoseph))
+- \[AV-132154\] Fix enum lookup for nested fields [\#650](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/650) ([matty271828](https://github.com/matty271828))
+- \[AV-129960\] Add handling for service unavailable errors [\#649](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/649) ([stanleefdz](https://github.com/stanleefdz))
+- \[AV-132148\] Validate free-tier cluster region at plan time [\#645](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/645) ([PaulomeeCb](https://github.com/PaulomeeCb))
+- \[AV-131924\] Fix provider\_type erased on import/read [\#643](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/643) ([tanushgolwala](https://github.com/tanushgolwala))
+- \[AV-129893\] Enhance network peer error handling and state management [\#639](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/639) ([stanleefdz](https://github.com/stanleefdz))
+- \[AV-134037\] Auto-attach enum validators for -to-named-enum fields [\#638](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/638) ([PaulomeeCb](https://github.com/PaulomeeCb))
+- \[AV-132231\] Add clear duplicate/missing-day validation for on/off schedule [\#635](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/635) ([PaulomeeCb](https://github.com/PaulomeeCb))
+- \[AV-132230\] Add UUID validation for cluster on/off schedule data source IDs [\#632](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/632) ([PaulomeeCb](https://github.com/PaulomeeCb))
+- \[AV-132229\] Add config validation for cluster on/off schedule time boundaries [\#631](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/631) ([PaulomeeCb](https://github.com/PaulomeeCb))
+- \[AV-132227\] Add config validation for cluster on/off schedule days [\#630](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/630) ([PaulomeeCb](https://github.com/PaulomeeCb))
+- \[AV-132908\] Serialize cloud\_snapshot\_restore acceptance tests [\#629](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/629) ([panigrahisubhrajit](https://github.com/panigrahisubhrajit))
+- \[AV-132944\] Add audit log export and settings validation coverage [\#626](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/626) ([nimiyajoseph](https://github.com/nimiyajoseph))
+
+**Merged pull requests:**
+
+- \[AV-131920\] Update network peer documentation to reflect changes in provider configuration attributes [\#672](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/672) ([akhilravuri-cb](https://github.com/akhilravuri-cb))
+- \[AV-132988\] Fix flaky private endpoint service acceptance test [\#633](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/633) ([nimiyajoseph](https://github.com/nimiyajoseph))
+
 ## [v1.9.0](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/tree/v1.9.0) (2026-05-29)
 
 [Full Changelog](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/compare/v1.8.1...v1.9.0)

--- a/acceptance_tests/access_management_membership_test.go
+++ b/acceptance_tests/access_management_membership_test.go
@@ -180,9 +180,9 @@ func TestAccDatasourceUsersFullFieldContent(t *testing.T) {
 
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
 					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
-						"name":              username,
-						"email":             email,
-						"organization_id":   globalOrgId,
+						"name":                 username,
+						"email":                email,
+						"organization_id":      globalOrgId,
 						"organization_roles.#": "1",
 						"organization_roles.0": "organizationMember",
 					}),

--- a/acceptance_tests/app_endpoint_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_acceptance_test.go
@@ -10,31 +10,33 @@ import (
 )
 
 func TestAccAppEndpoint(t *testing.T) {
-	ensureFixtureBucketByName(t, globalEPBucketName)
+	ensureFixtureCollection(t, globalEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointResourceConfig(resourceName, epName, globalEPBucketName, "syncFnXattr", true),
+				Config: testAccAppEndpointResourceConfig(resourceName, epName, globalEPCollectionName, "syncFnXattr", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
 					resource.TestCheckResourceAttr(resourceReference, "cluster_id", appEndpointClusterId),
 					resource.TestCheckResourceAttr(resourceReference, "app_service_id", appEndpointAppServiceId),
-					resource.TestCheckResourceAttr(resourceReference, "bucket", globalEPBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "bucket", appEndpointBucketName),
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
 					resource.TestCheckResourceAttr(resourceReference, "delta_sync_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceReference, "user_xattr_key", "syncFnXattr"),
 				),
 			},
 			{
-				Config: testAccAppEndpointResourceConfig(resourceName, epName, globalEPBucketName, "new_xattr", false),
+				Config: testAccAppEndpointResourceConfig(resourceName, epName, globalEPCollectionName, "new_xattr", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "delta_sync_enabled", "false"),
@@ -82,7 +84,9 @@ func TestAccAppEndpointInexistentCollection(t *testing.T) {
 		appEndpointBucketName,
 		epName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
@@ -93,7 +97,7 @@ func TestAccAppEndpointInexistentCollection(t *testing.T) {
 	})
 }
 
-func testAccAppEndpointResourceConfig(resourceName, endpointName, bucketName, userXattr string, deltaSync bool) string {
+func testAccAppEndpointResourceConfig(resourceName, endpointName, collectionName, userXattr string, deltaSync bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -102,7 +106,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id         = "%[4]s"
 	cluster_id         = "%[5]s"
 	app_service_id     = "%[6]s"
-	bucket             = "%[7]s"
+	bucket             = "`+appEndpointBucketName+`"
 	name               = "%[8]s"
 	user_xattr_key     = "%[9]s"
 	delta_sync_enabled = %[10]t
@@ -119,7 +123,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 		  collections = {
-			"_default" = {}
+			"%[7]s" = {}
 		  }
 		}
 	}
@@ -131,7 +135,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 		userXattr,
 		deltaSync,
@@ -141,15 +145,17 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // TestAccAppEndpointNoCors verifies that creating an app endpoint without a
 // cors block does not produce perpetual state drift on subsequent plans.
 func TestAccAppEndpointNoCors(t *testing.T) {
-	ensureFixtureBucketByName(t, globalNoCorsEPBucketName)
+	ensureFixtureCollection(t, globalNoCorsEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_ep_nocors_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_ep_nocors_")
 
-	cfg := testAccAppEndpointNoCorsConfig(resourceName, epName, globalNoCorsEPBucketName)
+	cfg := testAccAppEndpointNoCorsConfig(resourceName, epName, globalNoCorsEPCollectionName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
@@ -170,7 +176,7 @@ func TestAccAppEndpointNoCors(t *testing.T) {
 	})
 }
 
-func testAccAppEndpointNoCorsConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointNoCorsConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -179,12 +185,12 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 	scopes = {
 		"_default" = {
 		  collections = {
-			"_default" = {}
+			"%[7]s" = {}
 		  }
 		}
 	}
@@ -196,7 +202,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -230,25 +236,27 @@ func testAccAppEndpointComputedAttrs(resourceReference string) resource.TestChec
 // The API rejects empty/missing origin when a cors block is present.
 // Provider schema must reject this before issuing the API request.
 func TestAccAppEndpointCorsDisabledFalseNoOrigin(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsDisabledFalseEPBucketName)
+	ensureFixtureCollection(t, globalCorsDisabledFalseEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
+				Config:      testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, epName, globalCorsDisabledFalseEPCollectionName),
 				ExpectError: re.MustCompile(`(?s).*cors\.origin.*at least 1 value.*`),
 			},
 			{
-				Config:      testAccAppEndpointCorsEmptyOriginResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
+				Config:      testAccAppEndpointCorsEmptyOriginResourceConfig(resourceName, epName, globalCorsDisabledFalseEPCollectionName),
 				ExpectError: re.MustCompile(`(?s).*cors\.origin.*at least 1 value.*`),
 			},
 			{
-				Config: testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, epName, globalCorsDisabledFalseEPBucketName),
+				Config: testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, epName, globalCorsDisabledFalseEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "cors.disabled", "true"),
@@ -260,17 +268,19 @@ func TestAccAppEndpointCorsDisabledFalseNoOrigin(t *testing.T) {
 
 // ── S6: Full cors config (all fields) — happy path (also covers I2 import) ───
 func TestAccAppEndpointCorsFullConfig(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsFullEPBucketName)
+	ensureFixtureCollection(t, globalCorsFullEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalCorsFullEPBucketName),
+				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalCorsFullEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "cors.disabled", "false"),
@@ -298,16 +308,18 @@ func TestAccAppEndpointCorsFullConfig(t *testing.T) {
 // supplied. Single-provider creation (S17/S18) works correctly.
 func TestAccAppEndpointMultipleOIDC(t *testing.T) {
 	t.Skip("AV-128222: multiple OIDC providers cause a 500 Internal Server Error; unskip once the bug is fixed")
-	ensureFixtureBucketByName(t, globalMultipleOIDCEPBucketName)
+	ensureFixtureCollection(t, globalMultipleOIDCEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointMultipleOIDCResourceConfig(resourceName, epName, globalMultipleOIDCEPBucketName),
+				Config: testAccAppEndpointMultipleOIDCResourceConfig(resourceName, epName, globalMultipleOIDCEPCollectionName),
 			},
 		},
 	})
@@ -315,17 +327,19 @@ func TestAccAppEndpointMultipleOIDC(t *testing.T) {
 
 // ── S20: cors with specific (non-wildcard) origins — happy path ───────────────
 func TestAccAppEndpointCorsSpecificOrigins(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsSpecificEPBucketName)
+	ensureFixtureCollection(t, globalCorsSpecificEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, epName, globalCorsSpecificEPBucketName),
+				Config: testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, epName, globalCorsSpecificEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "cors.origin.#", "2"),
@@ -345,17 +359,19 @@ func TestAccAppEndpointCorsSpecificOrigins(t *testing.T) {
 // default). Users cannot set max_age=0 — the value is always silently replaced.
 func TestAccAppEndpointCorsMaxAgeZeroSilentDrift(t *testing.T) {
 	t.Skip("AV-128218: cors.max_age=0 is silently omitted by the API request model; unskip once zero values round-trip correctly")
-	ensureFixtureBucketByName(t, globalCorsMaxAge0EPBucketName)
+	ensureFixtureCollection(t, globalCorsMaxAge0EPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, epName, globalCorsMaxAge0EPBucketName),
+				Config: testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, epName, globalCorsMaxAge0EPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "cors.max_age", "0"),
 					// https://jira.issues.couchbase.com/browse/AV-128218
@@ -367,17 +383,19 @@ func TestAccAppEndpointCorsMaxAgeZeroSilentDrift(t *testing.T) {
 
 // ── S18: OIDC with all optional fields — happy path ───────────────────────────
 func TestAccAppEndpointOIDCFullFields(t *testing.T) {
-	ensureFixtureBucketByName(t, globalOIDCFullEPBucketName)
+	ensureFixtureCollection(t, globalOIDCFullEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointOIDCAllFieldsResourceConfig(resourceName, epName, globalOIDCFullEPBucketName),
+				Config: testAccAppEndpointOIDCAllFieldsResourceConfig(resourceName, epName, globalOIDCFullEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "oidc.#", "1"),
@@ -397,17 +415,19 @@ func TestAccAppEndpointOIDCFullFields(t *testing.T) {
 
 // ── S22: OIDC with discovery_url — happy path ─────────────────────────────────
 func TestAccAppEndpointOIDCDiscoveryURL(t *testing.T) {
-	ensureFixtureBucketByName(t, globalOIDCDiscEPBucketName)
+	ensureFixtureCollection(t, globalOIDCDiscEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointOIDCDiscoveryURLResourceConfig(resourceName, epName, globalOIDCDiscEPBucketName),
+				Config: testAccAppEndpointOIDCDiscoveryURLResourceConfig(resourceName, epName, globalOIDCDiscEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "oidc.#", "1"),
@@ -422,30 +442,32 @@ func TestAccAppEndpointOIDCDiscoveryURL(t *testing.T) {
 
 // ── U1: Expand cors from minimal (origin only) to full (all fields) — happy path ──
 func TestAccAppEndpointUpdateCorsExpand(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsExpandEPBucketName)
+	ensureFixtureCollection(t, globalCorsExpandEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsExpandEPBucketName),
+				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsExpandEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
 					resource.TestCheckResourceAttr(resourceReference, "cluster_id", appEndpointClusterId),
 					resource.TestCheckResourceAttr(resourceReference, "app_service_id", appEndpointAppServiceId),
-					resource.TestCheckResourceAttr(resourceReference, "bucket", globalCorsExpandEPBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "bucket", appEndpointBucketName),
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
 					resource.TestCheckTypeSetElemAttr(resourceReference, "cors.origin.*", "*"),
 				),
 			},
 			{
-				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalCorsExpandEPBucketName),
+				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalCorsExpandEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "cors.disabled", "false"),
@@ -463,19 +485,21 @@ func TestAccAppEndpointUpdateCorsExpand(t *testing.T) {
 // cors is effectively write-once via Terraform.
 func TestAccAppEndpointUpdateRemoveCors(t *testing.T) {
 	t.Skip("AV-128229 / AV-128217: removing the cors block after it is set should succeed once the bugs are fixed")
-	ensureFixtureBucketByName(t, globalRemoveCorsEPBucketName)
+	ensureFixtureCollection(t, globalRemoveCorsEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalRemoveCorsEPBucketName),
+				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalRemoveCorsEPCollectionName),
 			},
 			{
-				Config: testAccAppEndpointNoCorsResourceConfig(resourceName, epName, globalRemoveCorsEPBucketName),
+				Config: testAccAppEndpointNoCorsResourceConfig(resourceName, epName, globalRemoveCorsEPCollectionName),
 			},
 		},
 	})
@@ -485,19 +509,21 @@ func TestAccAppEndpointUpdateRemoveCors(t *testing.T) {
 // The API rejects disabling CORS when other cors fields (origin etc.) are also set.
 func TestAccAppEndpointUpdateCorsDisableToggle(t *testing.T) {
 	t.Skip("AV-128229: toggling cors.disabled=true while other CORS fields are set should succeed once the bug is fixed")
-	ensureFixtureBucketByName(t, globalCorsDisableToggleEPBucketName)
+	ensureFixtureCollection(t, globalCorsDisableToggleEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsDisableToggleEPBucketName),
+				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsDisableToggleEPCollectionName),
 			},
 			{
-				Config: testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, epName, globalCorsDisableToggleEPBucketName),
+				Config: testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, epName, globalCorsDisableToggleEPCollectionName),
 			},
 		},
 	})
@@ -505,23 +531,25 @@ func TestAccAppEndpointUpdateCorsDisableToggle(t *testing.T) {
 
 // ── U5: cors origin wildcard → specific URLs — happy path ────────────────────
 func TestAccAppEndpointUpdateCorsOriginWildcardToSpecific(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsWildEPBucketName)
+	ensureFixtureCollection(t, globalCorsWildEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsWildEPBucketName),
+				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsWildEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckTypeSetElemAttr(resourceReference, "cors.origin.*", "*"),
 				),
 			},
 			{
-				Config: testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, epName, globalCorsWildEPBucketName),
+				Config: testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, epName, globalCorsWildEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "cors.origin.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceReference, "cors.origin.*", "https://app.example.com"),
@@ -534,20 +562,22 @@ func TestAccAppEndpointUpdateCorsOriginWildcardToSpecific(t *testing.T) {
 
 // ── U7: Add OIDC block to existing endpoint — happy path ─────────────────────
 func TestAccAppEndpointUpdateAddOIDC(t *testing.T) {
-	ensureFixtureBucketByName(t, globalAddOIDCEPBucketName)
+	ensureFixtureCollection(t, globalAddOIDCEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalAddOIDCEPBucketName),
+				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalAddOIDCEPCollectionName),
 			},
 			{
-				Config: testAccAppEndpointWithOIDCResourceConfig(resourceName, epName, globalAddOIDCEPBucketName),
+				Config: testAccAppEndpointWithOIDCResourceConfig(resourceName, epName, globalAddOIDCEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "oidc.#", "1"),
 					resource.TestCheckResourceAttr(resourceReference, "oidc.0.issuer", "https://accounts.google.com"),
@@ -565,19 +595,21 @@ func TestAccAppEndpointUpdateAddOIDC(t *testing.T) {
 // from the GET response, and Terraform detects the plan/state mismatch.
 func TestAccAppEndpointUpdateRemoveOIDC(t *testing.T) {
 	t.Skip("AV-128167: removing the oidc block should succeed once the bug is fixed")
-	ensureFixtureBucketByName(t, globalRemoveOIDCEPBucketName)
+	ensureFixtureCollection(t, globalRemoveOIDCEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointWithOIDCResourceConfig(resourceName, epName, globalRemoveOIDCEPBucketName),
+				Config: testAccAppEndpointWithOIDCResourceConfig(resourceName, epName, globalRemoveOIDCEPCollectionName),
 			},
 			{
-				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalRemoveOIDCEPBucketName),
+				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalRemoveOIDCEPCollectionName),
 			},
 		},
 	})
@@ -585,7 +617,7 @@ func TestAccAppEndpointUpdateRemoveOIDC(t *testing.T) {
 
 // ── U9: Update access_control_function body — happy path ─────────────────────
 func TestAccAppEndpointUpdateACF(t *testing.T) {
-	ensureFixtureBucketByName(t, globalACFUpdateEPBucketName)
+	ensureFixtureCollection(t, globalACFUpdateEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
@@ -594,17 +626,19 @@ func TestAccAppEndpointUpdateACF(t *testing.T) {
 	initialACF := "function(doc, oldDoc, meta) { channel(doc.channels); }"
 	updatedACF := "function(doc, oldDoc, meta) { channel(doc.type); }"
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointACFResourceConfig(resourceName, epName, globalACFUpdateEPBucketName, initialACF),
+				Config: testAccAppEndpointACFResourceConfig(resourceName, epName, globalACFUpdateEPCollectionName, initialACF),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
 				),
 			},
 			{
-				Config: testAccAppEndpointACFResourceConfig(resourceName, epName, globalACFUpdateEPBucketName, updatedACF),
+				Config: testAccAppEndpointACFResourceConfig(resourceName, epName, globalACFUpdateEPCollectionName, updatedACF),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
 				),
@@ -619,19 +653,21 @@ func TestAccAppEndpointUpdateACF(t *testing.T) {
 // Terraform detects plan=0 vs state=3600 and raises inconsistency error.
 func TestAccAppEndpointUpdateCorsMaxAgeToZero(t *testing.T) {
 	t.Skip("AV-128218: updating cors.max_age to 0 currently produces inconsistent state; unskip once zero values round-trip correctly")
-	ensureFixtureBucketByName(t, globalCorsMaxAgeZeroEPBucketName)
+	ensureFixtureCollection(t, globalCorsMaxAgeZeroEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeZeroEPBucketName, 3600),
+				Config: testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeZeroEPCollectionName, 3600),
 			},
 			{
-				Config:      testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeZeroEPBucketName, 0),
+				Config:      testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeZeroEPCollectionName, 0),
 				ExpectError: re.MustCompile("Provider produced inconsistent result after apply"),
 				// https://jira.issues.couchbase.com/browse/AV-128218
 			},
@@ -644,23 +680,25 @@ func TestAccAppEndpointUpdateCorsMaxAgeToZero(t *testing.T) {
 // non-zero value recovers the drift. The non-zero value is not omitted by
 // omitempty and is applied correctly by the API.
 func TestAccAppEndpointUpdateCorsMaxAgeFromZero(t *testing.T) {
-	ensureFixtureBucketByName(t, globalCorsMaxAgeFromZeroEPBucketName)
+	ensureFixtureCollection(t, globalCorsMaxAgeFromZeroEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, epName, globalCorsMaxAgeFromZeroEPBucketName),
+				Config: testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, epName, globalCorsMaxAgeFromZeroEPCollectionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "cors.max_age", "0"),
 				),
 			},
 			{
-				Config: testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeFromZeroEPBucketName, 3600),
+				Config: testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, epName, globalCorsMaxAgeFromZeroEPCollectionName, 3600),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "cors.max_age", "3600"),
 				),
@@ -680,7 +718,7 @@ func TestAccAppEndpointUpdateCorsMaxAgeFromZero(t *testing.T) {
 
 // testAccAppEndpointNoCorsResourceConfig creates an endpoint with no cors block.
 // Used by: TestAccAppEndpointUpdateRemoveCors (U2 phase 2, skipped).
-func testAccAppEndpointNoCorsResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointNoCorsResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -689,13 +727,13 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -707,14 +745,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointCorsDisabledFalseResourceConfig creates an endpoint with
 // cors { disabled=false } and no origin field. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin.
-func testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsDisabledFalseResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -723,7 +761,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -733,7 +771,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -745,14 +783,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig creates an endpoint with
 // cors { disabled=true } and no origin field. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin.
-func testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -761,7 +799,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -771,7 +809,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -783,14 +821,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointCorsEmptyOriginResourceConfig creates an endpoint with
 // cors { disabled=false, origin=[] }. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin.
-func testAccAppEndpointCorsEmptyOriginResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsEmptyOriginResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -799,7 +837,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -810,7 +848,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -822,7 +860,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -830,7 +868,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // testAccAppEndpointCorsMaxAgeZeroResourceConfig creates an endpoint with
 // cors.max_age=0. Used by: TestAccAppEndpointCorsMaxAgeZeroSilentDrift (S21),
 // TestAccAppEndpointUpdateCorsMaxAgeFromZero (U11 phase 1).
-func testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsMaxAgeZeroResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -839,7 +877,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -851,7 +889,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -863,14 +901,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointMultipleOIDCResourceConfig creates an endpoint with two OIDC
 // providers. Used by: TestAccAppEndpointMultipleOIDC (S19, skipped).
-func testAccAppEndpointMultipleOIDCResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointMultipleOIDCResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -879,7 +917,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -901,7 +939,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -913,7 +951,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -921,7 +959,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // testAccAppEndpointCorsAllFieldsResourceConfig creates an endpoint with all
 // cors fields set. Used by: TestAccAppEndpointCorsFullConfig (S6),
 // TestAccAppEndpointUpdateCorsExpand (U1 phase 2), TestAccAppEndpointUpdateRemoveCors (U2 phase 1, skipped).
-func testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -930,7 +968,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -944,7 +982,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -956,7 +994,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -964,7 +1002,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // testAccAppEndpointCorsSpecificOriginsResourceConfig creates an endpoint with
 // specific (non-wildcard) cors origins. Used by: TestAccAppEndpointCorsSpecificOrigins (S20),
 // TestAccAppEndpointUpdateCorsOriginWildcardToSpecific (U5 phase 2).
-func testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsSpecificOriginsResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -973,7 +1011,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -987,7 +1025,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -999,14 +1037,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointOIDCAllFieldsResourceConfig creates an endpoint with an OIDC
 // provider using all optional fields. Used by: TestAccAppEndpointOIDCFullFields (S18).
-func testAccAppEndpointOIDCAllFieldsResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointOIDCAllFieldsResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1015,7 +1053,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1036,7 +1074,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1048,14 +1086,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointOIDCDiscoveryURLResourceConfig creates an endpoint with an OIDC
 // provider that includes a discovery_url. Used by: TestAccAppEndpointOIDCDiscoveryURL (S22).
-func testAccAppEndpointOIDCDiscoveryURLResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointOIDCDiscoveryURLResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1064,7 +1102,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1082,7 +1120,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1094,7 +1132,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -1104,7 +1142,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // TestAccAppEndpointUpdateCorsDisableToggle (U3 phase 1, skipped),
 // TestAccAppEndpointUpdateCorsOriginWildcardToSpecific (U5 phase 1),
 // TestAccAppEndpointUpdateAddOIDC (U7 phase 1), TestAccAppEndpointUpdateRemoveOIDC (U8 phase 2, skipped).
-func testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1113,7 +1151,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1123,7 +1161,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1135,14 +1173,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointCorsDisabledTrueResourceConfig creates an endpoint with
 // cors.disabled=true. Used by: TestAccAppEndpointUpdateCorsDisableToggle (U3 phase 2, skipped).
-func testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1151,7 +1189,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1162,7 +1200,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1174,7 +1212,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
@@ -1182,7 +1220,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // testAccAppEndpointCorsMaxAgeResourceConfig creates an endpoint with a
 // parameterised cors.max_age. Used by: TestAccAppEndpointUpdateCorsMaxAgeToZero (U10),
 // TestAccAppEndpointUpdateCorsMaxAgeFromZero (U11 phase 2).
-func testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, endpointName, bucketName string, maxAge int) string {
+func testAccAppEndpointCorsMaxAgeResourceConfig(resourceName, endpointName, collectionName string, maxAge int) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1191,7 +1229,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1202,7 +1240,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1214,7 +1252,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 		maxAge,
 	)
@@ -1223,7 +1261,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 // testAccAppEndpointWithOIDCResourceConfig creates an endpoint with cors and a
 // minimal OIDC provider. Used by: TestAccAppEndpointUpdateAddOIDC (U7 phase 2),
 // TestAccAppEndpointUpdateRemoveOIDC (U8 phase 1, skipped).
-func testAccAppEndpointWithOIDCResourceConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointWithOIDCResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1232,7 +1270,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1249,7 +1287,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -1261,14 +1299,14 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 // testAccAppEndpointACFResourceConfig creates an endpoint with a parameterised
 // access_control_function body. Used by: TestAccAppEndpointUpdateACF (U9).
-func testAccAppEndpointACFResourceConfig(resourceName, endpointName, bucketName, acfBody string) string {
+func testAccAppEndpointACFResourceConfig(resourceName, endpointName, collectionName, acfBody string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1277,7 +1315,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	cors = {
@@ -1287,7 +1325,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {
+				"%[7]s" = {
 					access_control_function = "%[9]s"
 				}
 			}
@@ -1301,7 +1339,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 		acfBody,
 	)

--- a/acceptance_tests/app_endpoint_deleted_externally_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_deleted_externally_acceptance_test.go
@@ -1,0 +1,213 @@
+package acceptance_tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccAppEndpointDeletedExternally verifies that when an App Endpoint is
+// deleted outside of Terraform (e.g. via the UI or management API), the
+// provider gracefully removes the resource from state during the Read operation
+// so that Terraform recreates it on the next apply.
+//
+// This tests the 403 → List check → remove-from-state flow implemented in
+// checkAppEndpointDeletedOrForbidden.
+func TestAccAppEndpointDeletedExternally(t *testing.T) {
+	ensureFixtureBucketByName(t, globalDeletedExternallyEPBucketName)
+
+	resourceName := randomStringWithPrefix("tf_acc_ep_del_ext_")
+	resourceReference := "couchbase-capella_app_endpoint." + resourceName
+	epName := randomStringWithPrefix("tf_acc_ep_del_ext_")
+
+	cfg := testAccAppEndpointDeletedExternallyConfig(resourceName, epName, globalDeletedExternallyEPBucketName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			// Step 1: Create the App Endpoint via Terraform.
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAppEndpointComputedAttrs(resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(resourceReference, "cluster_id", appEndpointClusterId),
+					resource.TestCheckResourceAttr(resourceReference, "app_service_id", appEndpointAppServiceId),
+					resource.TestCheckResourceAttr(resourceReference, "name", epName),
+					resource.TestCheckResourceAttr(resourceReference, "bucket", globalDeletedExternallyEPBucketName),
+				),
+			},
+			// Step 2: Delete the App Endpoint externally, then re-apply the same config.
+			// The provider should detect the deletion via the 403 → List fallback,
+			// remove the resource from state, and recreate it.
+			{
+				PreConfig: func() {
+					ctx := context.Background()
+					err := deleteAppEndpointFixtureEndpoint(
+						ctx,
+						globalClient,
+						globalProjectId,
+						appEndpointClusterId,
+						appEndpointAppServiceId,
+						epName,
+					)
+					if err != nil {
+						t.Fatalf("failed to delete app endpoint externally: %v", err)
+					}
+				},
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAppEndpointComputedAttrs(resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "name", epName),
+					resource.TestCheckResourceAttr(resourceReference, "bucket", globalDeletedExternallyEPBucketName),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAppEndpointAccessControlFunctionDeletedExternally verifies that when
+// an App Endpoint is deleted outside of Terraform, the access_control_function
+// resource attached to it is gracefully removed from state during Read.
+func TestAccAppEndpointAccessControlFunctionDeletedExternally(t *testing.T) {
+	ensureFixtureBucketByName(t, globalACFDeletedExtEPBucketName)
+
+	epResourceName := randomStringWithPrefix("tf_acc_ep_acf_del_")
+	epReference := "couchbase-capella_app_endpoint." + epResourceName
+	epName := randomStringWithPrefix("tf_acc_ep_acf_del_")
+
+	acfResourceName := randomStringWithPrefix("tf_acc_acf_del_")
+	acfReference := "couchbase-capella_app_endpoint_access_control_function." + acfResourceName
+
+	acfBody := "function(doc, oldDoc, meta) { channel(doc.channels); }"
+
+	cfgWithACF := testAccAppEndpointWithACFDeletedExternallyConfig(
+		epResourceName, epName, globalACFDeletedExtEPBucketName,
+		acfResourceName, acfBody,
+	)
+	cfgEndpointOnly := testAccAppEndpointDeletedExternallyConfig(epResourceName, epName, globalACFDeletedExtEPBucketName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			// Step 1: Create App Endpoint + ACF resource.
+			{
+				Config: cfgWithACF,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAppEndpointComputedAttrs(epReference),
+					resource.TestCheckResourceAttr(acfReference, "app_endpoint_name", epName),
+					resource.TestCheckResourceAttr(acfReference, "access_control_function", acfBody),
+				),
+			},
+			// Step 2: Delete the App Endpoint externally, then apply config without ACF.
+			// The ACF resource should be removed from state automatically during Read
+			// because the parent App Endpoint no longer exists.
+			{
+				PreConfig: func() {
+					ctx := context.Background()
+					err := deleteAppEndpointFixtureEndpoint(
+						ctx,
+						globalClient,
+						globalProjectId,
+						appEndpointClusterId,
+						appEndpointAppServiceId,
+						epName,
+					)
+					if err != nil {
+						t.Fatalf("failed to delete app endpoint externally: %v", err)
+					}
+				},
+				Config: cfgEndpointOnly,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAppEndpointComputedAttrs(epReference),
+					resource.TestCheckResourceAttr(epReference, "name", epName),
+				),
+			},
+		},
+	})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func testAccAppEndpointDeletedExternallyConfig(resourceName, endpointName, bucketName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_app_endpoint" "%[2]s" {
+	organization_id = "%[3]s"
+	project_id      = "%[4]s"
+	cluster_id      = "%[5]s"
+	app_service_id  = "%[6]s"
+	bucket          = "%[7]s"
+	name            = "%[8]s"
+
+	scopes = {
+		"_default" = {
+			collections = {
+				"_default" = {}
+			}
+		}
+	}
+}
+`,
+		globalProviderBlock,
+		resourceName,
+		globalOrgId,
+		globalProjectId,
+		appEndpointClusterId,
+		appEndpointAppServiceId,
+		bucketName,
+		endpointName,
+	)
+}
+
+func testAccAppEndpointWithACFDeletedExternallyConfig(
+	epResourceName, endpointName, bucketName string,
+	acfResourceName, acfBody string,
+) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_app_endpoint" "%[2]s" {
+	organization_id = "%[3]s"
+	project_id      = "%[4]s"
+	cluster_id      = "%[5]s"
+	app_service_id  = "%[6]s"
+	bucket          = "%[7]s"
+	name            = "%[8]s"
+
+	scopes = {
+		"_default" = {
+			collections = {
+				"_default" = {}
+			}
+		}
+	}
+}
+
+resource "couchbase-capella_app_endpoint_access_control_function" "%[9]s" {
+	organization_id         = "%[3]s"
+	project_id              = "%[4]s"
+	cluster_id              = "%[5]s"
+	app_service_id          = "%[6]s"
+	app_endpoint_name       = couchbase-capella_app_endpoint.%[2]s.name
+	access_control_function = "%[10]s"
+}
+`,
+		globalProviderBlock,
+		epResourceName,
+		globalOrgId,
+		globalProjectId,
+		appEndpointClusterId,
+		appEndpointAppServiceId,
+		bucketName,
+		endpointName,
+		acfResourceName,
+		acfBody,
+	)
+}

--- a/acceptance_tests/app_endpoint_deleted_externally_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_deleted_externally_acceptance_test.go
@@ -16,15 +16,17 @@ import (
 // This tests the 403 → List check → remove-from-state flow implemented in
 // checkAppEndpointDeletedOrForbidden.
 func TestAccAppEndpointDeletedExternally(t *testing.T) {
-	ensureFixtureBucketByName(t, globalDeletedExternallyEPBucketName)
+	ensureFixtureCollection(t, globalDeletedExternallyEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_ep_del_ext_")
 	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_ep_del_ext_")
 
-	cfg := testAccAppEndpointDeletedExternallyConfig(resourceName, epName, globalDeletedExternallyEPBucketName)
+	cfg := testAccAppEndpointDeletedExternallyConfig(resourceName, epName, globalDeletedExternallyEPCollectionName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			// Step 1: Create the App Endpoint via Terraform.
@@ -37,7 +39,7 @@ func TestAccAppEndpointDeletedExternally(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cluster_id", appEndpointClusterId),
 					resource.TestCheckResourceAttr(resourceReference, "app_service_id", appEndpointAppServiceId),
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
-					resource.TestCheckResourceAttr(resourceReference, "bucket", globalDeletedExternallyEPBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "bucket", appEndpointBucketName),
 				),
 			},
 			// Step 2: Delete the App Endpoint externally, then re-apply the same config.
@@ -62,7 +64,7 @@ func TestAccAppEndpointDeletedExternally(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAppEndpointComputedAttrs(resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "name", epName),
-					resource.TestCheckResourceAttr(resourceReference, "bucket", globalDeletedExternallyEPBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "bucket", appEndpointBucketName),
 				),
 			},
 		},
@@ -73,7 +75,7 @@ func TestAccAppEndpointDeletedExternally(t *testing.T) {
 // an App Endpoint is deleted outside of Terraform, the access_control_function
 // resource attached to it is gracefully removed from state during Read.
 func TestAccAppEndpointAccessControlFunctionDeletedExternally(t *testing.T) {
-	ensureFixtureBucketByName(t, globalACFDeletedExtEPBucketName)
+	ensureFixtureCollection(t, globalACFDeletedExtEPCollectionName)
 
 	epResourceName := randomStringWithPrefix("tf_acc_ep_acf_del_")
 	epReference := "couchbase-capella_app_endpoint." + epResourceName
@@ -85,12 +87,14 @@ func TestAccAppEndpointAccessControlFunctionDeletedExternally(t *testing.T) {
 	acfBody := "function(doc, oldDoc, meta) { channel(doc.channels); }"
 
 	cfgWithACF := testAccAppEndpointWithACFDeletedExternallyConfig(
-		epResourceName, epName, globalACFDeletedExtEPBucketName,
+		epResourceName, epName, globalACFDeletedExtEPCollectionName,
 		acfResourceName, acfBody,
 	)
-	cfgEndpointOnly := testAccAppEndpointDeletedExternallyConfig(epResourceName, epName, globalACFDeletedExtEPBucketName)
+	cfgEndpointOnly := testAccAppEndpointDeletedExternallyConfig(epResourceName, epName, globalACFDeletedExtEPCollectionName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	t.Parallel()
+	defer acquireAppEndpointCRUDSlot()()
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			// Step 1: Create App Endpoint + ACF resource.
@@ -134,7 +138,7 @@ func TestAccAppEndpointAccessControlFunctionDeletedExternally(t *testing.T) {
 // Config helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-func testAccAppEndpointDeletedExternallyConfig(resourceName, endpointName, bucketName string) string {
+func testAccAppEndpointDeletedExternallyConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -143,13 +147,13 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -161,13 +165,13 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 	)
 }
 
 func testAccAppEndpointWithACFDeletedExternallyConfig(
-	epResourceName, endpointName, bucketName string,
+	epResourceName, endpointName, collectionName string,
 	acfResourceName, acfBody string,
 ) string {
 	return fmt.Sprintf(`
@@ -178,13 +182,13 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	project_id      = "%[4]s"
 	cluster_id      = "%[5]s"
 	app_service_id  = "%[6]s"
-	bucket          = "%[7]s"
+	bucket          = "`+appEndpointBucketName+`"
 	name            = "%[8]s"
 
 	scopes = {
 		"_default" = {
 			collections = {
-				"_default" = {}
+				"%[7]s" = {}
 			}
 		}
 	}
@@ -196,6 +200,8 @@ resource "couchbase-capella_app_endpoint_access_control_function" "%[9]s" {
 	cluster_id              = "%[5]s"
 	app_service_id          = "%[6]s"
 	app_endpoint_name       = couchbase-capella_app_endpoint.%[2]s.name
+	scope                   = "_default"
+	collection              = "%[7]s"
 	access_control_function = "%[10]s"
 }
 `,
@@ -205,7 +211,7 @@ resource "couchbase-capella_app_endpoint_access_control_function" "%[9]s" {
 		globalProjectId,
 		appEndpointClusterId,
 		appEndpointAppServiceId,
-		bucketName,
+		collectionName,
 		endpointName,
 		acfResourceName,
 		acfBody,

--- a/acceptance_tests/app_endpoint_environment.go
+++ b/acceptance_tests/app_endpoint_environment.go
@@ -24,6 +24,28 @@ var appEndpointEnvironmentOnce struct {
 	err error
 }
 
+// appEndpointCRUDConcurrency bounds how many app_endpoint resource tests run
+// endpoint create/update/delete at once. Every app-endpoint test shares a
+// single app service, and each endpoint mutation forces a Sync Gateway
+// reconfiguration; running too many concurrently triggers transient HTTP 500s
+// ("internal server error", code 10000) on update/list. Bounding concurrency
+// keeps the suite mostly parallel while avoiding that contention. Tune if the
+// 500s persist (lower) or the suite is too slow (raise).
+const appEndpointCRUDConcurrency = 3
+
+var appEndpointCRUDSem = make(chan struct{}, appEndpointCRUDConcurrency)
+
+// acquireAppEndpointCRUDSlot blocks until an endpoint-CRUD slot is free and
+// returns a release function. Call it after t.Parallel() and after fixture
+// provisioning, deferring the returned release for the test body:
+//
+//	t.Parallel()
+//	defer acquireAppEndpointCRUDSlot()()
+func acquireAppEndpointCRUDSlot() func() {
+	appEndpointCRUDSem <- struct{}{}
+	return func() { <-appEndpointCRUDSem }
+}
+
 func ensureAppEndpointTestEnvironment(t *testing.T) {
 	t.Helper()
 

--- a/acceptance_tests/app_service.go
+++ b/acceptance_tests/app_service.go
@@ -14,14 +14,14 @@ import (
 )
 
 func createAppService(ctx context.Context, client *api.Client) error {
-	var n int64 = 2
+	var n int64 = 2	
 	appServiceRequest := appservice.CreateAppServiceRequest{
 		Name: globalAppServiceName,
 		Compute: appservice.AppServiceCompute{
 			Cpu: 2,
 			Ram: 4,
 		},
-		Nodes: &n,
+		Nodes:   &n,		
 	}
 
 	url := fmt.Sprintf(

--- a/acceptance_tests/appservice_acceptance_test.go
+++ b/acceptance_tests/appservice_acceptance_test.go
@@ -47,11 +47,12 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 	appServiceName := randomStringWithPrefix("tf_acc_app_svc_")
 	description := "terraform app service optional fields acceptance test"
 
+	const version = "4.0"
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, 2, 2, 4),
+				Config: testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, version, 2, 2, 4),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
@@ -61,10 +62,10 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.cpu", "2"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.ram", "4"),
+					resource.TestCheckResourceAttr(resourceReference, "version", version),
 					resource.TestCheckResourceAttrSet(resourceReference, "id"),
 					resource.TestCheckResourceAttrSet(resourceReference, "cluster_id"),
 					resource.TestCheckResourceAttrSet(resourceReference, "current_state"),
-					resource.TestCheckResourceAttrSet(resourceReference, "version"),
 					resource.TestCheckResourceAttrSet(resourceReference, "etag"),
 					resource.TestCheckResourceAttrSet(resourceReference, "audit.created_at"),
 					resource.TestCheckResourceAttrSet(resourceReference, "audit.modified_at"),
@@ -78,7 +79,7 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, 3, 4, 8),
+				Config: testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, version, 3, 4, 8),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
@@ -88,15 +89,20 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "cloud_provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.cpu", "4"),
 					resource.TestCheckResourceAttr(resourceReference, "compute.ram", "8"),
+					resource.TestCheckResourceAttr(resourceReference, "version", version),
 					resource.TestCheckResourceAttrSet(resourceReference, "id"),
 					resource.TestCheckResourceAttrSet(resourceReference, "cluster_id"),
 					resource.TestCheckResourceAttrSet(resourceReference, "current_state"),
-					resource.TestCheckResourceAttrSet(resourceReference, "version"),
 					resource.TestCheckResourceAttrSet(resourceReference, "etag"),
 					resource.TestCheckResourceAttrSet(resourceReference, "audit.created_at"),
 					resource.TestCheckResourceAttrSet(resourceReference, "audit.modified_at"),
 					resource.TestCheckResourceAttrSet(resourceReference, "audit.version"),
 				),
+			},
+			{
+				// Changing the major.minor version is not supported and must be rejected at apply time.
+				Config:      testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, "1.0", 3, 4, 8),
+				ExpectError: regexp.MustCompile(`(?s)version as this is not supported`),
 			},
 		},
 	})
@@ -207,7 +213,7 @@ resource "couchbase-capella_app_service" "%[4]s" {
 `, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, cidr)
 }
 
-func testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description string, nodes, cpu, ram int) string {
+func testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, version string, nodes, cpu, ram int) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -252,13 +258,14 @@ resource "couchbase-capella_app_service" "%[4]s" {
 	cluster_id      = couchbase-capella_cluster.%[5]s.id
 	name            = "%[7]s"
 	description     = "%[8]s"
+	version         = "%[12]s"
 	nodes           = %[9]d
 	compute = {
 		cpu = %[10]d
 		ram = %[11]d
 	}
 }
-`, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, cidr, appServiceName, description, nodes, cpu, ram)
+`, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, cidr, appServiceName, description, nodes, cpu, ram, version)
 }
 
 func testAccAppServiceResourceNameTooLongConfig(resourceName string) string {

--- a/acceptance_tests/audit_log_export_acceptance_test.go
+++ b/acceptance_tests/audit_log_export_acceptance_test.go
@@ -91,14 +91,55 @@ func TestAccAuditLogExportResource(t *testing.T) {
 // parse error in a "Could not parse start time" diagnostic.
 func TestAccAuditLogExportResourceInvalidStart(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_export_bad_start_")
-	_, end := auditLogExportWindow()
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAuditLogExportResourceConfig(resourceName, "not-a-timestamp", end),
-				ExpectError: regexp.MustCompile(`(?s)Could not parse start time`),
+				Config:      testAccAuditLogExportResourceInvalidStartConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)start must be a valid RFC3339 timestamp`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogExportResourceMissingStart(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_export_missing_start_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogExportResourceMissingStartConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)The argument "start" is required`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogExportResourceInvalidEnd(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_export_bad_end_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogExportResourceInvalidEndConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)end must be a valid RFC3339 timestamp`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogExportResourceEndBeforeStart(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_export_bad_window_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogExportResourceEndBeforeStartConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)end must not be earlier than start`),
 			},
 		},
 	})
@@ -131,6 +172,21 @@ resource "couchbase-capella_audit_log_export" "%[2]s" {
 	})
 }
 
+func TestAccAuditLogExportResourceEmptyClusterID(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_export_empty_cluster_")
+	start, end := auditLogExportWindow()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogExportResourceEmptyClusterConfig(resourceName, start, end),
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value.*Attribute cluster_id string length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
 func testAccAuditLogExportResourceConfig(resourceName, start, end string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -143,6 +199,75 @@ resource "couchbase-capella_audit_log_export" "%[2]s" {
   end             = "%[7]s"
 }
 `, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, start, end)
+}
+
+func testAccAuditLogExportResourceEmptyClusterConfig(resourceName, start, end string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_export" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = ""
+	start           = "%[3]s"
+	end             = "%[4]s"
+}
+`, globalProviderBlock, resourceName, start, end)
+}
+
+func testAccAuditLogExportResourceInvalidStartConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_export" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = "22222222-2222-2222-2222-222222222222"
+	start           = "not-a-date"
+	end             = "2026-05-02T00:00:00Z"
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogExportResourceMissingStartConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_export" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = "22222222-2222-2222-2222-222222222222"
+	end             = "2026-05-02T00:00:00Z"
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogExportResourceInvalidEndConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_export" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = "22222222-2222-2222-2222-222222222222"
+	start           = "2026-05-01T00:00:00Z"
+	end             = "not-a-date"
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogExportResourceEndBeforeStartConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_export" "%[2]s" {
+	organization_id = "00000000-0000-0000-0000-000000000000"
+	project_id      = "11111111-1111-1111-1111-111111111111"
+	cluster_id      = "22222222-2222-2222-2222-222222222222"
+	start           = "2026-05-02T00:00:00Z"
+	end             = "2026-05-01T00:00:00Z"
+}
+`, globalProviderBlock, resourceName)
 }
 
 func generateAuditLogExportImportIdForResource(resourceReference string) resource.ImportStateIdFunc {

--- a/acceptance_tests/audit_log_settings_acceptance_test.go
+++ b/acceptance_tests/audit_log_settings_acceptance_test.go
@@ -21,6 +21,7 @@ import (
 func TestAccAuditLogSettingsResource(t *testing.T) {
 	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_")
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_")
+	databaseCredentialName := randomStringWithPrefix("tf_acc_audit_db_credential_")
 	cidr := generateRandomCIDR()
 	clusterReference := "couchbase-capella_cluster." + clusterResourceName
 	resourceReference := "couchbase-capella_audit_log_settings." + resourceName
@@ -50,7 +51,12 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 				ImportStateVerifyIdentifierAttribute: "cluster_id",
 			},
 			{
-				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, true, []int{20488}),
+				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseClusterDatabaseCredentialAndDisabledUsers(clusterResourceName, resourceName, databaseCredentialName, cidr, true, []int{20488}, `[
+					{
+						domain = "local"
+						name   = "%[1]s"
+					}
+				]`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsAuditLogSettingsResource(t, resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
@@ -59,11 +65,15 @@ func TestAccAuditLogSettingsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
-					resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "0"),
+					resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceReference, "disabled_users.*", map[string]string{
+						"domain": "local",
+						"name":   databaseCredentialName,
+					}),
 				),
 			},
 			{
-				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, false, []int{20488}),
+				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseClusterDatabaseCredentialAndDisabledUsers(clusterResourceName, resourceName, databaseCredentialName, cidr, false, []int{20488}, "[]"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccExistsAuditLogSettingsResource(t, resourceReference),
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
@@ -103,6 +113,90 @@ resource "couchbase-capella_audit_log_settings" "%[2]s" {
 	})
 }
 
+func TestAccAuditLogSettingsResourceEmptyOrganizationID(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_empty_org_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceEmptyOrganizationIDConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)Attribute organization_id string length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogSettingsResourceEventIDWrongType(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_bad_event_id_type_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceEventIDWrongTypeConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)(Incorrect attribute value type|Invalid value for input variable|Invalid Attribute Value).*enabled_event_ids`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogSettingsResourceNegativeEventID(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_negative_event_id_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceNegativeEventIDConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)enabled_event_ids.*value must be at least 1`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogSettingsResourceDisabledUserEmptyDomain(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_empty_domain_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceDisabledUserEmptyDomainConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)Attribute.*disabled_users.*domain string\s+length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogSettingsResourceDisabledUserEmptyName(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_empty_name_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceDisabledUserEmptyNameConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)Attribute.*disabled_users.*name string\s+length must be at least 1, got: 0`),
+			},
+		},
+	})
+}
+
+func TestAccAuditLogSettingsResourceDisabledUserMissingName(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_missing_name_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAuditLogSettingsResourceDisabledUserMissingNameConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)(Missing required|Incorrect attribute value type|attribute).*disabled_users.*name.*required`),
+			},
+		},
+	})
+}
+
 func TestAccAuditLogSettingsResourcePlanUpgrade(t *testing.T) {
 	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_upgrade_")
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_upgrade_")
@@ -126,6 +220,113 @@ func TestAccAuditLogSettingsResourcePlanUpgrade(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccAuditLogSettingsResourceDisabledUserEmptyDomainConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = "00000000-0000-0000-0000-000000000000"
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = [20488]
+
+	disabled_users = [
+		{
+			domain = ""
+			name   = "audit-exempt-user"
+		}
+	]
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogSettingsResourceDisabledUserEmptyNameConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = "00000000-0000-0000-0000-000000000000"
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = [20488]
+
+	disabled_users = [
+		{
+			domain = "local"
+			name   = ""
+		}
+	]
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogSettingsResourceDisabledUserMissingNameConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = "00000000-0000-0000-0000-000000000000"
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = [20488]
+
+	disabled_users = [
+		{
+			domain = "local"
+		}
+	]
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogSettingsResourceEmptyOrganizationIDConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = ""
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = [20488]
+	disabled_users    = []
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogSettingsResourceEventIDWrongTypeConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = "00000000-0000-0000-0000-000000000000"
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = ["not-a-number"]
+	disabled_users    = []
+}
+`, globalProviderBlock, resourceName)
+}
+
+func testAccAuditLogSettingsResourceNegativeEventIDConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id   = "00000000-0000-0000-0000-000000000000"
+	project_id        = "11111111-1111-1111-1111-111111111111"
+	cluster_id        = "22222222-2222-2222-2222-222222222222"
+	audit_enabled     = true
+	enabled_event_ids = [-1]
+	disabled_users    = []
+}
+`, globalProviderBlock, resourceName)
 }
 
 func testAccAuditLogSettingsResourceConfigWithSupportPlan(clusterResourceName, auditSettingsResourceName, cidr, plan string, auditEnabled bool, enabledEventIDs []int) string {
@@ -192,6 +393,41 @@ resource "couchbase-capella_audit_log_settings" "%[6]s" {
 }
 
 func testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, auditSettingsResourceName, cidr string, auditEnabled bool, enabledEventIDs []int) string {
+	return testAccAuditLogSettingsResourceConfigWithEnterpriseClusterAndDisabledUsers(clusterResourceName, auditSettingsResourceName, cidr, auditEnabled, enabledEventIDs, "[]", "", "")
+}
+
+func testAccAuditLogSettingsResourceConfigWithEnterpriseClusterDatabaseCredentialAndDisabledUsers(clusterResourceName, auditSettingsResourceName, databaseCredentialName, cidr string, auditEnabled bool, enabledEventIDs []int, disabledUsers string) string {
+	databaseCredentialResource := fmt.Sprintf(`
+resource "couchbase-capella_database_credential" "%[1]s" {
+	name            = "%[1]s"
+	organization_id = "%[2]s"
+	project_id      = "%[3]s"
+	cluster_id      = couchbase-capella_cluster.%[4]s.id
+	access = [
+		{
+			privileges = ["data_writer"]
+		},
+	]
+}
+`, databaseCredentialName, globalOrgId, globalProjectId, clusterResourceName)
+	formattedDisabledUsers := disabledUsers
+	if disabledUsers != "[]" {
+		formattedDisabledUsers = fmt.Sprintf(disabledUsers, databaseCredentialName)
+	}
+
+	return testAccAuditLogSettingsResourceConfigWithEnterpriseClusterAndDisabledUsers(
+		clusterResourceName,
+		auditSettingsResourceName,
+		cidr,
+		auditEnabled,
+		enabledEventIDs,
+		formattedDisabledUsers,
+		databaseCredentialName,
+		databaseCredentialResource,
+	)
+}
+
+func testAccAuditLogSettingsResourceConfigWithEnterpriseClusterAndDisabledUsers(clusterResourceName, auditSettingsResourceName, cidr string, auditEnabled bool, enabledEventIDs []int, disabledUsers, databaseCredentialName, databaseCredentialResource string) string {
 	ids := "["
 	for i, id := range enabledEventIDs {
 		if i > 0 {
@@ -200,6 +436,13 @@ func testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceN
 		ids += fmt.Sprintf("%d", id)
 	}
 	ids += "]"
+
+	dependsOn := ""
+	if databaseCredentialResource != "" {
+		dependsOn = fmt.Sprintf(`
+
+	depends_on = [couchbase-capella_database_credential.%[1]s]`, databaseCredentialName)
+	}
 
 	return fmt.Sprintf(`
 %[1]s
@@ -243,15 +486,18 @@ resource "couchbase-capella_cluster" "%[2]s" {
 	}
 }
 
+%[10]s
+
 resource "couchbase-capella_audit_log_settings" "%[6]s" {
 	organization_id   = "%[3]s"
 	project_id        = "%[4]s"
 	cluster_id        = couchbase-capella_cluster.%[2]s.id
 	audit_enabled     = %[7]t
 	enabled_event_ids = %[8]s
-	disabled_users    = []
+	disabled_users    = %[9]s
+%[11]s
 }
-`, globalProviderBlock, clusterResourceName, globalOrgId, globalProjectId, cidr, auditSettingsResourceName, auditEnabled, ids)
+`, globalProviderBlock, clusterResourceName, globalOrgId, globalProjectId, cidr, auditSettingsResourceName, auditEnabled, ids, disabledUsers, databaseCredentialResource, dependsOn)
 }
 
 func generateAuditLogSettingsImportIdForResource(resourceReference string) resource.ImportStateIdFunc {

--- a/acceptance_tests/backup_schedule_acceptance_test.go
+++ b/acceptance_tests/backup_schedule_acceptance_test.go
@@ -76,7 +76,7 @@ func TestAccBackupScheduleResourceInvalidDayOfWeek(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "funday", 10, 4, "30days", false),
-				ExpectError: regexp.MustCompile("There is an error during backup schedule creation"),
+				ExpectError: regexp.MustCompile("day_of_week value must be one of"),
 			},
 		},
 	})
@@ -90,7 +90,7 @@ func TestAccBackupScheduleResourceInvalidRetention(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "sunday", 10, 4, "9999days", false),
-				ExpectError: regexp.MustCompile("There is an error during backup schedule creation"),
+				ExpectError: regexp.MustCompile("retention_time value must be one of"),
 			},
 		},
 	})
@@ -118,7 +118,21 @@ func TestAccBackupScheduleResourceInvalidStartAt(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "sunday", 99, 4, "30days", false),
-				ExpectError: regexp.MustCompile("There is an error during backup schedule creation"),
+				ExpectError: regexp.MustCompile("start_at value must be one of"),
+			},
+		},
+	})
+}
+
+func TestAccBackupScheduleResourceInvalidIncrementalEvery(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_backup_schedule_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBackupScheduleResourceConfig(resourceName, "weekly", "sunday", 10, 3, "30days", false),
+				ExpectError: regexp.MustCompile("incremental_every value must be one of"),
 			},
 		},
 	})

--- a/acceptance_tests/certificate_datasource_test.go
+++ b/acceptance_tests/certificate_datasource_test.go
@@ -1,0 +1,64 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDatasourceCertificate(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_certificate_ds_")
+	dsReference := "data.couchbase-capella_certificate." + dsName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateDatasourceConfig(dsName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(dsReference, "data.#", "1"),
+					resource.TestCheckResourceAttrSet(dsReference, "data.0.certificate"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceCertificateInvalidCluster(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_certificate_ds_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_certificate" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "00000000-0000-0000-0000-000000000000"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId),
+				ExpectError: regexp.MustCompile(`(?s)Error Reading Capella Certificate.*"httpStatusCode":(403|404)`),
+			},
+		},
+	})
+}
+
+func testAccCertificateDatasourceConfig(dsName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_certificate" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId, globalClusterId)
+}

--- a/acceptance_tests/cloud_snapshot_restore_datasource_test.go
+++ b/acceptance_tests/cloud_snapshot_restore_datasource_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestAccDatasourceCloudSnapshotRestores(t *testing.T) {
+	t.Parallel()
+	cloudSnapshotRestoreMu.Lock()
+	defer cloudSnapshotRestoreMu.Unlock()
+
 	clusterID, err := ensureSnapshotCluster()
 	if err != nil {
 		t.Fatalf("ensureSnapshotCluster: %v", err)
@@ -17,7 +21,7 @@ func TestAccDatasourceCloudSnapshotRestores(t *testing.T) {
 	dsName := randomStringWithPrefix("tf_acc_cloud_snapshot_restores_ds_")
 	dsReference := "data.couchbase-capella_cloud_snapshot_restores." + dsName
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			// Step 1: create snapshot backup (no restore yet).
@@ -41,6 +45,10 @@ func TestAccDatasourceCloudSnapshotRestores(t *testing.T) {
 }
 
 func TestAccDatasourceCloudSnapshotRestore(t *testing.T) {
+	t.Parallel()
+	cloudSnapshotRestoreMu.Lock()
+	defer cloudSnapshotRestoreMu.Unlock()
+
 	clusterID, err := ensureSnapshotCluster()
 	if err != nil {
 		t.Fatalf("ensureSnapshotCluster: %v", err)
@@ -50,7 +58,7 @@ func TestAccDatasourceCloudSnapshotRestore(t *testing.T) {
 	singleDsName := randomStringWithPrefix("tf_acc_cloud_snapshot_restore_ds_")
 	singleDsReference := "data.couchbase-capella_cloud_snapshot_restore." + singleDsName
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{

--- a/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
+++ b/acceptance_tests/cluster_onoff_schedule_acceptance_test.go
@@ -81,7 +81,26 @@ func TestAccClusterOnOffScheduleResourceInvalidTimezone(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccClusterOnOffScheduleResourceConfig(resourceName, "Mars/Olympus"),
-				ExpectError: regexp.MustCompile(`(?s)timezone|invalid value|Validation Error`),
+				ExpectError: regexp.MustCompile(`timezone value must be one of`),
+			},
+		},
+	})
+}
+
+// TestAccClusterOnOffScheduleEmptyTimezone verifies that an empty timezone is
+// rejected by local config validation at terraform validate. The timezone enum
+// validator is attached automatically by the schema builder from the OpenAPI
+// spec (no hand-coded list), so this also exercises the generator's handling of
+// $ref-to-named-enum properties.
+func TestAccClusterOnOffScheduleEmptyTimezone(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_cluster_onoff_schedule_empty_tz_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccClusterOnOffScheduleResourceConfig(resourceName, ""),
+				ExpectError: regexp.MustCompile(`timezone value must be one of`),
 			},
 		},
 	})

--- a/acceptance_tests/data_management_acceptance_test.go
+++ b/acceptance_tests/data_management_acceptance_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccBucketResourceRequiredOnly(t *testing.T) {
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_req_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -48,6 +49,7 @@ func TestAccBucketResourceRequiredOnly(t *testing.T) {
 }
 
 func TestAccBucketResourceAllOptionalFields(t *testing.T) {
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_full_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -78,6 +80,7 @@ func TestAccBucketResourceAllOptionalFields(t *testing.T) {
 }
 
 func TestAccBucketResourceUpdate(t *testing.T) {
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_upd_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -111,6 +114,7 @@ func TestAccBucketResourceUpdate(t *testing.T) {
 }
 
 func TestAccBucketResourceEphemeralType(t *testing.T) {
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_eph_")
 	resourceReference := "couchbase-capella_bucket." + resourceName
 
@@ -153,6 +157,7 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccBucketResourceInvalidProject(t *testing.T) {
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_bad_project_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -176,6 +181,7 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccBucketResourceInvalidDurabilityLevel(t *testing.T) {
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_bad_dur_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -200,6 +206,7 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccBucketResourceInvalidReplicaCount(t *testing.T) {
+	requireDMCluster(t)
 	resourceName := randomStringWithPrefix("tf_acc_bkt_bad_rep_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -224,6 +231,7 @@ resource "couchbase-capella_bucket" "%[2]s" {
 }
 
 func TestAccScopeResource(t *testing.T) {
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_scope_bkt_")
 	scopeName := randomStringWithPrefix("tf_acc_scope_")
 	bucketReference := "couchbase-capella_bucket." + bucketName
@@ -254,6 +262,7 @@ func TestAccScopeResource(t *testing.T) {
 }
 
 func TestAccScopeResourceInvalidBucket(t *testing.T) {
+	requireDMCluster(t)
 	scopeName := randomStringWithPrefix("tf_acc_scope_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -278,6 +287,7 @@ resource "couchbase-capella_scope" "%[2]s" {
 }
 
 func TestAccScopeResourceInvalidCluster(t *testing.T) {
+	requireDMCluster(t)
 	scopeName := randomStringWithPrefix("tf_acc_scope_bad_cluster_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -302,6 +312,7 @@ resource "couchbase-capella_scope" "%[2]s" {
 }
 
 func TestAccCollectionResourceNoTTL(t *testing.T) {
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_coll_bkt_nottl_")
 	scopeName := randomStringWithPrefix("tf_acc_coll_scope_nottl_")
 	collName := randomStringWithPrefix("tf_acc_coll_nottl_")
@@ -333,6 +344,7 @@ func TestAccCollectionResourceNoTTL(t *testing.T) {
 }
 
 func TestAccCollectionResourceWithTTL(t *testing.T) {
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_coll_bkt_ttl_")
 	scopeName := randomStringWithPrefix("tf_acc_coll_scope_ttl_")
 	collName := randomStringWithPrefix("tf_acc_coll_ttl_")
@@ -370,6 +382,7 @@ func TestAccCollectionResourceWithTTL(t *testing.T) {
 }
 
 func TestAccCollectionResourceInvalidScope(t *testing.T) {
+	requireDMCluster(t)
 	collName := randomStringWithPrefix("tf_acc_coll_bad_scope_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -384,6 +397,7 @@ func TestAccCollectionResourceInvalidScope(t *testing.T) {
 }
 
 func TestAccCollectionResourceInvalidBucket(t *testing.T) {
+	requireDMCluster(t)
 	collName := randomStringWithPrefix("tf_acc_coll_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -410,6 +424,7 @@ resource "couchbase-capella_collection" "%[2]s" {
 
 // AV-132307: API accepts negative max_ttl; restore ExpectError once fixed.
 func TestAccCollectionResourceNegativeTTL(t *testing.T) {
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_coll_neg_ttl_bkt_")
 	scopeName := randomStringWithPrefix("tf_acc_coll_neg_ttl_scope_")
 	collName := randomStringWithPrefix("tf_acc_coll_neg_ttl_")
@@ -430,6 +445,7 @@ func TestAccCollectionResourceNegativeTTL(t *testing.T) {
 }
 
 func TestAccFlushBucketResource(t *testing.T) {
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_flush_bkt_")
 	flushName := randomStringWithPrefix("tf_acc_flush_")
 	bucketReference := "couchbase-capella_bucket." + bucketName
@@ -452,6 +468,7 @@ func TestAccFlushBucketResource(t *testing.T) {
 }
 
 func TestAccFlushBucketResourceFlushDisabled(t *testing.T) {
+	requireDMCluster(t)
 	bucketName := randomStringWithPrefix("tf_acc_flush_disabled_bkt_")
 	flushName := randomStringWithPrefix("tf_acc_flush_disabled_")
 
@@ -467,6 +484,7 @@ func TestAccFlushBucketResourceFlushDisabled(t *testing.T) {
 }
 
 func TestAccFlushBucketResourceInvalidBucket(t *testing.T) {
+	requireDMCluster(t)
 	flushName := randomStringWithPrefix("tf_acc_flush_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -490,6 +508,7 @@ resource "couchbase-capella_flush" "%[2]s" {
 }
 
 func TestAccDatasourceBuckets(t *testing.T) {
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_buckets_")
 	dsReference := "data.couchbase-capella_buckets." + dsName
 
@@ -535,6 +554,7 @@ data "couchbase-capella_buckets" "%[2]s" {
 }
 
 func TestAccDatasourceScopes(t *testing.T) {
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_scopes_")
 	dsReference := "data.couchbase-capella_scopes." + dsName
 
@@ -557,6 +577,7 @@ func TestAccDatasourceScopes(t *testing.T) {
 }
 
 func TestAccDatasourceScopesInvalidBucket(t *testing.T) {
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_scopes_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -580,6 +601,7 @@ data "couchbase-capella_scopes" "%[2]s" {
 }
 
 func TestAccDatasourceCollections(t *testing.T) {
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_collections_")
 	dsReference := "data.couchbase-capella_collections." + dsName
 
@@ -604,6 +626,7 @@ func TestAccDatasourceCollections(t *testing.T) {
 }
 
 func TestAccDatasourceCollectionsInvalidScope(t *testing.T) {
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_collections_bad_scope_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -628,6 +651,7 @@ data "couchbase-capella_collections" "%[2]s" {
 }
 
 func TestAccDatasourceCollectionsInvalidBucket(t *testing.T) {
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_collections_bad_bkt_")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -652,6 +676,7 @@ data "couchbase-capella_collections" "%[2]s" {
 }
 
 func TestAccDatasourceSampleBuckets(t *testing.T) {
+	requireDMCluster(t)
 	dsName := randomStringWithPrefix("tf_acc_ds_sample_buckets_")
 	dsReference := "data.couchbase-capella_sample_buckets." + dsName
 

--- a/acceptance_tests/dm_setup.go
+++ b/acceptance_tests/dm_setup.go
@@ -1,0 +1,54 @@
+package acceptance_tests
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+)
+
+var (
+	dmClusterOnce sync.Once
+	dmClusterErr  error
+)
+
+// requireDMCluster ensures the data-management cluster is provisioned, failing
+// the test if provisioning errored. DM tests call this before building their
+// config so dmClusterId/dmBucketId are populated.
+func requireDMCluster(t *testing.T) {
+	t.Helper()
+	if err := ensureDMCluster(); err != nil {
+		t.Fatalf("ensureDMCluster: %v", err)
+	}
+}
+
+// ensureDMCluster lazily provisions the dedicated data-management cluster (and
+// its bucket) used by the data_management_* acceptance tests. It is built on
+// first call from the first DM test that runs and reused thereafter, so runs
+// that exercise no DM tests don't pay the cluster-creation cost. cleanup()
+// tears it down via the dmClusterCreated/dmBucketCreated flags.
+func ensureDMCluster() error {
+	dmClusterOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Minute)
+		defer cancel()
+		client := api.NewClient(timeout)
+
+		if err := setupDMCluster(ctx, client); err != nil {
+			dmClusterErr = err
+			return
+		}
+		if err := resolveDMBucket(ctx, client); err != nil {
+			dmClusterErr = err
+			return
+		}
+		// Bucket creation triggers a rebalance; wait for the cluster to return
+		// to Healthy before dependent resources are created.
+		if err := dmClusterWait(ctx, client, false); err != nil {
+			dmClusterErr = err
+			return
+		}
+	})
+	return dmClusterErr
+}

--- a/acceptance_tests/endpoint_setup.go
+++ b/acceptance_tests/endpoint_setup.go
@@ -16,48 +16,49 @@ import (
 	bucketapi "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/bucket"
 )
 
-// fixtBucketState holds a once-and-error pair for a single pre-created bucket.
-type fixtBucketState struct {
-	once    sync.Once
-	err     error
-	created bool // true only if this test process created the bucket
+// fixtCollectionState holds a once-and-error pair for a single pre-created
+// collection in the shared app-endpoint bucket.
+type fixtCollectionState struct {
+	once sync.Once
+	err  error
 }
 
 var (
-	fixtBucketMu     sync.Mutex
-	fixtBucketStates = map[string]*fixtBucketState{}
+	fixtCollectionMu     sync.Mutex
+	fixtCollectionStates = map[string]*fixtCollectionState{}
 )
 
-// ensureFixtureBucketByName creates the named bucket exactly once per test
-// process. Safe to call from parallel tests.
-func ensureFixtureBucketByName(t *testing.T, name string) {
+// ensureFixtureCollection creates the named collection in the shared
+// app-endpoint bucket's _default scope exactly once per test process. App
+// endpoint resource tests use one collection each instead of a dedicated
+// bucket: Capella allows only one endpoint per bucket/scope/collection, and a
+// cluster's bucket cap (1 per 0.2 cores) is far smaller than its collection
+// cap. Sharing the bucket keeps parallel tests well under the bucket limit that
+// previously caused flaky "maximum number of buckets reached" failures.
+//
+// The collection lives in the shared bucket and is torn down with it at the end
+// of the suite, so no per-test cleanup is registered. Safe to call from
+// parallel tests.
+func ensureFixtureCollection(t *testing.T, name string) {
 	t.Helper()
 	ensureAppEndpointTestEnvironment(t)
-	fixtBucketMu.Lock()
-	state, ok := fixtBucketStates[name]
+	fixtCollectionMu.Lock()
+	state, ok := fixtCollectionStates[name]
 	if !ok {
-		state = &fixtBucketState{}
-		fixtBucketStates[name] = state
+		state = &fixtCollectionState{}
+		fixtCollectionStates[name] = state
 	}
-	// Unlock immediately — the mutex only guards the map. Bucket creation is
-	// serialised per-name by state.once (sync.Once), so parallel tests for
-	// different buckets are not blocked behind each other.
-	fixtBucketMu.Unlock()
+	// Unlock immediately — the mutex only guards the map. Collection creation is
+	// serialised per-name by state.once, so parallel tests for different
+	// collections are not blocked behind each other.
+	fixtCollectionMu.Unlock()
 
 	state.once.Do(func() {
 		ctx := context.Background()
-		state.created, state.err = createFixtureBucket(ctx, globalClient, name)
+		state.err = createFixtureCollection(ctx, globalClient, appEndpointBucketId, globalScopeName, name)
 	})
 	if state.err != nil {
-		t.Fatalf("failed to provision test bucket %s: %v", name, state.err)
-	}
-
-	if state.created {
-		t.Cleanup(func() {
-			if err := deleteAppEndpointFixtureBucket(context.Background(), globalClient, globalProjectId, appEndpointClusterId, name); err != nil {
-				t.Logf("warning: failed to delete fixture bucket %q: %v", name, err)
-			}
-		})
+		t.Fatalf("failed to provision test collection %s: %v", name, state.err)
 	}
 }
 
@@ -156,6 +157,76 @@ func createFixtureBucket(ctx context.Context, client *api.Client, name string) (
 	}
 
 	return true, waitForFixtureBucket(ctx, client, bucketResp.Id)
+}
+
+// createFixtureCollection creates the named collection in the given scope of the
+// shared bucket if it does not already exist, then waits until it is listable.
+func createFixtureCollection(ctx context.Context, client *api.Client, bucketID, scope, name string) error {
+	collectionsUrl := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/buckets/%s/scopes/%s/collections",
+		globalHost, globalOrgId, globalProjectId, appEndpointClusterId, bucketID, scope)
+
+	exists, err := fixtureCollectionExists(ctx, client, collectionsUrl, name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		log.Printf("fixture collection %q already exists", name)
+		return nil
+	}
+
+	createCfg := api.EndpointCfg{Url: collectionsUrl, Method: http.MethodPost, SuccessStatus: http.StatusCreated}
+	if _, err = client.ExecuteWithRetry(ctx, createCfg, api.CreateCollectionRequest{Name: name}, globalToken, nil); err != nil {
+		return fmt.Errorf("creating fixture collection %q: %w", name, err)
+	}
+
+	return waitForFixtureCollection(ctx, client, collectionsUrl, name)
+}
+
+// fixtureCollectionExists reports whether a collection with the given name is
+// present at the collections list endpoint.
+func fixtureCollectionExists(ctx context.Context, client *api.Client, collectionsUrl, name string) (bool, error) {
+	listCfg := api.EndpointCfg{Url: collectionsUrl, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := client.ExecuteWithRetry(ctx, listCfg, nil, globalToken, nil)
+	if err != nil {
+		return false, fmt.Errorf("listing collections for %q: %w", name, err)
+	}
+
+	var collections api.GetCollectionsResponse
+	if err = json.Unmarshal(response.Body, &collections); err != nil {
+		return false, fmt.Errorf("unmarshalling collections list for %q: %w", name, err)
+	}
+	for _, c := range collections.Data {
+		if c.Name != nil && *c.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// waitForFixtureCollection polls until the collection is listable. App endpoint
+// creation rejects a collection that is not yet visible ("Collection Not
+// Found"), so fixtures wait for it before pointing endpoints at it.
+func waitForFixtureCollection(ctx context.Context, client *api.Client, collectionsUrl, name string) error {
+	const maxWait = 2 * time.Minute
+	deadline := time.Now().Add(maxWait)
+
+	for {
+		exists, err := fixtureCollectionExists(ctx, client, collectionsUrl, name)
+		if err == nil && exists {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return fmt.Errorf("timeout waiting for fixture collection %q: %w", name, err)
+			}
+			return fmt.Errorf("timeout waiting for fixture collection %q to become listable", name)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context done waiting for fixture collection %q: %w", name, ctx.Err())
+		case <-time.After(5 * time.Second):
+		}
+	}
 }
 
 // deleteBucketWithRetry retries the bucket DELETE on 412 (App Service not yet

--- a/acceptance_tests/globals.go
+++ b/acceptance_tests/globals.go
@@ -79,35 +79,39 @@ var (
 	appEndpointLoggingEndpointName    = "tf_acc_test_logging_endpoint"
 	appEndpointLoggingBucketName      = "tf_acc_logging_bkt"
 
-	// Fixture buckets for app_endpoint resource tests. Each test gets its
-	// own bucket because Capella only permits one endpoint per bucket/scope/collection.
-	// These buckets are not created or managed by Terraform; instead, test helpers
-	// manage their lifecycle through the API during test runs, including cleanup
-	// when needed.
-	globalEPBucketName                   = "tf_acc_ep_bkt"
-	globalNoCorsEPBucketName             = "tf_acc_ep_nocors_bkt"
-	globalCorsFullEPBucketName           = "tf_acc_ep_cors_full_bkt"
-	globalCorsSpecificEPBucketName       = "tf_acc_ep_cors_spec_bkt"
-	globalCorsMaxAge0EPBucketName        = "tf_acc_ep_cors_ma0_bkt"
-	globalOIDCFullEPBucketName           = "tf_acc_ep_oidc_full_bkt"
-	globalOIDCDiscEPBucketName           = "tf_acc_ep_oidc_disc_bkt"
-	globalCorsExpandEPBucketName         = "tf_acc_ep_cors_exp_bkt"
-	globalCorsWildEPBucketName           = "tf_acc_ep_cors_wld_bkt"
-	globalAddOIDCEPBucketName            = "tf_acc_ep_add_oidc_bkt"
-	globalACFUpdateEPBucketName          = "tf_acc_ep_acf_bkt"
-	globalCorsMaxAgeZeroEPBucketName     = "tf_acc_ep_maz_bkt"
-	globalCorsMaxAgeFromZeroEPBucketName = "tf_acc_ep_mafz_bkt"
-	// Buckets for "deleted externally" tests — validates the 403 → List fallback
+	// Fixture collections for app_endpoint resource tests. Each test gets its
+	// own collection in the shared appEndpointBucketName bucket (under the
+	// _default scope) rather than a dedicated bucket: Capella permits only one
+	// endpoint per bucket/scope/collection, and a cluster's bucket cap (1 per
+	// 0.2 cores, so 20 here) is far smaller than its collection cap. Sharing the
+	// bucket keeps parallel runs well under the bucket limit that previously
+	// caused flaky "maximum number of buckets reached" failures. These
+	// collections are created via the API by ensureFixtureCollection and torn
+	// down with the shared bucket at the end of the suite.
+	globalEPCollectionName                   = "tf_acc_ep_col"
+	globalNoCorsEPCollectionName             = "tf_acc_ep_nocors_col"
+	globalCorsFullEPCollectionName           = "tf_acc_ep_cors_full_col"
+	globalCorsSpecificEPCollectionName       = "tf_acc_ep_cors_spec_col"
+	globalCorsMaxAge0EPCollectionName        = "tf_acc_ep_cors_ma0_col"
+	globalOIDCFullEPCollectionName           = "tf_acc_ep_oidc_full_col"
+	globalOIDCDiscEPCollectionName           = "tf_acc_ep_oidc_disc_col"
+	globalCorsExpandEPCollectionName         = "tf_acc_ep_cors_exp_col"
+	globalCorsWildEPCollectionName           = "tf_acc_ep_cors_wld_col"
+	globalAddOIDCEPCollectionName            = "tf_acc_ep_add_oidc_col"
+	globalACFUpdateEPCollectionName          = "tf_acc_ep_acf_col"
+	globalCorsMaxAgeZeroEPCollectionName     = "tf_acc_ep_maz_col"
+	globalCorsMaxAgeFromZeroEPCollectionName = "tf_acc_ep_mafz_col"
+	// Collections for "deleted externally" tests — validates the 403 → List fallback
 	// that removes resources from state when the App Endpoint is deleted outside TF.
-	globalDeletedExternallyEPBucketName = "tf_acc_ep_del_ext_bkt"
-	globalACFDeletedExtEPBucketName     = "tf_acc_ep_acf_dex_bkt"
-	// Buckets for currently-skipped tests — not provisioned while skipped, but
-	// named so the tests are ready to run once the underlying bugs are fixed.
-	globalCorsDisabledFalseEPBucketName = "tf_acc_ep_cors_df_bkt"
-	globalMultipleOIDCEPBucketName      = "tf_acc_ep_moidc_bkt"
-	globalRemoveCorsEPBucketName        = "tf_acc_ep_rmcors_bkt"
-	globalCorsDisableToggleEPBucketName = "tf_acc_ep_cdtgl_bkt"
-	globalRemoveOIDCEPBucketName        = "tf_acc_ep_rmoidc_bkt"
+	globalDeletedExternallyEPCollectionName = "tf_acc_ep_del_ext_col"
+	globalACFDeletedExtEPCollectionName     = "tf_acc_ep_acf_dex_col"
+	// Collections for currently-skipped tests — not provisioned while skipped, but
+	// named so the tests are ready to run once the underlying bugs are fixed. 
+	globalCorsDisabledFalseEPCollectionName = "tf_acc_ep_cors_df_col"
+	globalMultipleOIDCEPCollectionName      = "tf_acc_ep_moidc_col"
+	globalRemoveCorsEPCollectionName        = "tf_acc_ep_rmcors_col"
+	globalCorsDisableToggleEPCollectionName = "tf_acc_ep_cdtgl_col"
+	globalRemoveOIDCEPCollectionName        = "tf_acc_ep_rmoidc_col"
 	// TestAccAppEndpointInexistentCollection reuses globalBucketName: it tries
 	// _default/INVALID_COLLECTION which does not conflict with the common
 	// endpoint on _default/_default, so no dedicated bucket is needed.

--- a/acceptance_tests/globals.go
+++ b/acceptance_tests/globals.go
@@ -97,6 +97,10 @@ var (
 	globalACFUpdateEPBucketName          = "tf_acc_ep_acf_bkt"
 	globalCorsMaxAgeZeroEPBucketName     = "tf_acc_ep_maz_bkt"
 	globalCorsMaxAgeFromZeroEPBucketName = "tf_acc_ep_mafz_bkt"
+	// Buckets for "deleted externally" tests — validates the 403 → List fallback
+	// that removes resources from state when the App Endpoint is deleted outside TF.
+	globalDeletedExternallyEPBucketName = "tf_acc_ep_del_ext_bkt"
+	globalACFDeletedExtEPBucketName     = "tf_acc_ep_acf_dex_bkt"
 	// Buckets for currently-skipped tests — not provisioned while skipped, but
 	// named so the tests are ready to run once the underlying bugs are fixed.
 	globalCorsDisabledFalseEPBucketName = "tf_acc_ep_cors_df_bkt"

--- a/acceptance_tests/network_peer_acceptance_test.go
+++ b/acceptance_tests/network_peer_acceptance_test.go
@@ -1,0 +1,48 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccNetworkPeerInvalidProviderType verifies that the network peer resource rejects an
+// unsupported provider_type at plan time. The OneOf("aws", "gcp", "azure") validator fires
+// before any API call, so dummy org/project/cluster IDs are sufficient.
+func TestAccNetworkPeerInvalidProviderType(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_network_peer_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNetworkPeerInvalidProviderTypeConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)provider_type.*value must be one of.*aws.*gcp.*azure`),
+			},
+		},
+	})
+}
+
+func testAccNetworkPeerInvalidProviderTypeConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_network_peer" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  cluster_id      = "22222222-2222-2222-2222-222222222222"
+  name            = "qe-invalid-provider-type"
+  provider_type   = "ibm"
+  provider_config = {
+    aws_config = {
+      account_id = "123456789012"
+      vpc_id     = "vpc-1234567890abcdef0"
+      cidr       = "10.10.0.0/16"
+      region     = "us-east-1"
+    }
+  }
+}
+`, globalProviderBlock, resourceName)
+}

--- a/acceptance_tests/private_endpoint_acceptance_test.go
+++ b/acceptance_tests/private_endpoint_acceptance_test.go
@@ -174,3 +174,33 @@ data "couchbase-capella_private_endpoints" "%[3]s" {
 }
 `, globalProviderBlock, serviceResourceName, dataSourceName, globalOrgId, globalProjectId, globalClusterId)
 }
+
+// TestAccPrivateEndpointsInvalidEndpointID verifies that the private endpoints resource rejects
+// an empty endpoint_id at plan time. The LengthAtLeast(1) validator fires before any API call,
+// so dummy org/project/cluster IDs are sufficient.
+func TestAccPrivateEndpointsInvalidEndpointID(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_private_endpoints_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPrivateEndpointsInvalidEndpointIDConfig(resourceName),
+				ExpectError: regexp.MustCompile(`(?s)endpoint_id.*string length must be at least 1`),
+			},
+		},
+	})
+}
+
+func testAccPrivateEndpointsInvalidEndpointIDConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_private_endpoints" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  cluster_id      = "22222222-2222-2222-2222-222222222222"
+  endpoint_id     = ""
+}
+`, globalProviderBlock, resourceName)
+}

--- a/acceptance_tests/private_endpoint_acceptance_test.go
+++ b/acceptance_tests/private_endpoint_acceptance_test.go
@@ -2,6 +2,7 @@ package acceptance_tests
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -42,6 +43,100 @@ func TestAccPrivateEndpointServiceEnableDisable(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccAWSPrivateEndpointCommandInvalidVPCID verifies that the AWS private endpoint
+// command data source rejects a vpc_id shorter than the OpenAPI minimum length at plan
+// time. The generated LengthBetween(12, 21) validator fires before any API call, so dummy
+// org/project/cluster IDs are sufficient.
+func TestAccAWSPrivateEndpointCommandInvalidVPCID(t *testing.T) {
+	dataSourceName := randomStringWithPrefix("tf_acc_aws_pe_command_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSPrivateEndpointCommandInvalidVPCIDConfig(dataSourceName),
+				ExpectError: regexp.MustCompile(`(?s)vpc_id.*string length must be between 12 and 21`),
+			},
+		},
+	})
+}
+
+func testAccAWSPrivateEndpointCommandInvalidVPCIDConfig(dataSourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_aws_private_endpoint_command" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  cluster_id      = "22222222-2222-2222-2222-222222222222"
+  vpc_id          = "vpc-short"
+  subnet_ids      = ["subnet-1234567890abcdef0"]
+}
+`, globalProviderBlock, dataSourceName)
+}
+
+// TestAccAzurePrivateEndpointCommandInvalidVirtualNetwork verifies that the Azure private
+// endpoint command data source rejects a virtual_network shorter than the OpenAPI minimum
+// length at plan time. The generated LengthBetween(2, 64) validator fires before any API call.
+func TestAccAzurePrivateEndpointCommandInvalidVirtualNetwork(t *testing.T) {
+	dataSourceName := randomStringWithPrefix("tf_acc_azure_pe_command_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAzurePrivateEndpointCommandInvalidVirtualNetworkConfig(dataSourceName),
+				ExpectError: regexp.MustCompile(`(?s)virtual_network.*string length must be between 2 and 64`),
+			},
+		},
+	})
+}
+
+func testAccAzurePrivateEndpointCommandInvalidVirtualNetworkConfig(dataSourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_azure_private_endpoint_command" "%[2]s" {
+  organization_id     = "00000000-0000-0000-0000-000000000000"
+  project_id          = "11111111-1111-1111-1111-111111111111"
+  cluster_id          = "22222222-2222-2222-2222-222222222222"
+  resource_group_name = "my-resource-group"
+  virtual_network     = "a"
+}
+`, globalProviderBlock, dataSourceName)
+}
+
+// TestAccGCPPrivateEndpointCommandInvalidVPCNetworkID verifies that the GCP private endpoint
+// command data source rejects a vpc_network_id shorter than the OpenAPI minimum length at
+// plan time. The generated LengthBetween(12, 21) validator fires before any API call.
+func TestAccGCPPrivateEndpointCommandInvalidVPCNetworkID(t *testing.T) {
+	dataSourceName := randomStringWithPrefix("tf_acc_gcp_pe_command_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccGCPPrivateEndpointCommandInvalidVPCNetworkIDConfig(dataSourceName),
+				ExpectError: regexp.MustCompile(`(?s)vpc_network_id.*string length must be between 12 and 21`),
+			},
+		},
+	})
+}
+
+func testAccGCPPrivateEndpointCommandInvalidVPCNetworkIDConfig(dataSourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_gcp_private_endpoint_command" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  cluster_id      = "22222222-2222-2222-2222-222222222222"
+  vpc_network_id  = "vpc-short"
+  subnet_ids      = ["subnet-1234567890abcdef0"]
+}
+`, globalProviderBlock, dataSourceName)
 }
 
 // testAccPrivateEndpointServiceEnableConfig returns terraform config for enabling/disabling private endpoint service

--- a/acceptance_tests/setup_test.go
+++ b/acceptance_tests/setup_test.go
@@ -104,16 +104,8 @@ func setup(ctx context.Context, client *api.Client) error {
 		return err
 	}
 
-	if err := setupDMCluster(ctx, client); err != nil {
-		return err
-	}
-
-	if err := resolveDMBucket(ctx, client); err != nil {
-		return err
-	}
-	if err := dmClusterWait(ctx, client, false); err != nil {
-		return err
-	}
+	// The data-management cluster is provisioned lazily by ensureDMCluster()
+	// from the first data_management_* test that runs, so non-DM runs skip it.
 
 	// Create app service only if not provided via env var
 	if globalAppServiceId == "" {

--- a/acceptance_tests/snapshot_backup_schedule_acceptance_test.go
+++ b/acceptance_tests/snapshot_backup_schedule_acceptance_test.go
@@ -122,7 +122,7 @@ func TestAccSnapshotBackupScheduleResourceInvalidStartTime(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccSnapshotBackupScheduleResourceConfigWithCopyToRegions(resourceName, 12, 240, "invalid_time", "[]"),
-				ExpectError: regexp.MustCompile("There is an error during snapshot backup schedule creation"),
+				ExpectError: regexp.MustCompile("A string value was provided that is not valid RFC3339 string format"),
 			},
 		},
 	})

--- a/acceptance_tests/snapshot_setup.go
+++ b/acceptance_tests/snapshot_setup.go
@@ -21,6 +21,9 @@ var (
 	snapshotClusterID      string
 	snapshotClusterCreated bool
 	snapshotClusterErr     error
+
+	// Serializes tests that trigger snapshot restores; Capella allows only one restore per cluster.
+	cloudSnapshotRestoreMu sync.Mutex
 )
 
 // ensureSnapshotCluster lazily provisions a dedicated cluster used by the

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -43,7 +43,7 @@ Read-Only:
 - `connection_string` (String) - ConnectionString specifies the Capella database endpoint for your client connection.
 - `couchbase_server` (Attributes) (see [below for nested schema](#nestedatt--data--couchbase_server))
 - `current_state` (String) - **Valid Values**: `draft`, `deploying`, `scaling`, `upgrading`, `rebalancing`, `peering`, `destroying`, `healthy`, `degraded`, `turnedOff`, `turningOff`, `turningOn`, `deploymentFailed`, `scaleFailed`, `upgradeFailed`, `rebalanceFailed`, `peeringFailed`, `destroyFailed`, `offline`, `turningOffFailed`, `turningOnFailed`
-- `deletion_protection` (Boolean)
+- `deletion_protection` (Boolean) - Indicates whether deletion protection is enabled for the cluster. When enabled, the cluster cannot be deleted.
 - `description` (String) - Description of the cluster (up to 1024 characters).
  - **Constraints**: Maximum length: 1024 characters
 - `enable_private_dns_resolution` (Boolean)

--- a/docs/data-sources/free_tier_clusters.md
+++ b/docs/data-sources/free_tier_clusters.md
@@ -43,7 +43,7 @@ Read-Only:
 - `connection_string` (String) - ConnectionString specifies the Capella database endpoint for your client connection.
 - `couchbase_server` (Attributes) (see [below for nested schema](#nestedatt--data--couchbase_server))
 - `current_state` (String) - **Valid Values**: `draft`, `deploying`, `scaling`, `upgrading`, `rebalancing`, `peering`, `destroying`, `healthy`, `degraded`, `turnedOff`, `turningOff`, `turningOn`, `deploymentFailed`, `scaleFailed`, `upgradeFailed`, `rebalanceFailed`, `peeringFailed`, `destroyFailed`, `offline`, `turningOffFailed`, `turningOnFailed`
-- `deletion_protection` (Boolean)
+- `deletion_protection` (Boolean) - Indicates whether deletion protection is enabled for the cluster. When enabled, the cluster cannot be deleted.
 - `description` (String) - Description of the cluster (up to 1024 characters).
  - **Constraints**: Maximum length: 1024 characters
 - `enable_private_dns_resolution` (Boolean)

--- a/docs/data-sources/network_peers.md
+++ b/docs/data-sources/network_peers.md
@@ -39,11 +39,9 @@ data "couchbase-capella_network_peers" "existing_network_peers" {
 Read-Only:
 
 - `audit` (Attributes) Couchbase audit data. (see [below for nested schema](#nestedatt--data--audit))
-- `commands` (Attributes) (see [below for nested schema](#nestedatt--data--commands))
 - `id` (String)
 - `name` (String)
-- `provider_config` (String)
-- `provider_type` (String) Type of provider to filter on. By default all providers are returned.
+- `provider_config` (Attributes) (see [below for nested schema](#nestedatt--data--provider_config))
 - `status` (Attributes) (see [below for nested schema](#nestedatt--data--status))
 
 <a id="nestedatt--data--audit"></a>
@@ -60,37 +58,50 @@ Read-Only:
 - `version` (Number) - The version of the document. This value is incremented each time the resource is modified.
 
 
-<a id="nestedatt--data--commands"></a>
-### Nested Schema for `data.commands`
+<a id="nestedatt--data--provider_config"></a>
+### Nested Schema for `data.provider_config`
 
 Read-Only:
 
-- `aws` (Attributes) (see [below for nested schema](#nestedatt--data--commands--aws))
-- `azure` (Attributes) (see [below for nested schema](#nestedatt--data--commands--azure))
-- `gcp` (Attributes) (see [below for nested schema](#nestedatt--data--commands--gcp))
+- `aws_config` (Attributes) (see [below for nested schema](#nestedatt--data--provider_config--aws_config))
+- `azure_config` (Attributes) (see [below for nested schema](#nestedatt--data--provider_config--azure_config))
+- `gcp_config` (Attributes) (see [below for nested schema](#nestedatt--data--provider_config--gcp_config))
 
-<a id="nestedatt--data--commands--aws"></a>
-### Nested Schema for `data.commands.aws`
-
-Read-Only:
-
-- `command` (String)
-
-
-<a id="nestedatt--data--commands--azure"></a>
-### Nested Schema for `data.commands.azure`
+<a id="nestedatt--data--provider_config--aws_config"></a>
+### Nested Schema for `data.provider_config.aws_config`
 
 Read-Only:
 
-- `command` (String)
+- `account_id` (String)
+- `cidr` (String)
+- `provider_id` (String) The unique identifier of the provider.
+- `region` (String)
+- `vpc_id` (String)
 
 
-<a id="nestedatt--data--commands--gcp"></a>
-### Nested Schema for `data.commands.gcp`
+<a id="nestedatt--data--provider_config--azure_config"></a>
+### Nested Schema for `data.provider_config.azure_config`
 
 Read-Only:
 
-- `command` (String)
+- `cidr` (String)
+- `provider_id` (String) The unique identifier of the provider.
+- `resource_group` (String)
+- `subscription_id` (String)
+- `tenant_id` (String)
+- `vnet_id` (String)
+
+
+<a id="nestedatt--data--provider_config--gcp_config"></a>
+### Nested Schema for `data.provider_config.gcp_config`
+
+Read-Only:
+
+- `cidr` (String)
+- `network_name` (String)
+- `project_id` (String) The GUID4 ID of the project.
+- `provider_id` (String) The unique identifier of the provider.
+- `service_account` (String)
 
 
 

--- a/docs/data-sources/private_endpoint_service.md
+++ b/docs/data-sources/private_endpoint_service.md
@@ -32,3 +32,5 @@ data "couchbase-capella_private_endpoint_service" "service_status" {
 ### Read-Only
 
 - `enabled` (Boolean) - Returns true if private endpoint is enabled
+- `status` (String) - status of the private endpoint
+ - **Valid Values**: `idle`, `unknown`, `enabling`, `enabled`, `enableFailed`, `disabling`, `disabled`, `disableFailed`

--- a/docs/guides/1.9.1-upgrade-guide.md
+++ b/docs/guides/1.9.1-upgrade-guide.md
@@ -1,0 +1,62 @@
+---
+layout: "couchbase-capella"
+page_title: "Couchbase Capella Provider 1.9.1: Upgrade and Information Guide"
+sidebar_current: "docs-couchbase-capella-guides-191-upgrade-guide"
+description: |-
+Couchbase Capella Provider 1.9.1: Upgrade and Information Guide
+---
+
+# Couchbase Capella Provider 1.9.1: Upgrade and Information Guide
+
+Here is a list of what's new in 1.9.1
+
+## Enhancements
+
+This release adds plan-time validation across several resources so that invalid configuration is caught during `terraform plan` instead of failing at apply time:
+
+* Validate the free-tier cluster region before apply [#645](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/645)
+* Reject unsupported `provider_type` values on network peers [#660](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/660)
+* Reject an empty private endpoint `endpoint_id` at plan time [#663](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/663)
+* Reject short private endpoint command VPC IDs at plan time [#659](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/659)
+* Validate RFC3339 format for `start_time` in the snapshot backup schedule resource [#665](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/665)
+* Validate days, time boundaries, and duplicate/missing days for the cluster on/off schedule [#630](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/630), [#631](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/631), [#635](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/635)
+* Validate UUIDs for cluster on/off schedule data source IDs [#632](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/632)
+* Automatically attach enum validators for named-enum fields [#638](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/638)
+
+## Reliability Improvements
+
+* Fail fast and auto-recover from private endpoint service failed states [#647](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/647)
+* Add handling for service unavailable errors so transient failures are surfaced cleanly [#649](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/649)
+* Improve network peer error handling and state management [#639](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/639)
+* Handle app endpoint deletion and forbidden errors across resource operations [#634](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/634)
+
+## Bug Fixes
+
+* Fix `provider_type` being erased on network peer import/read [#643](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/643)
+* Fix the `couchbase-capella_network_peers` data source so reads no longer fail with a value conversion error [#666](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/666)
+* Fix enum lookup for nested fields [#650](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/650)
+
+## Breaking Changes
+
+WARNING: **ACTION REQUIRED**
+
+The output schema of the `couchbase-capella_network_peers` data source changed as part of [#666](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/666). This is a breaking change for any configuration that reads this data source's output:
+
+* `provider_config` changed from a string to a nested object exposing `aws_config`, `gcp_config`, and `azure_config`. Update any reference that treated `provider_config` as a string to read the appropriate nested field instead (for example, `provider_config.aws_config.vpc_id`).
+* The `provider_type` and `commands` attributes were removed. Remove references to them, otherwise `terraform plan` will fail with "Unsupported attribute" errors.
+
+Only the `couchbase-capella_network_peers` data source is affected. The `couchbase-capella_network_peer` resource schema is unchanged, so no state migration is required.
+
+See the [network peer examples](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/tree/main/examples/network_peer) for the corrected shape.
+
+## Changes
+
+There are no deprecations as part of this release.
+
+1.9.1 includes validation enhancements, reliability improvements, and bug fixes, along with one breaking change to the `couchbase-capella_network_peers` data source output described above. See the [CHANGELOG](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/blob/master/CHANGELOG.md) for more specific information.
+
+### Helpful Links
+
+- [Getting Started with the Terraform Provider](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/blob/master/examples/getting_started)
+- [Capella Management API v4.0](https://docs.couchbase.com/cloud/management-api-reference/index.html)
+- [See Specific Examples](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/blob/master/examples)

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -86,7 +86,7 @@ resource "couchbase-capella_cluster" "new_cluster" {
 - `audit` (Attributes) Couchbase audit data. (see [below for nested schema](#nestedatt--audit))
 - `connection_string` (String) - ConnectionString specifies the Capella database endpoint for your client connection.
 - `current_state` (String) - **Valid Values**: `draft`, `deploying`, `scaling`, `upgrading`, `rebalancing`, `peering`, `destroying`, `healthy`, `degraded`, `turnedOff`, `turningOff`, `turningOn`, `deploymentFailed`, `scaleFailed`, `upgradeFailed`, `rebalanceFailed`, `peeringFailed`, `destroyFailed`, `offline`, `turningOffFailed`, `turningOnFailed`
-- `deletion_protection` (Boolean)
+- `deletion_protection` (Boolean) - Indicates whether deletion protection is enabled for the cluster. When enabled, the cluster cannot be deleted.
 - `etag` (String) Entity tag for the resource, used for caching and conditional requests.
 - `id` (String) - The ID of the cluster created.
  - **Format**: UUID (GUID4)

--- a/docs/resources/private_endpoint_service.md
+++ b/docs/resources/private_endpoint_service.md
@@ -4,11 +4,14 @@ page_title: "couchbase-capella_private_endpoint_service Resource - terraform-pro
 subcategory: ""
 description: |-
   This resource allows you to manage the private endpoint service for an operational cluster. The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. This enables secure access to your cluster without exposing traffic to the public internet.
+  ~> Enablement failure handling: If enablement terminally fails (status = enableFailed), the provider automatically issues a cleanup request to tear down the partially provisioned service and then removes the resource from Terraform state before the apply errors out. This is intentional: the resource disappearing from state is expected, and the next terraform apply performs a clean re-create. If the automatic cleanup cannot complete, the error will say so — contact Couchbase Capella Support to check for orphaned resources in your cloud account.
 ---
 
 # couchbase-capella_private_endpoint_service (Resource)
 
 This resource allows you to manage the private endpoint service for an operational cluster. The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. This enables secure access to your cluster without exposing traffic to the public internet.
+
+~> **Enablement failure handling:** If enablement terminally fails (`status` = `enableFailed`), the provider automatically issues a cleanup request to tear down the partially provisioned service and then removes the resource from Terraform state before the apply errors out. This is intentional: the resource disappearing from state is expected, and the next `terraform apply` performs a clean re-create. If the automatic cleanup cannot complete, the error will say so — contact Couchbase Capella Support to check for orphaned resources in your cloud account.
 
 ## Example Usage
 
@@ -30,6 +33,11 @@ resource "couchbase-capella_private_endpoint_service" "new_service" {
 - `enabled` (Boolean) - Returns true if private endpoint is enabled
 - `organization_id` (String) The GUID4 ID of the organization.
 - `project_id` (String) The GUID4 ID of the project.
+
+### Read-Only
+
+- `status` (String) - status of the private endpoint
+ - **Valid Values**: `idle`, `unknown`, `enabling`, `enabled`, `enableFailed`, `disabling`, `disabled`, `disableFailed`
 
 ## Import
 

--- a/examples/network_peer/README.md
+++ b/examples/network_peer/README.md
@@ -485,9 +485,9 @@ network_peers_list = {
           "region" = "us-east-1"
           "vpc_id" = "vpc-141f0fffff141aa00ff"
         }
+        "azure_config" = null /* object */
         "gcp_config" = null /* object */
       }
-      "provider_type" = ""
       "status" = {
         "reasoning" = ""
         "state" = "complete"
@@ -618,9 +618,9 @@ Changes to Outputs:
                       - region      = "us-east-1"
                       - vpc_id      = "vpc-12345678912345678"
                     }
+                  - azure_config = null
                   - gcp_config = null
                 }
-              - provider_type   = ""
               - status          = {
                   - reasoning = ""
                   - state     = "complete"
@@ -1114,6 +1114,7 @@ Changes to Outputs:
               - name            = "VPCPeerTFTestGCP"
               - provider_config = {
                   - aws_config = null
+                  - azure_config = null
                   - gcp_config = {
                       - cidr            = "10.0.4.0/23"
                       - network_name    = "cc-ffffffff-aaaa-1414-eeee-000000000000"
@@ -1297,6 +1298,7 @@ Changes to Outputs:
               - name            = "VPCPeerTFTestGCP"
               - provider_config = {
                   - aws_config = null
+                  - azure_config = null
                   - gcp_config = {
                       - cidr            = "10.0.4.0/23"
                       - network_name    = "cc-ffffffff-aaaa-1414-eeee-000000000000"

--- a/examples/resources/couchbase-capella_app_service/resource.tf
+++ b/examples/resources/couchbase-capella_app_service/resource.tf
@@ -4,6 +4,7 @@ resource "couchbase-capella_app_service" "new_app_service" {
   cluster_id      = "<cluster_id>"
   name            = "MyAppSyncService"
   description     = "My app sync service."
+  version         = "4.0"
   nodes           = 2
   compute = {
     cpu = 2

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.25.0 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect
 	github.com/hashicorp/terraform-plugin-docs v0.25.0 // indirect
+	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.5 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/hashicorp/terraform-plugin-docs v0.25.0 h1:qHs1V257NxVe8tv6HS4UQfNqja
 github.com/hashicorp/terraform-plugin-docs v0.25.0/go.mod h1:MQggCmY8zgP7R7E/cC0b0cmTvA9hSj3ZKyrrsDjRbLo=
 github.com/hashicorp/terraform-plugin-framework v1.15.0 h1:LQ2rsOfmDLxcn5EeIwdXFtr03FVsNktbbBci8cOKdb4=
 github.com/hashicorp/terraform-plugin-framework v1.15.0/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0 h1:v3DapR8gsp3EM8fKMh6up9cJUFQ2iRaFsYLP8UJnCco=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0/go.mod h1:c3PnGE9pHBDfdEVG9t1S1C9ia5LW+gkFR0CygXlM8ak=
 github.com/hashicorp/terraform-plugin-framework-validators v0.18.0 h1:OQnlOt98ua//rCw+QhBbSqfW3QbwtVrcdWeQN5gI3Hw=
 github.com/hashicorp/terraform-plugin-framework-validators v0.18.0/go.mod h1:lZvZvagw5hsJwuY7mAY6KUz45/U6fiDR0CzQAwWD0CA=
 github.com/hashicorp/terraform-plugin-go v0.27.0 h1:ujykws/fWIdsi6oTUT5Or4ukvEan4aN9lY+LOxVP8EE=

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -122,6 +122,18 @@ func (c *Client) ExecuteWithRetry(
 				"retry_after": dur.Seconds(),
 			})
 			return nil, dur, errors.ErrRatelimit
+		case http.StatusServiceUnavailable:
+			var retryAfter time.Duration
+			if header := apiRes.Header.Get("Retry-After"); header != "" {
+				if secs, parseErr := strconv.Atoi(header); parseErr == nil {
+					retryAfter = time.Second * time.Duration(secs)
+				}
+			}
+			tflog.Debug(ctx, "API returned 503 Service Unavailable, retrying", map[string]interface{}{
+				"method": endpointCfg.Method,
+				"url":    endpointCfg.Url,
+			})
+			return nil, retryAfter, errors.ErrServiceUnavailable
 		case http.StatusGatewayTimeout:
 			var apiError Error
 			if err := json.Unmarshal(responseBody, &apiError); err != nil {
@@ -188,6 +200,7 @@ func exec(
 			case err == nil:
 				return response, nil
 			case goer.Is(err, errors.ErrRatelimit):
+			case goer.Is(err, errors.ErrServiceUnavailable):
 			case !goer.Is(err, errors.ErrGatewayTimeout):
 				return response, err
 			}

--- a/internal/api/error.go
+++ b/internal/api/error.go
@@ -65,3 +65,9 @@ func CheckResourceNotFoundError(err error) (bool, string) {
 		return false, err.Error()
 	}
 }
+
+// IsForbiddenError checks whether the given error is an api.Error with HTTP status 403.
+func IsForbiddenError(err error) bool {
+	var apiError *Error
+	return errors.As(err, &apiError) && apiError.HttpStatusCode == http.StatusForbidden
+}

--- a/internal/api/private_endpoint_service.go
+++ b/internal/api/private_endpoint_service.go
@@ -3,6 +3,14 @@ package api
 // GetPrivateEndpointServiceStatusResponse is the response received from the Capella V4 Public API
 // when getting private endpoint service status.
 type GetPrivateEndpointServiceStatusResponse struct {
-	Enabled    bool   `json:"enabled"`
+	Enabled bool `json:"enabled"`
+
+	// Status is the lifecycle state of the private endpoint service derived from
+	// the most recent enable/disable/update operation (for example "enableFailed"
+	// or "enabling"). It is optional and best-effort: it is omitted on GCP, when
+	// the status feature flag is disabled, and on older control planes, in which
+	// case callers fall back to the Enabled boolean.
+	Status *string `json:"status,omitempty"`
+
 	PrivateDns string `json:"privateDns"`
 }

--- a/internal/datasources/attributes.go
+++ b/internal/datasources/attributes.go
@@ -3,6 +3,7 @@ package datasources
 import (
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -41,6 +42,13 @@ func requiredUUIDString() *schema.StringAttribute {
 func computedString() *schema.StringAttribute {
 	return &schema.StringAttribute{
 		Computed: true,
+	}
+}
+
+func computedRFC3339() *schema.StringAttribute {
+	return &schema.StringAttribute{
+		Computed:   true,
+		CustomType: timetypes.RFC3339Type{},
 	}
 }
 

--- a/internal/datasources/aws_private_endpoint_command_schema.go
+++ b/internal/datasources/aws_private_endpoint_command_schema.go
@@ -16,7 +16,7 @@ func AwsPrivateEndpointCommandSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", awsPrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "project_id", awsPrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "cluster_id", awsPrivateEndpointCommandBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "vpc_id", awsPrivateEndpointCommandBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "vpc_id", awsPrivateEndpointCommandBuilder, requiredString(), "CreateVPCEndpointCommandRequest")
 	capellaschema.AddAttr(attrs, "subnet_ids", awsPrivateEndpointCommandBuilder, &schema.SetAttribute{
 		Required:    true,
 		ElementType: types.StringType,

--- a/internal/datasources/azure_private_endpoint_command_schema.go
+++ b/internal/datasources/azure_private_endpoint_command_schema.go
@@ -15,8 +15,8 @@ func AzurePrivateEndpointCommandSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", azurePrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "project_id", azurePrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "cluster_id", azurePrivateEndpointCommandBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "resource_group_name", azurePrivateEndpointCommandBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "virtual_network", azurePrivateEndpointCommandBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "resource_group_name", azurePrivateEndpointCommandBuilder, requiredString(), "CreateAzurePrivateEndpointCommandRequest")
+	capellaschema.AddAttr(attrs, "virtual_network", azurePrivateEndpointCommandBuilder, requiredString(), "CreateAzurePrivateEndpointCommandRequest")
 	capellaschema.AddAttr(attrs, "command", azurePrivateEndpointCommandBuilder, computedString())
 
 	return schema.Schema{

--- a/internal/datasources/gcp_private_endpoint_command_schema.go
+++ b/internal/datasources/gcp_private_endpoint_command_schema.go
@@ -16,7 +16,7 @@ func GcpPrivateEndpointCommandSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", gcpPrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "project_id", gcpPrivateEndpointCommandBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "cluster_id", gcpPrivateEndpointCommandBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "vpc_network_id", gcpPrivateEndpointCommandBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "vpc_network_id", gcpPrivateEndpointCommandBuilder, requiredString(), "CreateGCPPrivateEndpointCommandRequest")
 	capellaschema.AddAttr(attrs, "subnet_ids", gcpPrivateEndpointCommandBuilder, &schema.SetAttribute{
 		Required:    true,
 		ElementType: types.StringType,

--- a/internal/datasources/network_peer_schema.go
+++ b/internal/datasources/network_peer_schema.go
@@ -15,28 +15,49 @@ func NetworkPeerSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "project_id", networkPeerBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "cluster_id", networkPeerBuilder, requiredString())
 
-	commandAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(commandAttrs, "command", networkPeerBuilder, computedString())
+	awsConfigAttrs := make(map[string]schema.Attribute)
+	capellaschema.AddAttr(awsConfigAttrs, "account_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(awsConfigAttrs, "vpc_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(awsConfigAttrs, "region", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(awsConfigAttrs, "cidr", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(awsConfigAttrs, "provider_id", networkPeerBuilder, computedString())
 
-	commandsAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(commandsAttrs, "aws", networkPeerBuilder, &schema.SingleNestedAttribute{
+	gcpConfigAttrs := make(map[string]schema.Attribute)
+	capellaschema.AddAttr(gcpConfigAttrs, "cidr", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(gcpConfigAttrs, "network_name", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(gcpConfigAttrs, "project_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(gcpConfigAttrs, "service_account", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(gcpConfigAttrs, "provider_id", networkPeerBuilder, computedString())
+
+	azureConfigAttrs := make(map[string]schema.Attribute)
+	capellaschema.AddAttr(azureConfigAttrs, "tenant_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(azureConfigAttrs, "cidr", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(azureConfigAttrs, "resource_group", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(azureConfigAttrs, "subscription_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(azureConfigAttrs, "vnet_id", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(azureConfigAttrs, "provider_id", networkPeerBuilder, computedString())
+
+	providerConfigAttrs := make(map[string]schema.Attribute)
+	capellaschema.AddAttr(providerConfigAttrs, "aws_config", networkPeerBuilder, &schema.SingleNestedAttribute{
 		Computed:   true,
-		Attributes: commandAttrs,
+		Attributes: awsConfigAttrs,
 	})
-	capellaschema.AddAttr(commandsAttrs, "gcp", networkPeerBuilder, &schema.SingleNestedAttribute{
+	capellaschema.AddAttr(providerConfigAttrs, "gcp_config", networkPeerBuilder, &schema.SingleNestedAttribute{
 		Computed:   true,
-		Attributes: commandAttrs,
+		Attributes: gcpConfigAttrs,
 	})
-	capellaschema.AddAttr(commandsAttrs, "azure", networkPeerBuilder, &schema.SingleNestedAttribute{
+	capellaschema.AddAttr(providerConfigAttrs, "azure_config", networkPeerBuilder, &schema.SingleNestedAttribute{
 		Computed:   true,
-		Attributes: commandAttrs,
+		Attributes: azureConfigAttrs,
 	})
 
 	dataAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(dataAttrs, "id", networkPeerBuilder, computedString())
 	capellaschema.AddAttr(dataAttrs, "name", networkPeerBuilder, computedString())
-	capellaschema.AddAttr(dataAttrs, "provider_type", networkPeerBuilder, computedString())
-	capellaschema.AddAttr(dataAttrs, "provider_config", networkPeerBuilder, computedString())
+	capellaschema.AddAttr(dataAttrs, "provider_config", networkPeerBuilder, &schema.SingleNestedAttribute{
+		Computed:   true,
+		Attributes: providerConfigAttrs,
+	})
 	capellaschema.AddAttr(dataAttrs, "audit", networkPeerBuilder, computedAudit())
 	capellaschema.AddAttr(dataAttrs, "status", networkPeerBuilder, &schema.SingleNestedAttribute{
 		Computed: true,
@@ -44,10 +65,6 @@ func NetworkPeerSchema() schema.Schema {
 			"state":     schema.StringAttribute{Computed: true},
 			"reasoning": schema.StringAttribute{Computed: true},
 		},
-	})
-	capellaschema.AddAttr(dataAttrs, "commands", networkPeerBuilder, &schema.SingleNestedAttribute{
-		Computed:   true,
-		Attributes: commandsAttrs,
 	})
 
 	capellaschema.AddAttr(attrs, "data", networkPeerBuilder, &schema.ListNestedAttribute{

--- a/internal/datasources/private_endpoint_service.go
+++ b/internal/datasources/private_endpoint_service.go
@@ -92,6 +92,10 @@ func (p *PrivateEndpointService) Read(ctx context.Context, req datasource.ReadRe
 	}
 
 	state.Enabled = types.BoolValue(privateEndpointServiceStatus.Enabled)
+	state.Status = types.StringNull()
+	if privateEndpointServiceStatus.Status != nil {
+		state.Status = types.StringValue(*privateEndpointServiceStatus.Status)
+	}
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/datasources/private_endpoint_service_schema.go
+++ b/internal/datasources/private_endpoint_service_schema.go
@@ -16,6 +16,7 @@ func PrivateEndpointServiceSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "project_id", privateEndpointServiceBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "cluster_id", privateEndpointServiceBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "enabled", privateEndpointServiceBuilder, computedBool())
+	capellaschema.AddAttr(attrs, "status", privateEndpointServiceBuilder, computedString())
 
 	return schema.Schema{
 		MarkdownDescription: "The data source to retrieve private endpoint service information for a cluster.",

--- a/internal/datasources/snapshot_backup_schedule_schema.go
+++ b/internal/datasources/snapshot_backup_schedule_schema.go
@@ -15,7 +15,7 @@ func SnapshotBackupScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "cluster_id", snapshotBackupScheduleBuilder, requiredStringWithValidator())
 	capellaschema.AddAttr(attrs, "interval", snapshotBackupScheduleBuilder, computedInt64())
 	capellaschema.AddAttr(attrs, "retention", snapshotBackupScheduleBuilder, computedInt64())
-	capellaschema.AddAttr(attrs, "start_time", snapshotBackupScheduleBuilder, computedString())
+	capellaschema.AddAttr(attrs, "start_time", snapshotBackupScheduleBuilder, computedRFC3339())
 	capellaschema.AddAttr(attrs, "copy_to_regions", snapshotBackupScheduleBuilder, computedStringSet())
 	return schema.Schema{
 		MarkdownDescription: "The snapshot backups data source retrieves the snapshot backup schedule for a cluster.",

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -205,6 +205,9 @@ var (
 	// ErrGatewayTimeoutForIndexDDL is returned when API server times out while waiting for response for index DDL.
 	ErrGatewayTimeoutForIndexDDL = errors.New("timeout waiting for response for index DDL")
 
+	// ErrServiceUnavailable is returned when the API returns 503 due to a transient condition (e.g. bucket deletion in progress).
+	ErrServiceUnavailable = errors.New("service unavailable")
+
 	// ErrNotTrimmed is returned when any attribute has leading or trailing spaces.
 	ErrNotTrimmed = errors.New("attribute has leading or trailing spaces")
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -246,6 +246,14 @@ var (
 
 	ErrPrivateEndpointServiceTimeout = errors.New("changing private endpoint service status timed out after initiation")
 
+	// ErrPrivateEndpointServiceEnableFailed is returned when the backend reports a terminal
+	// enableFailed state for the private endpoint service. This is not retried by polling.
+	ErrPrivateEndpointServiceEnableFailed = errors.New("private endpoint service enablement failed")
+
+	// ErrPrivateEndpointServiceDisableFailed is returned when the backend reports a terminal
+	// disableFailed state for the private endpoint service. This is not retried by polling.
+	ErrPrivateEndpointServiceDisableFailed = errors.New("private endpoint service disable failed")
+
 	ErrBucketCreationStatusTimeout = errors.New("bucket backup creation status transition timed out after initiation")
 
 	ErrSnapshotBackupCreationStatusTimeout = errors.New("snapshot backup creation status transition timed out after initiation")

--- a/internal/generated/api/retry_http_client.go
+++ b/internal/generated/api/retry_http_client.go
@@ -57,8 +57,10 @@ func customRetryPolicy(ctx context.Context, resp *http.Response, err error) (boo
 	}
 
 	switch resp.StatusCode {
-	case http.StatusTooManyRequests:
+	case http.StatusTooManyRequests, http.StatusServiceUnavailable:
 		// Always retry 429 responses - retryablehttp handles Retry-After header automatically
+		// Retry 503 responses - these indicate transient conditions such as a bucket
+		// deletion in progress that prevents creation of another bucket.
 		return true, nil
 
 	case http.StatusGatewayTimeout:

--- a/internal/generated/api/retry_http_client_test.go
+++ b/internal/generated/api/retry_http_client_test.go
@@ -62,6 +62,21 @@ func TestCustomRetryPolicyDirectly(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error for 429, got: %v", err)
 	}
+
+	// Test 503 case
+	resp = &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Body:       io.NopCloser(bytes.NewBufferString("service unavailable")),
+		Header:     make(http.Header),
+	}
+
+	shouldRetry, err = customRetryPolicy(context.Background(), resp, nil)
+	if !shouldRetry {
+		t.Error("expected retry for 503 case")
+	}
+	if err != nil {
+		t.Errorf("expected no error for 503, got: %v", err)
+	}
 }
 
 func TestCustomRetryPolicyJSONDecoder(t *testing.T) {
@@ -366,6 +381,40 @@ func Test429_RetryAfter_Respected(t *testing.T) {
 	}
 }
 
+func Test503_ServiceUnavailable_Retried(t *testing.T) {
+	var callCount int32
+
+	// Create test server that returns 503 on the first call, then success
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		if count == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("service unavailable"))
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("success"))
+		}
+	}))
+	defer server.Close()
+
+	client := NewRetryHTTPClient(context.Background(), 30*time.Second, false, WithFastBackoff())
+
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Should have retried once after 503
+	if atomic.LoadInt32(&callCount) != 2 {
+		t.Fatalf("expected 2 calls, got %d", atomic.LoadInt32(&callCount))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected successful status, got %d", resp.StatusCode)
+	}
+}
+
 func TestSuccessPassthrough(t *testing.T) {
 	var callCount int32
 
@@ -412,7 +461,6 @@ func TestDefaultCase_NoRetry(t *testing.T) {
 		{"NotFound", http.StatusNotFound, "not found"},
 		{"InternalServerError", http.StatusInternalServerError, "internal server error"},
 		{"BadGateway", http.StatusBadGateway, "bad gateway"},
-		{"ServiceUnavailable", http.StatusServiceUnavailable, "service unavailable"},
 	}
 
 	for _, tc := range testCases {

--- a/internal/generated/enums/enums.gen.go
+++ b/internal/generated/enums/enums.gen.go
@@ -43,6 +43,9 @@ var enumTable = map[string]map[string]EnumDef{
 	"CloudProvider": {
 		"type": {Type: "string", Values: []string{"aws", "gcp", "azure"}},
 	},
+	"ClusterOnOffSchedule": {
+		"timezone": {Type: "string", Values: []string{"Pacific/Midway", "US/Hawaii", "US/Alaska", "US/Pacific", "US/Mountain", "US/Central", "US/Eastern", "America/Puerto_Rico", "Canada/Newfoundland", "America/Argentina/Buenos_Aires", "Atlantic/Cape_Verde", "Europe/London", "Europe/Amsterdam", "Europe/Athens", "Africa/Nairobi", "Asia/Tehran", "Indian/Mauritius", "Asia/Karachi", "Asia/Calcutta", "Asia/Dhaka", "Asia/Bangkok", "Asia/Hong_Kong", "Asia/Tokyo", "Australia/North", "Australia/Sydney", "Pacific/Ponape", "Antarctica/South_Pole"}},
+	},
 	"ColumnarAnalyticsOnOffSchedule": {
 		"timezone": {Type: "string", Values: []string{"Pacific/Midway", "US/Hawaii", "US/Alaska", "US/Pacific", "US/Mountain", "US/Central", "US/Eastern", "America/Puerto_Rico", "Canada/Newfoundland", "America/Argentina/Buenos_Aires", "Atlantic/Cape_Verde", "Europe/London", "Europe/Amsterdam", "Europe/Athens", "Africa/Nairobi", "Asia/Tehran", "Indian/Mauritius", "Asia/Karachi", "Asia/Calcutta", "Asia/Dhaka", "Asia/Bangkok", "Asia/Hong_Kong", "Asia/Tokyo", "Australia/North", "Australia/Sydney", "Pacific/Ponape", "Antarctica/South_Pole"}},
 	},
@@ -60,17 +63,30 @@ var enumTable = map[string]map[string]EnumDef{
 		"logKeys":  {Type: "string", IsArray: true, Values: []string{"Admin", "Access", "Auth", "Cache", "Changes", "CRUD", "HTTP", "HTTP+", "Import", "Javascript", "Query", "Sync", "SyncMsg"}},
 		"logLevel": {Type: "string", Values: []string{"info", "warn", "error"}},
 	},
+	"CreateAPIKeyRequest": {
+		"organizationRoles": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator"}},
+	},
 	"CreateAlertRequest": {
 		"kind": {Type: "string", Values: []string{"webhook"}},
 	},
 	"CreateBucketRequest": {
-		"vbuckets": {Type: "integer", Values: []string{"128", "1024"}},
+		"bucketConflictResolution": {Type: "string", Values: []string{"seqno", "lww"}},
+		"durabilityLevel":          {Type: "string", Values: []string{"none", "majority", "majorityAndPersistActive", "persistToMajority"}},
+		"evictionPolicy":           {Type: "string", Values: []string{"fullEviction", "noEviction", "nruEviction"}},
+		"replicas":                 {Type: "integer", Values: []string{"1", "2", "3"}},
+		"storageBackend":           {Type: "string", Values: []string{"couchstore", "magma"}},
+		"type":                     {Type: "string", Values: []string{"couchbase", "ephemeral"}},
+		"vbuckets":                 {Type: "integer", Values: []string{"128", "1024"}},
+	},
+	"CreateClusterRequest": {
+		"configurationType": {Type: "string", Values: []string{"singleNode", "multiNode"}},
 	},
 	"CreateColumnarAnalyticsClusterRequest": {
 		"cloudProvider": {Type: "string", Values: []string{"aws", "gcp"}},
 	},
 	"CreateOnDemandRestoreRequest": {
 		"replaceTTL": {Type: "string", Values: []string{"none", "all", "expired"}},
+		"services":   {Type: "string", IsArray: true, Values: []string{"data", "query"}},
 	},
 	"CreatePrivateEndpointResponse": {
 		"status": {Type: "string", Values: []string{"pending", "pendingAcceptance", "linked", "rejected", "failed", "unrecognized"}},
@@ -98,6 +114,9 @@ var enumTable = map[string]map[string]EnumDef{
 		"unstructuredDataProcessingConfig.chunkingStrategy.strategyType": {Type: "string", Values: []string{"RECURSIVE_SPLITTER", "SEMANTIC_SPLITTER", "PARAGRAPH_SPLITTER", "SENTENCE_SPLITTER", "FIXED_TOKEN_SPLITTER"}},
 		"unstructuredDataProcessingConfig.exclusions":                    {Type: "string", IsArray: true, Values: []string{"header", "footer", "table"}},
 	},
+	"CreateUserRequest": {
+		"organizationRoles": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator"}},
+	},
 	"CreateWorkflowRequest": {
 		"type": {Type: "string", Values: []string{"structuredDataProcessing", "unstructuredDataProcessing", "vectorization"}},
 	},
@@ -121,6 +140,9 @@ var enumTable = map[string]map[string]EnumDef{
 	"ExternalModel": {
 		"external.modelName": {Type: "string", Values: []string{"text-embedding-3-small", "text-embedding-3-large", "text-embedding-ada-002"}},
 	},
+	"GetAPIKey": {
+		"organizationRoles": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator"}},
+	},
 	"GetAlertResponse": {
 		"kind": {Type: "string", Values: []string{"webhook"}},
 	},
@@ -128,17 +150,45 @@ var enumTable = map[string]map[string]EnumDef{
 		"state":       {Type: "string", Values: []string{"enabled", "enabling", "disabled", "disabling", "failed"}},
 		"targetState": {Type: "string", Values: []string{"enabled", "disabled"}},
 	},
+	"GetAppServiceResponse": {
+		"currentState": {Type: "string", Values: []string{"pending", "deploying", "deploymentFailed", "destroying", "destroyFailed", "healthy", "degraded", "scaling", "scaleFailed", "upgrading", "upgradeFailed", "turnedOff", "turningOff", "turnOffFailed", "turningOn", "turnOnFailed"}},
+		"plan":         {Type: "string", Values: []string{"basic", "developer pro", "enterprise"}},
+	},
+	"GetBackupByIDResponse": {
+		"method": {Type: "string", Values: []string{"incremental", "full"}},
+		"source": {Type: "string", Values: []string{"manual", "scheduled"}},
+		"status": {Type: "string", Values: []string{"pending", "ready", "failed"}},
+	},
+	"GetBackupResponse": {
+		"method": {Type: "string", Values: []string{"incremental", "full"}},
+		"source": {Type: "string", Values: []string{"manual", "scheduled"}},
+		"status": {Type: "string", Values: []string{"pending", "ready", "failed"}},
+	},
 	"GetBucketResponse": {
-		"vbuckets": {Type: "integer", Values: []string{"128", "1024"}},
+		"evictionPolicy": {Type: "string", Values: []string{"fullEviction", "noEviction", "nruEviction"}},
+		"vbuckets":       {Type: "integer", Values: []string{"128", "1024"}},
 	},
 	"GetClusterAuditLogExportResponse": {
 		"status": {Type: "string", Values: []string{"In Progress", "Completed", "Queued", "Failed"}},
 	},
 	"GetClusterOnOffScheduleResponse": {
 		"activationStatus": {Type: "string", Values: []string{"active", "paused"}},
+		"timezone":         {Type: "string", Values: []string{"Pacific/Midway", "US/Hawaii", "US/Alaska", "US/Pacific", "US/Mountain", "US/Central", "US/Eastern", "America/Puerto_Rico", "Canada/Newfoundland", "America/Argentina/Buenos_Aires", "Atlantic/Cape_Verde", "Europe/London", "Europe/Amsterdam", "Europe/Athens", "Africa/Nairobi", "Asia/Tehran", "Indian/Mauritius", "Asia/Karachi", "Asia/Calcutta", "Asia/Dhaka", "Asia/Bangkok", "Asia/Hong_Kong", "Asia/Tokyo", "Australia/North", "Australia/Sydney", "Pacific/Ponape", "Antarctica/South_Pole"}},
 	},
 	"GetClusterResponse": {
-		"expressScaling": {Type: "string", Values: []string{"enabled", "disabled"}},
+		"configurationType": {Type: "string", Values: []string{"singleNode", "multiNode"}},
+		"currentState":      {Type: "string", Values: []string{"draft", "deploying", "scaling", "upgrading", "rebalancing", "peering", "destroying", "healthy", "degraded", "turnedOff", "turningOff", "turningOn", "deploymentFailed", "scaleFailed", "upgradeFailed", "rebalanceFailed", "peeringFailed", "destroyFailed", "offline", "turningOffFailed", "turningOnFailed"}},
+		"expressScaling":    {Type: "string", Values: []string{"enabled", "disabled"}},
+	},
+	"GetClusterSupport": {
+		"plan":     {Type: "string", Values: []string{"basic", "developer pro", "enterprise"}},
+		"timezone": {Type: "string", Values: []string{"ET", "GMT", "IST", "PT"}},
+	},
+	"GetColumnarAnalyticsClusterResponse": {
+		"currentState": {Type: "string", Values: []string{"deploying", "deploymentFailed", "destroying", "destroyFailed", "healthy", "scaling", "scaleFailed", "turningOff", "turnedOff", "turningOn"}},
+	},
+	"GetLanguageModelResponse": {
+		"model.actions": {Type: "string", IsArray: true, Values: []string{"deploy", "delete", "pause", "resume"}},
 	},
 	"GetLogStreamingResponse": {
 		"configState":    {Type: "string", Values: []string{"disabled", "disabling", "enabled", "enabling", "paused", "pausing", "errored"}},
@@ -167,7 +217,8 @@ var enumTable = map[string]map[string]EnumDef{
 		"unstructuredDataProcessingConfig.exclusions":                    {Type: "string", IsArray: true, Values: []string{"header", "footer", "table"}},
 	},
 	"GetUserResponse": {
-		"status": {Type: "string", Values: []string{"verified", "not-verified", "pending-primary"}},
+		"organizationRoles": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator"}},
+		"status":            {Type: "string", Values: []string{"verified", "not-verified", "pending-primary"}},
 	},
 	"GetWorkflowResponse": {
 		"type": {Type: "string", Values: []string{"structuredDataProcessing", "unstructuredDataProcessing", "vectorization"}},
@@ -188,7 +239,8 @@ var enumTable = map[string]map[string]EnumDef{
 		"op": {Type: "string", Values: []string{"update"}},
 	},
 	"PatchEntry": {
-		"op": {Type: "string", Values: []string{"add", "remove"}},
+		"op":    {Type: "string", Values: []string{"add", "remove"}},
+		"value": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator", "projectOwner", "projectManager", "projectViewer", "projectDataReaderWriter", "projectDataReader"}},
 	},
 	"PostLogStreamingRequest": {
 		"outputType": {Type: "string", Values: []string{"datadog", "generic_http", "sumologic", "loki", "elastic", "splunk", "dynatrace"}},
@@ -205,15 +257,29 @@ var enumTable = map[string]map[string]EnumDef{
 	"RequestWebhook": {
 		"method": {Type: "string", Values: []string{"POST", "PUT"}},
 	},
+	"Resource": {
+		"roles": {Type: "string", IsArray: true, Values: []string{"projectOwner", "projectManager", "projectViewer", "projectDataReaderWriter", "projectDataReader"}},
+		"type":  {Type: "string", Values: []string{"project"}},
+	},
 	"ResponseWebhook": {
 		"method": {Type: "string", Values: []string{"POST", "PUT"}},
 	},
 	"ResyncStatus": {
 		"state": {Type: "string", Values: []string{"running", "completed", "stopping", "stopped", "error"}},
 	},
+	"ServiceGroup": {
+		"services": {Type: "string", IsArray: true, Values: []string{"data", "query", "index", "search", "analytics", "eventing"}},
+	},
+	"Support": {
+		"plan":     {Type: "string", Values: []string{"basic", "developer pro", "enterprise"}},
+		"timezone": {Type: "string", Values: []string{"ET", "GMT", "IST", "PT"}},
+	},
 	"UpdateBucketRequest": {
 		"durabilityLevel": {Type: "string", Values: []string{"none", "majority", "majorityAndPersistActive", "persistToMajority"}},
 		"replicas":        {Type: "integer", Values: []string{"1", "2", "3"}},
+	},
+	"UpdateClusterResponse": {
+		"currentState": {Type: "string", Values: []string{"draft", "deploying", "scaling", "upgrading", "rebalancing", "peering", "destroying", "healthy", "degraded", "turnedOff", "turningOff", "turningOn", "deploymentFailed", "scaleFailed", "upgradeFailed", "rebalanceFailed", "peeringFailed", "destroyFailed", "offline", "turningOffFailed", "turningOnFailed"}},
 	},
 	"UpdateReplicationRequest": {
 		"priority": {Type: "string", Values: []string{"low", "medium", "high"}},

--- a/internal/generated/enums/enums.gen.go
+++ b/internal/generated/enums/enums.gen.go
@@ -35,6 +35,9 @@ var enumTable = map[string]map[string]EnumDef{
 	"Caching": {
 		"defaultCache": {Type: "string", Values: []string{"standard", "semantic"}},
 	},
+	"Channel": {
+		"type": {Type: "string", Values: []string{"public", "private"}},
+	},
 	"CloudConfig": {
 		"compute.cpu":       {Type: "integer", Values: []string{"4", "32"}},
 		"compute.gpuMemory": {Type: "integer", Values: []string{"24", "48", "192"}},
@@ -67,7 +70,7 @@ var enumTable = map[string]map[string]EnumDef{
 		"organizationRoles": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator"}},
 	},
 	"CreateAlertRequest": {
-		"kind": {Type: "string", Values: []string{"webhook"}},
+		"kind": {Type: "string", Values: []string{"webhook", "slack", "teams"}},
 	},
 	"CreateBucketRequest": {
 		"bucketConflictResolution": {Type: "string", Values: []string{"seqno", "lww"}},
@@ -144,7 +147,7 @@ var enumTable = map[string]map[string]EnumDef{
 		"organizationRoles": {Type: "string", IsArray: true, Values: []string{"organizationOwner", "organizationMember", "projectCreator"}},
 	},
 	"GetAlertResponse": {
-		"kind": {Type: "string", Values: []string{"webhook"}},
+		"kind": {Type: "string", Values: []string{"webhook", "slack", "teams"}},
 	},
 	"GetAppServicePrivateEndpointStateResponse": {
 		"state":       {Type: "string", Values: []string{"enabled", "enabling", "disabled", "disabling", "failed"}},
@@ -273,6 +276,9 @@ var enumTable = map[string]map[string]EnumDef{
 	"Support": {
 		"plan":     {Type: "string", Values: []string{"basic", "developer pro", "enterprise"}},
 		"timezone": {Type: "string", Values: []string{"ET", "GMT", "IST", "PT"}},
+	},
+	"UpdateAlertRequest": {
+		"kind": {Type: "string", Values: []string{"webhook", "slack", "teams"}},
 	},
 	"UpdateBucketRequest": {
 		"durabilityLevel": {Type: "string", Values: []string{"none", "majority", "majorityAndPersistActive", "persistToMajority"}},
@@ -469,6 +475,9 @@ var requiredTable = map[string]map[string]RequiredDef{
 	},
 	"CategorizedBillingResponse": {
 		"data": {},
+	},
+	"Channel": {
+		"name": {},
 	},
 	"CloudAccounts": {
 		"aws-capella-account":        {},
@@ -1009,18 +1018,19 @@ var requiredTable = map[string]map[string]RequiredDef{
 		"timezone":         {},
 	},
 	"GetClusterResponse": {
-		"audit":             {},
-		"availability":      {},
-		"cloudProvider":     {},
-		"configurationType": {},
-		"connectionString":  {},
-		"couchbaseServer":   {},
-		"currentState":      {},
-		"description":       {},
-		"id":                {},
-		"name":              {},
-		"serviceGroups":     {},
-		"support":           {},
+		"audit":              {},
+		"availability":       {},
+		"cloudProvider":      {},
+		"configurationType":  {},
+		"connectionString":   {},
+		"couchbaseServer":    {},
+		"currentState":       {},
+		"deletionProtection": {},
+		"description":        {},
+		"id":                 {},
+		"name":               {},
+		"serviceGroups":      {},
+		"support":            {},
 	},
 	"GetClusterSupport": {
 		"plan":     {},
@@ -1249,6 +1259,13 @@ var requiredTable = map[string]map[string]RequiredDef{
 	"ListBackupsResponse": {
 		"data": {},
 	},
+	"ListChannelsRequest": {
+		"botToken":      {},
+		"integrationId": {},
+	},
+	"ListChannelsResponse": {
+		"channels": {},
+	},
 	"ListCloudSnapshotBackupsResponse": {
 		"cursor": {},
 		"data":   {},
@@ -1386,7 +1403,17 @@ var requiredTable = map[string]map[string]RequiredDef{
 		"createdBy": {},
 	},
 	"RequestConfig": {
+		"slack":   {},
+		"teams":   {},
 		"webhook": {},
+	},
+	"RequestSlack": {
+		"botToken":                  {},
+		"channel":                   {},
+		"channelWebhookUrlMappings": {},
+	},
+	"RequestTeams": {
+		"webhookUrlMappings": {},
 	},
 	"RequestWebhook": {
 		"method": {},
@@ -1403,6 +1430,8 @@ var requiredTable = map[string]map[string]RequiredDef{
 		"name": {},
 	},
 	"ResponseConfig": {
+		"slack":   {},
+		"teams":   {},
 		"webhook": {},
 	},
 	"ResponseWebhook": {
@@ -1438,6 +1467,9 @@ var requiredTable = map[string]map[string]RequiredDef{
 	"ScopeConfig": {
 		"collections": {},
 	},
+	"SlackCustomPayload": {
+		"payload": {},
+	},
 	"Stats": {
 		"diskUsedInMib":   {},
 		"itemCount":       {},
@@ -1447,8 +1479,16 @@ var requiredTable = map[string]map[string]RequiredDef{
 	"Support": {
 		"plan": {},
 	},
-	"UpdateAlertRequest": {
-		"config": {},
+	"TeamsCustomPayload": {
+		"payload": {},
+	},
+	"TestRequestConfig": {
+		"slack":   {},
+		"teams":   {},
+		"webhook": {},
+	},
+	"TestRequestTeams": {
+		"url": {},
 	},
 	"UpdateAppEndpointRequest": {
 		"bucket":               {},
@@ -1530,6 +1570,11 @@ var requiredTable = map[string]map[string]RequiredDef{
 	},
 	"UpdateProviderRequest": {
 		"configuration": {},
+	},
+	"UpdateRequestConfig": {
+		"slack":   {},
+		"teams":   {},
+		"webhook": {},
 	},
 	"UpsertColumnarAnalyticsBackupScheduleRequest": {
 		"interval":  {},

--- a/internal/generated/enums/generate/discover.go
+++ b/internal/generated/enums/generate/discover.go
@@ -332,10 +332,10 @@ func (w *walker) run() {
 	}
 }
 
-// schema visits a single schema node. Property $refs are skipped — those schemas
-// are visited independently as top-level entries in run. Composition keywords
-// (allOf/oneOf/anyOf) are traversed transparently: branches contribute to the
-// same logical field, and dedupByID merges any colliding sites at the end.
+// schema visits a single schema node. Object-typed property $refs are skipped
+// (visited as top-level entries in run); scalar-enum $refs are captured via
+// refEnum. Composition keywords (allOf/oneOf/anyOf) are traversed transparently
+// and dedupByID merges colliding sites at the end.
 func (w *walker) schema(id string, s *openapi3.Schema, schemaName, fieldPath, sourcePath string, sc scope) {
 	if s == nil {
 		return
@@ -370,16 +370,52 @@ func (w *walker) schema(id string, s *openapi3.Schema, schemaName, fieldPath, so
 		w.recordConstraints(s, schemaName, fieldPath, sourcePath)
 	}
 	for fieldName, propRef := range s.Properties {
-		if propRef == nil || propRef.Ref != "" || propRef.Value == nil {
+		if propRef == nil || propRef.Value == nil {
 			continue
 		}
-		w.schema(
-			id+"_"+toPascal(fieldName), propRef.Value,
-			schemaName, joinPath(fieldPath, fieldName),
-			sourcePath+".properties."+fieldName, sc,
-		)
+		childID := id + "_" + toPascal(fieldName)
+		childPath := joinPath(fieldPath, fieldName)
+		childSource := sourcePath + ".properties." + fieldName
+		// Skip object $refs (walked top-level); capture scalar-enum $refs.
+		if propRef.Ref != "" {
+			w.refEnum(childID, propRef.Value, schemaName, childPath, childSource, sc)
+			continue
+		}
+		w.schema(childID, propRef.Value, schemaName, childPath, childSource, sc)
 	}
 	w.items(id, s, schemaName, fieldPath, sourcePath, sc)
+}
+
+// refEnum records an enum site for a $ref target that is a scalar enum (or an
+// array of one). Object targets are ignored — they are walked top-level.
+func (w *walker) refEnum(id string, v *openapi3.Schema, schemaName, fieldPath, sourcePath string, sc scope) {
+	if v == nil {
+		return
+	}
+	if len(v.Enum) > 0 {
+		w.sites = append(w.sites, enumSite{
+			ID:         id,
+			Scope:      sc,
+			SchemaName: schemaName,
+			FieldPath:  fieldPath,
+			Type:       typeOf(v),
+			Values:     enumValues(v.Enum),
+			SourcePath: sourcePath,
+		})
+		return
+	}
+	if v.Items != nil && v.Items.Value != nil && len(v.Items.Value.Enum) > 0 {
+		iv := v.Items.Value
+		w.sites = append(w.sites, enumSite{
+			ID:         id + "_Item",
+			Scope:      sc,
+			SchemaName: schemaName,
+			FieldPath:  joinPath(fieldPath, "[]"),
+			Type:       typeOf(iv),
+			Values:     enumValues(iv.Enum),
+			SourcePath: sourcePath + ".items",
+		})
+	}
 }
 
 func (w *walker) composition(id string, refs openapi3.SchemaRefs, schemaName, fieldPath, sourcePath string, sc scope, kw string) {
@@ -502,7 +538,12 @@ func (w *walker) recordConstraints(s *openapi3.Schema, schemaName, fieldPath, so
 }
 
 func (w *walker) items(id string, s *openapi3.Schema, schemaName, fieldPath, sourcePath string, sc scope) {
-	if s.Items == nil || s.Items.Ref != "" || s.Items.Value == nil {
+	if s.Items == nil || s.Items.Value == nil {
+		return
+	}
+	// Skip object $ref items (walked top-level); capture scalar-enum ones.
+	if s.Items.Ref != "" {
+		w.refEnum(id+"_Item", s.Items.Value, schemaName, joinPath(fieldPath, "[]"), sourcePath+".items", sc)
 		return
 	}
 	w.schema(id+"_Item", s.Items.Value, schemaName, joinPath(fieldPath, "[]"), sourcePath+".items", sc)

--- a/internal/generated/enums/generate/discover_test.go
+++ b/internal/generated/enums/generate/discover_test.go
@@ -241,8 +241,9 @@ func TestWalker_NestedProperty(t *testing.T) {
 }
 
 func TestWalker_PropertyRefSkipped(t *testing.T) {
-	// A $ref'd property should not be inlined; the referenced schema is
-	// visited as its own top-level entry instead.
+	// An unresolved $ref property (Value nil) is skipped; the referenced schema
+	// is visited as its own top-level entry instead. (Resolved scalar-enum refs
+	// are captured — see TestWalker_PropertyRefScalarEnumCaptured.)
 	doc := &openapi3.T{
 		Components: &openapi3.Components{
 			Schemas: openapi3.Schemas{
@@ -299,6 +300,100 @@ func TestWalker_ArrayItems(t *testing.T) {
 	}
 	if got.ID != "Roles_Roles_Item" {
 		t.Errorf("ID = %q, want Roles_Roles_Item", got.ID)
+	}
+}
+
+func TestWalker_PropertyRefScalarEnumCaptured(t *testing.T) {
+	// A property whose resolved $ref target is a scalar enum is captured under
+	// (schema, field) — the case the generator previously dropped (the enum
+	// reached only the field-less top-level site, which buildEnumTable discards).
+	tz := &openapi3.Schema{Type: &openapi3.Types{"string"}, Enum: []any{"PT", "ET"}}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"onOffTimezone": refOf(tz),
+				"Schedule": refOf(&openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"timezone": resolvedRef("#/components/schemas/onOffTimezone", tz),
+					},
+				}),
+			},
+		},
+	}
+
+	sites := runWalker(t, doc)
+	got, ok := findSite(sites, "Schedule", "timezone")
+	if !ok {
+		t.Fatalf("want a Schedule.timezone site, got %v", idsOf(sites))
+	}
+	if got.ID != "Schedule_Timezone" || got.Type != "string" {
+		t.Errorf("unexpected site: %+v", got)
+	}
+	if !equalStrings(got.Values, []string{"PT", "ET"}) {
+		t.Errorf("values = %v, want [PT ET]", got.Values)
+	}
+}
+
+func TestWalker_ArrayItemRefScalarEnumCaptured(t *testing.T) {
+	// An array whose items resolve to a scalar-enum $ref is captured at "[]".
+	role := &openapi3.Schema{Type: &openapi3.Types{"string"}, Enum: []any{"admin", "viewer"}}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"Role": refOf(role),
+				"User": refOf(&openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"roles": refOf(&openapi3.Schema{
+							Type:  &openapi3.Types{"array"},
+							Items: resolvedRef("#/components/schemas/Role", role),
+						}),
+					},
+				}),
+			},
+		},
+	}
+
+	sites := runWalker(t, doc)
+	got, ok := findSite(sites, "User", "roles.[]")
+	if !ok {
+		t.Fatalf("want a User.roles.[] site, got %v", idsOf(sites))
+	}
+	if !equalStrings(got.Values, []string{"admin", "viewer"}) {
+		t.Errorf("values = %v, want [admin viewer]", got.Values)
+	}
+}
+
+func TestWalker_ObjectRefPropertyNotInlined(t *testing.T) {
+	// A property whose resolved $ref target is an object is NOT inlined; only
+	// the object's own top-level visit records its inner enum.
+	inner := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"kind": refOf(&openapi3.Schema{Type: &openapi3.Types{"string"}, Enum: []any{"a", "b"}}),
+		},
+	}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"Inner": refOf(inner),
+				"Container": refOf(&openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"inner": resolvedRef("#/components/schemas/Inner", inner),
+					},
+				}),
+			},
+		},
+	}
+
+	sites := runWalker(t, doc)
+	if _, ok := findSite(sites, "Container", "inner.kind"); ok {
+		t.Errorf("object $ref property must not be inlined; got Container.inner.kind in %v", idsOf(sites))
+	}
+	if _, ok := findSite(sites, "Inner", "kind"); !ok {
+		t.Errorf("want Inner.kind from the top-level visit, got %v", idsOf(sites))
 	}
 }
 
@@ -416,6 +511,21 @@ func TestWalker_SortedOutput(t *testing.T) {
 
 func refOf(s *openapi3.Schema) *openapi3.SchemaRef {
 	return &openapi3.SchemaRef{Value: s}
+}
+
+// resolvedRef mimics what the OpenAPI loader produces for a property/item $ref:
+// both the Ref string and the resolved target Value are populated.
+func resolvedRef(ref string, s *openapi3.Schema) *openapi3.SchemaRef {
+	return &openapi3.SchemaRef{Ref: ref, Value: s}
+}
+
+func findSite(sites []enumSite, schemaName, fieldPath string) (enumSite, bool) {
+	for _, s := range sites {
+		if s.SchemaName == schemaName && s.FieldPath == fieldPath {
+			return s, true
+		}
+	}
+	return enumSite{}, false
 }
 
 func runWalker(t *testing.T, doc *openapi3.T) []enumSite {

--- a/internal/generated/enums/generate/generator_test.go
+++ b/internal/generated/enums/generate/generator_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 func TestBuildEnumTable(t *testing.T) {
@@ -92,6 +94,39 @@ func TestBuildEnumTable(t *testing.T) {
 			t.Errorf("top-level enum sites must be excluded, got %#v", got)
 		}
 	})
+}
+
+func TestBuildEnumTable_RefEnumPopulatesField(t *testing.T) {
+	// End-to-end regression for the $ref-to-named-enum gap: a property that
+	// $refs a scalar enum schema must yield a populated (schema, field) entry
+	// instead of being dropped as a field-less top-level enum.
+	tz := &openapi3.Schema{Type: &openapi3.Types{"string"}, Enum: []any{"PT", "ET"}}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"onOffTimezone": {Value: tz},
+				"Schedule": {Value: &openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"timezone": {Ref: "#/components/schemas/onOffTimezone", Value: tz},
+					},
+				}},
+			},
+		},
+	}
+
+	sites, err := discoverDoc(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	table := buildEnumTable(sites)
+	def, ok := table["Schedule"]["timezone"]
+	if !ok {
+		t.Fatalf("Schedule.timezone missing from enum table: %#v", table)
+	}
+	if def.Type != "string" || !reflect.DeepEqual(def.Values, []string{"PT", "ET"}) {
+		t.Errorf("unexpected def: %#v", def)
+	}
 }
 
 func TestIsArrayLiteral(t *testing.T) {

--- a/internal/generated/enums/lookup.go
+++ b/internal/generated/enums/lookup.go
@@ -39,6 +39,12 @@ func Lookup(b SchemaBuilder, alternateSchemas []string, tfFieldName string) *Enu
 		patterns = append(patterns, schemaPatterns(b.GetResourceName())...)
 	}
 
+	// Resolve nested object fields keyed by OpenAPI path, e.g.
+	// "weeklySchedule.dayOfWeek" under CreateScheduledBackupRequest. Dotted
+	// candidates are tried before the bare name so a hinted nested field never
+	// resolves to a same-named top-level field in the same schema.
+	candidates = append(nestedFieldCandidates(alternateSchemas, candidates), candidates...)
+
 	for _, p := range patterns {
 		if p == "" {
 			continue
@@ -178,6 +184,30 @@ func capitalize(s string) string {
 		return s
 	}
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func lowerCamel(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToLower(s[:1]) + s[1:]
+}
+
+// nestedFieldCandidates prefixes each base field with the lower-camel of each
+// alternate schema (the flattened nested object's name), yielding dotted keys
+// like "weeklySchedule.dayOfWeek" that match the generated table.
+func nestedFieldCandidates(alternateSchemas, base []string) []string {
+	var out []string
+	for _, s := range alternateSchemas {
+		prefix := lowerCamel(s)
+		if prefix == "" {
+			continue
+		}
+		for _, f := range base {
+			out = append(out, prefix+"."+f)
+		}
+	}
+	return out
 }
 
 // CompositionLookup returns the composition definition (oneOf/anyOf/allOf)

--- a/internal/generated/enums/lookup_test.go
+++ b/internal/generated/enums/lookup_test.go
@@ -54,6 +54,55 @@ func TestLookup_AlternateSchemaWins(t *testing.T) {
 	}
 }
 
+func TestLookup_NestedObjectViaAlternateSchema(t *testing.T) {
+	// backup_schedule_schema.go flattens weekly_schedule into its own
+	// attribute map with NewSchemaBuilder("backupSchedule", "scheduledBackup")
+	// and passes "WeeklySchedule" as the alternate schema. The generator keys
+	// the enums as CreateScheduledBackupRequest → "weeklySchedule.dayOfWeek",
+	// so Lookup must resolve the nested dotted path.
+	b := stubBuilder{resource: "backupSchedule", schema: "scheduledBackup"}
+
+	cases := []struct {
+		field    string
+		wantType string
+	}{
+		{"day_of_week", "string"},
+		{"start_at", "integer"},
+		{"incremental_every", "integer"},
+		{"retention_time", "string"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			def := Lookup(b, []string{"WeeklySchedule"}, tc.field)
+			if def == nil {
+				t.Fatalf("expected enum for weekly_schedule.%s, got nil", tc.field)
+			}
+			if def.Type != tc.wantType {
+				t.Errorf("expected %s enum, got %q", tc.wantType, def.Type)
+			}
+		})
+	}
+
+	// A nested field without an enum (cost_optimized_retention is a bool)
+	// must not resolve.
+	if def := Lookup(b, []string{"WeeklySchedule"}, "cost_optimized_retention"); def != nil {
+		t.Errorf("expected nil for non-enum nested field, got %+v", def)
+	}
+
+	// Without the nested-object hint the bare leaf name must not resolve:
+	// the enum is only keyed under the dotted path.
+	if def := Lookup(b, nil, "day_of_week"); def != nil {
+		t.Errorf("expected nil for day_of_week without WeeklySchedule hint, got %+v", def)
+	}
+}
+
+func TestNestedFieldCandidates(t *testing.T) {
+	got := nestedFieldCandidates([]string{"WeeklySchedule"}, []string{"dayOfWeek"})
+	if len(got) != 1 || got[0] != "weeklySchedule.dayOfWeek" {
+		t.Fatalf(`nestedFieldCandidates = %v, want ["weeklySchedule.dayOfWeek"]`, got)
+	}
+}
+
 // Composition lookup tests
 
 func TestCompositionLookup_OneOf(t *testing.T) {

--- a/internal/resources/app_endpoint.go
+++ b/internal/resources/app_endpoint.go
@@ -339,6 +339,12 @@ func (a *AppEndpoint) Read(ctx context.Context, req resource.ReadRequest, resp *
 			resp.State.RemoveResource(ctx)
 			return
 		}
+		if handled, forbiddenErr := handleAppEndpointForbidden(ctx, err, a.Data, resp, organizationId, projectId, clusterId, appServiceId, endpointName); handled {
+			return
+		} else if forbiddenErr != nil {
+			resp.Diagnostics.AddError("Error refreshing App Endpoint", forbiddenErr.Error())
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error refreshing App Endpoint",
 			fmt.Sprintf("Could not refresh App Endpoint %s: %s", endpointName, errString),

--- a/internal/resources/app_endpoint_access_control_function.go
+++ b/internal/resources/app_endpoint_access_control_function.go
@@ -133,6 +133,12 @@ func (a *AccessControlFunction) Read(ctx context.Context, req resource.ReadReque
 			resp.State.RemoveResource(ctx)
 			return
 		}
+		if handled, forbiddenErr := handleAppEndpointForbidden(ctx, err, a.Data, resp, IDs["organizationId"], IDs["projectId"], IDs["clusterId"], IDs["appServiceId"], IDs["appEndpointName"]); handled {
+			return
+		} else if forbiddenErr != nil {
+			resp.Diagnostics.AddError("Error Reading Capella Access Function", forbiddenErr.Error())
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Capella Access Function",
 			"Could not read Capella access function: "+errString,

--- a/internal/resources/app_endpoint_activation_status.go
+++ b/internal/resources/app_endpoint_activation_status.go
@@ -203,6 +203,12 @@ func (r *AppEndpointActivationStatus) Read(ctx context.Context, req resource.Rea
 			resp.State.RemoveResource(ctx)
 			return
 		}
+		if handled, forbiddenErr := handleAppEndpointForbidden(ctx, err, r.Data, resp, organizationId, projectId, clusterId, appServiceId, appEndpointName); handled {
+			return
+		} else if forbiddenErr != nil {
+			resp.Diagnostics.AddError("Error parsing read app endpoint activation request", forbiddenErr.Error())
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error parsing read app endpoint activation request",
 			"Could not read the app endpoint details, unexpected error: "+err.Error(),

--- a/internal/resources/app_endpoint_cors.go
+++ b/internal/resources/app_endpoint_cors.go
@@ -266,6 +266,12 @@ func (c *Cors) Read(ctx context.Context, req resource.ReadRequest, resp *resourc
 			resp.State.RemoveResource(ctx)
 			return
 		}
+		if handled, forbiddenErr := handleAppEndpointForbidden(ctx, err, c.Data, resp, organizationId, projectId, clusterId, appServiceId, appEndpointName); handled {
+			return
+		} else if forbiddenErr != nil {
+			resp.Diagnostics.AddError("Error Reading CORS Configuration", forbiddenErr.Error())
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading CORS Configuration",
 			"Could not read CORS configuration: "+errString,

--- a/internal/resources/app_endpoint_deleted_check.go
+++ b/internal/resources/app_endpoint_deleted_check.go
@@ -1,0 +1,107 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/app_endpoints"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+// appEndpointDeletedResult represents the outcome of checking whether an App Endpoint
+// was deleted outside of Terraform.
+type appEndpointDeletedResult int
+
+const (
+	// appEndpointDeleted indicates the App Endpoint no longer exists and should be removed from state.
+	appEndpointDeleted appEndpointDeletedResult = iota
+	// appEndpointExists indicates the App Endpoint still exists (possible race condition).
+	appEndpointExists
+	// appEndpointCheckFailed indicates the check itself failed and the error should be returned to the user.
+	appEndpointCheckFailed
+)
+
+// checkAppEndpointDeletedOrForbidden determines whether a 403 response from a Get App Endpoint
+// call is caused by the App Endpoint being deleted outside of Terraform, or by a genuine
+// permission error.
+//
+// It does this by listing all App Endpoints for the App Service (using paginated fetches)
+// and checking whether the target endpoint appears in any page. If the list call itself
+// returns 403, the original error is treated as a genuine permission issue.
+func checkAppEndpointDeletedOrForbidden(
+	ctx context.Context,
+	data *providerschema.Data,
+	organizationId, projectId, clusterId, appServiceId, appEndpointName string,
+) (appEndpointDeletedResult, string) {
+	listURL := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/appservices/%s/appEndpoints",
+		data.HostURL,
+		organizationId,
+		projectId,
+		clusterId,
+		appServiceId,
+	)
+
+	cfg := api.EndpointCfg{
+		Url:           listURL,
+		Method:        http.MethodGet,
+		SuccessStatus: http.StatusOK,
+	}
+
+	allEndpoints, err := api.GetPaginated[[]app_endpoints.GetAppEndpointResponse](
+		ctx,
+		data.ClientV1,
+		data.Token,
+		cfg,
+		api.SortByName,
+	)
+	if err != nil {
+		if api.IsForbiddenError(err) {
+			return appEndpointCheckFailed, "permission denied: unable to list app endpoints for this app service"
+		}
+		return appEndpointCheckFailed, fmt.Sprintf("unable to list app endpoints for this app service: %s", api.ParseError(err))
+	}
+
+	for _, ep := range allEndpoints {
+		if ep.Name == appEndpointName {
+			tflog.Warn(ctx, "App Endpoint exists in list but Get returned 403; possible race condition, please retry")
+			return appEndpointExists, "App Endpoint exists but the Get request returned 403. This may be a transient issue, please retry."
+		}
+	}
+
+	tflog.Info(ctx, "App Endpoint not found in list response; it has been deleted outside of Terraform")
+	return appEndpointDeleted, ""
+}
+
+// handleAppEndpointForbidden checks whether err is a 403, and if so determines
+// whether the App Endpoint was deleted externally. Returns (true, nil) when the
+// endpoint was confirmed deleted and removed from state — the caller should return.
+// Returns (false, error) when the error is a 403 but the endpoint still exists or
+// the check failed. Returns (false, nil) when the error is not a 403 and the
+// caller should continue with its own error handling.
+func handleAppEndpointForbidden(
+	ctx context.Context,
+	err error,
+	data *providerschema.Data,
+	resp *resource.ReadResponse,
+	organizationId, projectId, clusterId, appServiceId, appEndpointName string,
+) (bool, error) {
+	if !api.IsForbiddenError(err) {
+		return false, nil
+	}
+
+	result, msg := checkAppEndpointDeletedOrForbidden(ctx, data, organizationId, projectId, clusterId, appServiceId, appEndpointName)
+	switch result {
+	case appEndpointDeleted:
+		tflog.Info(ctx, "App Endpoint has been deleted outside of Terraform, removing from state")
+		resp.State.RemoveResource(ctx)
+		return true, nil
+	default:
+		return false, fmt.Errorf("%s", msg)
+	}
+}

--- a/internal/resources/app_endpoint_import_filter.go
+++ b/internal/resources/app_endpoint_import_filter.go
@@ -170,6 +170,12 @@ func (f *ImportFilter) Read(ctx context.Context, req resource.ReadRequest, resp 
 			resp.State.RemoveResource(ctx)
 			return
 		}
+		if handled, forbiddenErr := handleAppEndpointForbidden(ctx, err, f.Data, resp, IDs["organizationId"], IDs["projectId"], IDs["clusterId"], IDs["appServiceId"], IDs["appEndpointName"]); handled {
+			return
+		} else if forbiddenErr != nil {
+			resp.Diagnostics.AddError("Error Reading Import Filter", forbiddenErr.Error())
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Import Filter",
 			"Could not read Import Filter: "+errString,

--- a/internal/resources/app_endpoint_logging_config.go
+++ b/internal/resources/app_endpoint_logging_config.go
@@ -139,6 +139,12 @@ func (l *LoggingConfig) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	loggingConfig, err := l.getLoggingConfig(ctx, organizationId, projectId, clusterId, appServiceId, appEndpointName)
 	if err != nil {
+		if handled, forbiddenErr := handleAppEndpointForbidden(ctx, err, l.Data, resp, organizationId, projectId, clusterId, appServiceId, appEndpointName); handled {
+			return
+		} else if forbiddenErr != nil {
+			resp.Diagnostics.AddError("Error Getting App Endpoint Logging Config in Capella", forbiddenErr.Error())
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Getting App Endpoint Logging Config in Capella",
 			"Could not get Capella App Endpoint Logging Config for app endpoint with name "+state.AppEndpointName.String()+": "+err.Error(),

--- a/internal/resources/app_endpoint_oidc.go
+++ b/internal/resources/app_endpoint_oidc.go
@@ -149,6 +149,12 @@ func (r *AppEndpointOidcProvider) Read(ctx context.Context, req resource.ReadReq
 			resp.State.RemoveResource(ctx)
 			return
 		}
+		if handled, forbiddenErr := handleAppEndpointForbidden(ctx, err, r.Data, resp, IDs[providerschema.OrganizationId], IDs[providerschema.ProjectId], IDs[providerschema.ClusterId], IDs[providerschema.AppServiceId], IDs[providerschema.AppEndpointName]); handled {
+			return
+		} else if forbiddenErr != nil {
+			resp.Diagnostics.AddError("Error Reading OIDC Provider", forbiddenErr.Error())
+			return
+		}
 		resp.Diagnostics.AddError("Error Reading OIDC Provider", "Could not read OIDC provider: "+errString)
 		return
 	}

--- a/internal/resources/app_endpoint_oidc_default.go
+++ b/internal/resources/app_endpoint_oidc_default.go
@@ -117,6 +117,12 @@ func (r *AppEndpointDefaultOidcProvider) Read(ctx context.Context, req resource.
 
 	selected, err := r.getDefaultProvider(ctx, IDs[providerschema.OrganizationId], IDs[providerschema.ProjectId], IDs[providerschema.ClusterId], IDs[providerschema.AppServiceId], IDs[providerschema.AppEndpointName])
 	if err != nil {
+		if handled, forbiddenErr := handleAppEndpointForbidden(ctx, err, r.Data, resp, IDs[providerschema.OrganizationId], IDs[providerschema.ProjectId], IDs[providerschema.ClusterId], IDs[providerschema.AppServiceId], IDs[providerschema.AppEndpointName]); handled {
+			return
+		} else if forbiddenErr != nil {
+			resp.Diagnostics.AddError("Error Reading Default OIDC Provider", forbiddenErr.Error())
+			return
+		}
 		resp.Diagnostics.AddError("Error Reading Default OIDC Provider", "Could not list OIDC providers: "+err.Error())
 		return
 	}

--- a/internal/resources/app_endpoint_resync.go
+++ b/internal/resources/app_endpoint_resync.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	internalapi "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/generated/api"
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/utils"
@@ -144,6 +145,18 @@ func (a *AppEndpointResync) Read(ctx context.Context, req resource.ReadRequest, 
 
 	resyncResponse, err := a.getResyncStatus(ctx, organizationId, projectId, clusterId, appServiceId, appEndpointName)
 	if err != nil {
+		resourceNotFound, _ := internalapi.CheckResourceNotFoundError(err)
+		if resourceNotFound {
+			tflog.Info(ctx, "resource doesn't exist in remote server removing resource from state file")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		if handled, forbiddenErr := handleAppEndpointForbidden(ctx, err, a.Data, resp, organizationId, projectId, clusterId, appServiceId, appEndpointName); handled {
+			return
+		} else if forbiddenErr != nil {
+			resp.Diagnostics.AddError("Error Getting App Endpoint Resync status in Capella", forbiddenErr.Error())
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Getting App Endpoint Resync status in Capella",
 			errorAfterAppEndpointResyncInitiation+err.Error(),
@@ -299,14 +312,18 @@ func (a *AppEndpointResync) getResyncStatus(ctx context.Context, organizationId,
 	}
 
 	if getResyncStatusResp.JSON200 == nil {
-		tflog.Debug(ctx, "unexpected status getting app endpoint logging config", map[string]interface{}{
+		tflog.Debug(ctx, "unexpected status getting app endpoint resync status", map[string]interface{}{
 			"organizationId":  organizationId,
 			"projectId":       projectId,
 			"clusterId":       clusterId,
 			"appServiceId":    appServiceId,
 			"appEndpointName": appEndpointName,
+			"statusCode":      getResyncStatusResp.HTTPResponse.StatusCode,
 		})
-		return nil, errors.New("Unexpected status while getting App Endpoint Logging Config: " + string(getResyncStatusResp.Body))
+		return nil, &internalapi.Error{
+			HttpStatusCode: getResyncStatusResp.HTTPResponse.StatusCode,
+			Message:        "Unexpected status while getting App Endpoint Resync status: " + string(getResyncStatusResp.Body),
+		}
 	}
 
 	return getResyncStatusResp.JSON200, err

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -5,13 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/appservice"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
-
-	"time"
-
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -255,6 +253,17 @@ func (a *AppService) Update(ctx context.Context, req resource.UpdateRequest, res
 		resp.Diagnostics.AddError(
 			"Error updating app service",
 			"Could not update app service id "+state.Id.String()+" unexpected error: "+errors.ErrUnableToUpdateAppServiceName.Error(),
+		)
+		return
+	}
+
+	if !plan.Version.IsNull() && !plan.Version.IsUnknown() && !plan.Version.Equal(state.Version) {
+		resp.Diagnostics.AddError(
+			"Error updating app service",
+			"Could not update app service ID "+state.Id.String()+" version as this is not supported. "+
+				"To fix, destroy the App Service and create a new one with the desired version, "+
+				"update the version in the plan to the current version ("+state.Version.ValueString()+"), "+
+				"or omit version from the plan completely.",
 		)
 		return
 	}

--- a/internal/resources/appservice_schema.go
+++ b/internal/resources/appservice_schema.go
@@ -27,7 +27,7 @@ func AppServiceSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "nodes", appServiceBuilder, int64Attribute(optional, computed))
 	capellaschema.AddAttr(attrs, "cloud_provider", appServiceBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "current_state", appServiceBuilder, stringAttribute([]string{computed}))
-	capellaschema.AddAttr(attrs, "version", appServiceBuilder, stringAttribute([]string{computed}))
+	capellaschema.AddAttr(attrs, "version", appServiceBuilder, stringAttribute([]string{optional, computed}))
 	capellaschema.AddAttr(attrs, "audit", appServiceBuilder, computedAuditAttribute())
 	capellaschema.AddAttr(attrs, "if_match", appServiceBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(attrs, "etag", appServiceBuilder, stringAttribute([]string{computed}))

--- a/internal/resources/attributes.go
+++ b/internal/resources/attributes.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -98,6 +99,22 @@ func requiredNonEmptyStringAttribute() *schema.StringAttribute {
 		[]string{required, requiresReplace},
 		validator.String(stringvalidator.LengthAtLeast(1)),
 	)
+}
+
+// rfc3339Attribute is a variadic function which returns a string attribute with the requested fields set to true
+// if the string satisfies the rfc3339 format, otherwise an error is returned.
+func rfc3339Attribute(fields ...string) *schema.StringAttribute {
+	attribute := stringAttribute(fields)
+	attribute.CustomType = timetypes.RFC3339Type{}
+	return attribute
+}
+
+// rfc3339DefaultAttribute sets the default values for a string field that should satisfy the rfc3339 format
+// and returns the string attribute.
+func rfc3339DefaultAttribute(defaultValue string, fields ...string) *schema.StringAttribute {
+	attribute := rfc3339Attribute(fields...)
+	attribute.Default = stringdefault.StaticString(defaultValue)
+	return attribute
 }
 
 // boolAttribute is a variadic function which sets the requested fields

--- a/internal/resources/audit_log_export.go
+++ b/internal/resources/audit_log_export.go
@@ -19,9 +19,10 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &AuditLogExport{}
-	_ resource.ResourceWithConfigure   = &AuditLogExport{}
-	_ resource.ResourceWithImportState = &AuditLogExport{}
+	_ resource.Resource                   = &AuditLogExport{}
+	_ resource.ResourceWithConfigure      = &AuditLogExport{}
+	_ resource.ResourceWithImportState    = &AuditLogExport{}
+	_ resource.ResourceWithValidateConfig = &AuditLogExport{}
 )
 
 const errorMessageAfterAuditLogExportCreation = "Audit log export job creating is successful, but encountered an error while checking the current" +
@@ -49,6 +50,36 @@ func (a *AuditLogExport) Metadata(_ context.Context, req resource.MetadataReques
 // Schema defines the schema for the audit log export resource.
 func (a *AuditLogExport) Schema(ctx context.Context, rsc resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = AuditLogExportSchema()
+}
+
+func (a *AuditLogExport) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config providerschema.AuditLogExport
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.Start.IsNull() || config.Start.IsUnknown() || config.End.IsNull() || config.End.IsUnknown() {
+		return
+	}
+
+	start, err := time.Parse(time.RFC3339, config.Start.ValueString())
+	if err != nil {
+		return
+	}
+
+	end, err := time.Parse(time.RFC3339, config.End.ValueString())
+	if err != nil {
+		return
+	}
+
+	if end.Before(start) {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("end"),
+			"Invalid Audit Log Export Window",
+			"end must not be earlier than start",
+		)
+	}
 }
 
 // Configure set provider-defined data, clients, etc. that is passed to data sources or resources in the provider.
@@ -100,6 +131,13 @@ func (a *AuditLogExport) Create(ctx context.Context, req resource.CreateRequest,
 		resp.Diagnostics.AddError(
 			"Error creating audit log export job",
 			"Could not parse end time, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	if end.Before(start) {
+		resp.Diagnostics.AddError(
+			"Error creating audit log export job",
+			"end must not be earlier than start",
 		)
 		return
 	}

--- a/internal/resources/audit_log_export_schema.go
+++ b/internal/resources/audit_log_export_schema.go
@@ -1,24 +1,55 @@
 package resources
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
 
 var auditLogExportBuilder = capellaschema.NewSchemaBuilder("auditLogExport", "clusterAuditLogExport")
 
+type rfc3339TimestampValidator struct {
+	attributeName string
+}
+
+func (v rfc3339TimestampValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("%s must be a valid RFC3339 timestamp", v.attributeName)
+}
+
+func (v rfc3339TimestampValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v rfc3339TimestampValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if _, err := time.Parse(time.RFC3339, req.ConfigValue.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid RFC3339 Timestamp",
+			fmt.Sprintf("%s must be a valid RFC3339 timestamp", v.attributeName),
+		)
+	}
+}
+
 func AuditLogExportSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
 
 	capellaschema.AddAttr(attrs, "id", auditLogExportBuilder, stringAttribute([]string{computed, useStateForUnknown}))
-	capellaschema.AddAttr(attrs, "organization_id", auditLogExportBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(attrs, "project_id", auditLogExportBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(attrs, "cluster_id", auditLogExportBuilder, stringAttribute([]string{required}))
+	capellaschema.AddAttr(attrs, "organization_id", auditLogExportBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "project_id", auditLogExportBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "cluster_id", auditLogExportBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "audit_log_download_url", auditLogExportBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "expiration", auditLogExportBuilder, stringAttribute([]string{computed}))
-	capellaschema.AddAttr(attrs, "start", auditLogExportBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(attrs, "end", auditLogExportBuilder, stringAttribute([]string{required}))
+	capellaschema.AddAttr(attrs, "start", auditLogExportBuilder, stringAttribute([]string{required, requiresReplace}, rfc3339TimestampValidator{attributeName: "start"}))
+	capellaschema.AddAttr(attrs, "end", auditLogExportBuilder, stringAttribute([]string{required, requiresReplace}, rfc3339TimestampValidator{attributeName: "end"}))
 	capellaschema.AddAttr(attrs, "created_at", auditLogExportBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "status", auditLogExportBuilder, stringAttribute([]string{computed}))
 

--- a/internal/resources/audit_log_settings_schema.go
+++ b/internal/resources/audit_log_settings_schema.go
@@ -1,7 +1,11 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
@@ -12,19 +16,22 @@ var auditLogSettingsBuilder = capellaschema.NewSchemaBuilder("auditLogSettings",
 func AuditLogSettingsSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
 
-	capellaschema.AddAttr(attrs, "organization_id", auditLogSettingsBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(attrs, "project_id", auditLogSettingsBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(attrs, "cluster_id", auditLogSettingsBuilder, stringAttribute([]string{required}))
+	capellaschema.AddAttr(attrs, "organization_id", auditLogSettingsBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "project_id", auditLogSettingsBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "cluster_id", auditLogSettingsBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "audit_enabled", auditLogSettingsBuilder, boolAttribute(computed, optional))
 	capellaschema.AddAttr(attrs, "enabled_event_ids", auditLogSettingsBuilder, &schema.SetAttribute{
 		Computed:    true,
 		Optional:    true,
 		ElementType: types.Int64Type,
+		Validators: []validator.Set{
+			setvalidator.ValueInt64sAre(int64validator.AtLeast(1)),
+		},
 	})
 
 	disabledUserAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(disabledUserAttrs, "domain", auditLogSettingsBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(disabledUserAttrs, "name", auditLogSettingsBuilder, stringAttribute([]string{required}))
+	capellaschema.AddAttr(disabledUserAttrs, "domain", auditLogSettingsBuilder, stringAttribute([]string{required}, stringvalidator.LengthAtLeast(1)))
+	capellaschema.AddAttr(disabledUserAttrs, "name", auditLogSettingsBuilder, stringAttribute([]string{required}, stringvalidator.LengthAtLeast(1)))
 
 	capellaschema.AddAttr(attrs, "disabled_users", auditLogSettingsBuilder, &schema.SetNestedAttribute{
 		Computed: true,

--- a/internal/resources/backup_schedule_schema_test.go
+++ b/internal/resources/backup_schedule_schema_test.go
@@ -1,0 +1,57 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestBackupScheduleSchema_NestedEnumValidators verifies the generated enum
+// OneOf validators auto-attach to weekly_schedule's nested fields.
+func TestBackupScheduleSchema_NestedEnumValidators(t *testing.T) {
+	weekly, ok := BackupScheduleSchema().Attributes["weekly_schedule"].(*schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("weekly_schedule is %T, want *SingleNestedAttribute", BackupScheduleSchema().Attributes["weekly_schedule"])
+	}
+
+	t.Run("string enum fields reject invalid values", func(t *testing.T) {
+		for name, bad := range map[string]string{"day_of_week": "funday", "retention_time": "7days"} {
+			attr, ok := weekly.Attributes[name].(*schema.StringAttribute)
+			if !ok {
+				t.Fatalf("%s is %T, want *StringAttribute", name, weekly.Attributes[name])
+			}
+			if len(attr.Validators) == 0 {
+				t.Fatalf("weekly_schedule.%s has no validators; OneOf enum validator not attached", name)
+			}
+			resp := &validator.StringResponse{}
+			for _, v := range attr.Validators {
+				v.ValidateString(context.Background(), validator.StringRequest{ConfigValue: types.StringValue(bad)}, resp)
+			}
+			if !resp.Diagnostics.HasError() {
+				t.Errorf("weekly_schedule.%s accepted invalid value %q", name, bad)
+			}
+		}
+	})
+
+	t.Run("integer enum fields reject invalid values", func(t *testing.T) {
+		for name, bad := range map[string]int64{"start_at": 24, "incremental_every": 3} {
+			attr, ok := weekly.Attributes[name].(*schema.Int64Attribute)
+			if !ok {
+				t.Fatalf("%s is %T, want *Int64Attribute", name, weekly.Attributes[name])
+			}
+			if len(attr.Validators) == 0 {
+				t.Fatalf("weekly_schedule.%s has no validators; OneOf enum validator not attached", name)
+			}
+			resp := &validator.Int64Response{}
+			for _, v := range attr.Validators {
+				v.ValidateInt64(context.Background(), validator.Int64Request{ConfigValue: types.Int64Value(bad)}, resp)
+			}
+			if !resp.Diagnostics.HasError() {
+				t.Errorf("weekly_schedule.%s accepted invalid value %d", name, bad)
+			}
+		}
+	})
+}

--- a/internal/resources/free_tier_cluster_schema.go
+++ b/internal/resources/free_tier_cluster_schema.go
@@ -8,9 +8,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+	customvalidator "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema/validator"
 )
 
 var freeTierClusterBuilder = capellaschema.NewSchemaBuilder("freeTierCluster")
+
+// freeTierClusterRegions maps a lowercased cloud provider type to the regions
+// Capella allows for free tier clusters. Sourced from the "Create Free Tier
+// Cluster" endpoint description; update when that changes:
+// https://docs.couchbase.com/cloud/management-api-reference/index.html#tag/Free-Tier
+var freeTierClusterRegions = map[string][]string{
+	"aws":   {"us-east-2", "eu-west-1", "ap-southeast-1"},
+	"gcp":   {"us-central1", "europe-west1", "asia-east1"},
+	"azure": {"eastus", "swedencentral", "koreacentral"},
+}
 
 func FreeTierClusterSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
@@ -47,6 +58,9 @@ func FreeTierClusterSchema() schema.Schema {
 		Attributes: cloudProviderAttrs,
 		PlanModifiers: []planmodifier.Object{
 			objectplanmodifier.RequiresReplace(),
+		},
+		Validators: []validator.Object{
+			customvalidator.CloudProviderRegion(freeTierClusterRegions),
 		},
 	})
 

--- a/internal/resources/network_peer.go
+++ b/internal/resources/network_peer.go
@@ -442,7 +442,9 @@ func (n *NetworkPeer) retrieveNetworkPeer(
 		return nil, fmt.Errorf("%s: %w", errors.ErrRefreshingState, err)
 	}
 
-	refreshedState.ProviderType = types.StringValue(providerType)
+	if providerType != "" {
+		refreshedState.ProviderType = types.StringValue(providerType)
+	}
 
 	return refreshedState, nil
 }
@@ -471,7 +473,7 @@ func (n *NetworkPeer) getNetworkPeer(
 		return nil, fmt.Errorf("%s: %w", errors.ErrUnmarshallingResponse, err)
 	}
 
-	if err := defineProviderForResponse(networkResp); err != nil {
+	if err := defineProviderForResponse(&networkResp); err != nil {
 		return nil, err
 	}
 
@@ -480,7 +482,7 @@ func (n *NetworkPeer) getNetworkPeer(
 
 // defineProviderForResponse sets the provider type in the retrieved network peer as per the fields populated in the provider config.
 // If the provider type is not set through terraform separately in this manner, it will throw error as v4 get doesn't return it, but it's a field in resources.
-func defineProviderForResponse(networkResp network_peer_api.GetNetworkPeeringRecordResponse) error {
+func defineProviderForResponse(networkResp *network_peer_api.GetNetworkPeeringRecordResponse) error {
 	azure, err := networkResp.AsAZURE()
 	if err != nil {
 		return fmt.Errorf("%s: %w", errors.ErrReadingAzureConfig, err)
@@ -505,7 +507,7 @@ func defineProviderForResponse(networkResp network_peer_api.GetNetworkPeeringRec
 	case aws.AWSConfigData.VpcId != "":
 		networkResp.ProviderType = "aws"
 	default:
-		return fmt.Errorf("%s: %w", errors.ErrReadingProviderConfig, err)
+		return errors.ErrReadingProviderConfig
 	}
 
 	return nil

--- a/internal/resources/network_peer.go
+++ b/internal/resources/network_peer.go
@@ -1,21 +1,23 @@
 package resources
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
-	network_peer_api "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/network_peer"
-	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
-	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	network_peer_api "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/network_peer"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -129,10 +131,38 @@ func (n *NetworkPeer) Create(ctx context.Context, req resource.CreateRequest, re
 		nil,
 	)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating network peer",
-			errorMessageWhileNetworkPeerCreation+api.ParseError(err),
+		// The API may persist a failed peering record even when returning a non-success status.
+		// Attempt to find the resource so we can save it to state for lifecycle management.
+		peerID := n.findNetworkPeerByName(ctx, organizationId, projectId, clusterId, plan.Name.ValueString())
+		if peerID == "" {
+			resp.Diagnostics.AddError(
+				"Error creating network peer",
+				errorMessageWhileNetworkPeerCreation+api.ParseError(err),
+			)
+			return
+		}
+
+		tflog.Info(ctx, "network peer was persisted despite creation error, saving to state", map[string]interface{}{
+			"peer_id": peerID,
+		})
+
+		resp.Diagnostics.AddWarning(
+			"Network peer created with errors",
+			fmt.Sprintf(
+				"The API returned an error during creation (%s) but the network peer %q was persisted. "+
+					"The resource has been saved to state for lifecycle management. "+
+					"Review the peer status in Capella and, if necessary, run terraform destroy to clean up.",
+				api.ParseError(err), peerID,
+			),
 		)
+
+		diags = resp.State.Set(ctx, initializeNetworkPeerPlanId(plan, peerID))
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		n.setRefreshedStateOrWarn(ctx, resp, organizationId, projectId, clusterId, peerID, plan.ProviderType.ValueString(), err)
 		return
 	}
 
@@ -141,7 +171,7 @@ func (n *NetworkPeer) Create(ctx context.Context, req resource.CreateRequest, re
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating network peer",
-			errorMessageWhileNetworkPeerCreation+"error during unmarshalling:"+err.Error(),
+			errorMessageWhileNetworkPeerCreation+"error during unmarshalling: "+err.Error(),
 		)
 		return
 	}
@@ -152,21 +182,28 @@ func (n *NetworkPeer) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
-	refreshedState, err := n.retrieveNetworkPeer(ctx, organizationId, projectId, clusterId, networkPeerResponse.Id.String(), plan.ProviderType.ValueString())
+	n.setRefreshedStateOrWarn(ctx, resp, organizationId, projectId, clusterId, networkPeerResponse.Id.String(), plan.ProviderType.ValueString(), nil)
+}
+
+// setRefreshedStateOrWarn attempts to read the full peer state and set it on the response.
+// If the read fails (e.g. peer is in failed state with incomplete providerConfig), a warning
+// is emitted instead of an error so that the partial state (containing the ID) is preserved.
+func (n *NetworkPeer) setRefreshedStateOrWarn(ctx context.Context, resp *resource.CreateResponse, organizationId, projectId, clusterId, peerID, providerType string, originalErr error) {
+	refreshedState, err := n.retrieveNetworkPeer(ctx, organizationId, projectId, clusterId, peerID, providerType)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading network peering service status",
-			"Error reading network peering service status, unexpected error: "+err.Error(),
+		detail := "The network peer was created but its current status could not be fully read: " + err.Error()
+		if originalErr != nil {
+			detail += ". Original creation error: " + api.ParseError(originalErr)
+		}
+		resp.Diagnostics.AddWarning(
+			"Network peer created with incomplete state",
+			detail,
 		)
-
 		return
 	}
 
-	diags = resp.State.Set(ctx, refreshedState)
+	diags := resp.State.Set(ctx, refreshedState)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 // createAWSProviderConfig is the function to handle AWS configuration.
@@ -423,18 +460,20 @@ func (n *NetworkPeer) retrieveNetworkPeer(
 ) (*providerschema.NetworkPeer, error) {
 	networkPeerResp, err := n.getNetworkPeer(ctx, organizationId, projectId, clusterId, peerId)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errors.ErrNotFound, err)
+		return nil, fmt.Errorf("%w: %w", errors.ErrNotFound, err)
+	}
+
+	// Use the known provider type when the response doesn't include it
+	// (common for failed peers with empty providerConfig).
+	if networkPeerResp.ProviderType == "" || validateProviderTypeIsSameInPlanAndState(providerType, networkPeerResp.ProviderType) {
+		networkPeerResp.ProviderType = providerType
 	}
 
 	audit := providerschema.NewCouchbaseAuditData(networkPeerResp.Audit)
 
 	auditObj, diags := types.ObjectValueFrom(ctx, audit.AttributeTypes(), audit)
 	if diags.HasError() {
-		return nil, fmt.Errorf("%s: %w", errors.ErrUnableToConvertAuditData, err)
-	}
-
-	if validateProviderTypeIsSameInPlanAndState(providerType, networkPeerResp.ProviderType) {
-		networkPeerResp.ProviderType = providerType
+		return nil, fmt.Errorf("%w: %v", errors.ErrUnableToConvertAuditData, diags.Errors())
 	}
 
 	refreshedState, err := providerschema.NewNetworkPeer(ctx, networkPeerResp, organizationId, projectId, clusterId, auditObj)
@@ -449,8 +488,8 @@ func (n *NetworkPeer) retrieveNetworkPeer(
 	return refreshedState, nil
 }
 
-// getNetworkPeer retrieves cluster information from the specified organization and project
-// using the provided cluster ID by open-api call.
+// getNetworkPeer retrieves network peer information from the specified organization and project
+// using the provided cluster ID and peer ID by open-api call.
 func (n *NetworkPeer) getNetworkPeer(
 	ctx context.Context, organizationId, projectId, clusterId, peerId string,
 ) (*network_peer_api.GetNetworkPeeringRecordResponse, error) {
@@ -473,32 +512,35 @@ func (n *NetworkPeer) getNetworkPeer(
 		return nil, fmt.Errorf("%s: %w", errors.ErrUnmarshallingResponse, err)
 	}
 
-	if err := defineProviderForResponse(&networkResp); err != nil {
-		return nil, err
-	}
+	// Best-effort provider type detection from response config fields.
+	// For failed peers, providerConfig may be empty so this detection is not fatal.
+	_ = defineProviderForResponse(&networkResp)
 
 	return &networkResp, nil
 }
 
-// defineProviderForResponse sets the provider type in the retrieved network peer as per the fields populated in the provider config.
-// If the provider type is not set through terraform separately in this manner, it will throw error as v4 get doesn't return it, but it's a field in resources.
+// defineProviderForResponse sets the provider type on the response based on populated
+// provider config fields. Returns an error if provider type cannot be determined (e.g.
+// when a failed peer has an empty providerConfig), but callers may choose to ignore it.
 func defineProviderForResponse(networkResp *network_peer_api.GetNetworkPeeringRecordResponse) error {
+	if len(networkResp.ProviderConfig) == 0 || bytes.Equal(networkResp.ProviderConfig, json.RawMessage("null")) {
+		return fmt.Errorf("%w: providerConfig is empty", errors.ErrReadingProviderConfig)
+	}
 	azure, err := networkResp.AsAZURE()
 	if err != nil {
-		return fmt.Errorf("%s: %w", errors.ErrReadingAzureConfig, err)
+		return fmt.Errorf("%w: %w", errors.ErrReadingAzureConfig, err)
 	}
 
 	gcp, err := networkResp.AsGCP()
 	if err != nil {
-		return fmt.Errorf("%s: %w", errors.ErrReadingGCPConfig, err)
+		return fmt.Errorf("%w: %w", errors.ErrReadingGCPConfig, err)
 	}
 
 	aws, err := networkResp.AsAWS()
 	if err != nil {
-		return fmt.Errorf("%s: %w", errors.ErrReadingAWSConfig, err)
+		return fmt.Errorf("%w: %w", errors.ErrReadingAWSConfig, err)
 	}
 
-	// if there is no error, set the provider type for the provider config as per the populated fields in the get response.
 	switch {
 	case azure.AzureConfigData.AzureTenantId != "":
 		networkResp.ProviderType = "azure"
@@ -507,10 +549,52 @@ func defineProviderForResponse(networkResp *network_peer_api.GetNetworkPeeringRe
 	case aws.AWSConfigData.VpcId != "":
 		networkResp.ProviderType = "aws"
 	default:
-		return errors.ErrReadingProviderConfig
+		return fmt.Errorf("%w: unable to determine provider type from config fields", errors.ErrReadingProviderConfig)
 	}
 
 	return nil
+}
+
+// findNetworkPeerByName lists all network peers for a cluster and returns the ID
+// of the peer whose name matches. Retries a few times with a short delay to
+// account for eventual consistency where the peer may not be immediately visible
+// after the create API returns an error.
+func (n *NetworkPeer) findNetworkPeerByName(ctx context.Context, organizationId, projectId, clusterId, name string) string {
+	const maxAttempts = 3
+	const retryDelay = 3 * time.Second
+
+	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/networkPeers", n.HostURL, organizationId, projectId, clusterId)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		peers, err := api.GetPaginated[[]network_peer_api.GetNetworkPeeringRecordResponse](ctx, n.ClientV1, n.Token, cfg, api.SortById)
+		if err != nil {
+			tflog.Warn(ctx, "failed to list network peers while searching for persisted record", map[string]interface{}{
+				"error":   err.Error(),
+				"attempt": attempt,
+			})
+		} else {
+			for i := range peers {
+				if peers[i].Name == name {
+					return peers[i].Id.String()
+				}
+			}
+		}
+
+		if attempt < maxAttempts {
+			tflog.Info(ctx, "network peer not found yet, retrying after delay", map[string]interface{}{
+				"attempt": attempt,
+				"delay":   retryDelay.String(),
+			})
+			select {
+			case <-ctx.Done():
+				return ""
+			case <-time.After(retryDelay):
+			}
+		}
+	}
+
+	return ""
 }
 
 func validateProviderTypeIsSameInPlanAndState(planProviderType, stateProviderType string) bool {

--- a/internal/resources/network_peer_schema.go
+++ b/internal/resources/network_peer_schema.go
@@ -1,10 +1,12 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
@@ -25,7 +27,10 @@ func NetworkPeerSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "project_id", networkPeerBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "cluster_id", networkPeerBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "name", networkPeerBuilder, stringAttribute([]string{required, requiresReplace}))
-	capellaschema.AddAttr(attrs, "provider_type", networkPeerBuilder, stringAttribute([]string{required, requiresReplace}))
+	capellaschema.AddAttr(attrs, "provider_type", networkPeerBuilder, stringAttribute(
+		[]string{required, requiresReplace},
+		validator.String(stringvalidator.OneOf("aws", "gcp", "azure")),
+	))
 	capellaschema.AddAttr(attrs, "audit", networkPeerBuilder, computedAuditAttribute())
 	capellaschema.AddAttr(attrs, "commands", networkPeerBuilder, &schema.SetAttribute{
 		Computed:    true,

--- a/internal/resources/private_endpoint_service.go
+++ b/internal/resources/private_endpoint_service.go
@@ -3,12 +3,15 @@ package resources
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -25,7 +28,37 @@ var (
 )
 
 const (
-	errorMessageWhileEnablingPrivateEndpointService = "There is an error while enabling private endpoint service. Please check in Capella to see if there are any hanging resources\" +\n\t\" have been created, unexpected error: "
+	errorMessageWhileEnablingPrivateEndpointService = "There is an error while enabling private endpoint service. Please check in Capella to see if there are any hanging resources that have been created, unexpected error: "
+)
+
+// Private endpoint service lifecycle states returned by the GET status API.
+// enableFailed/disableFailed are terminal (no automatic retry); enabling,
+// disabling, and unknown are transient; idle means no operation has run.
+const (
+	statusIdle          = "idle"
+	statusEnabling      = "enabling"
+	statusEnabled       = "enabled"
+	statusEnableFailed  = "enableFailed"
+	statusDisabling     = "disabling"
+	statusDisabled      = "disabled"
+	statusDisableFailed = "disableFailed"
+	statusUnknown       = "unknown"
+)
+
+// These are vars rather than consts so unit tests can shorten them; production
+// behavior is unchanged.
+var (
+	// cleanupTimeout bounds how long we wait for the backend to tear down a
+	// failed enable before giving up and surfacing an escalation error.
+	cleanupTimeout = 15 * time.Minute
+
+	// pollInterval is how often the service status is polled while waiting for a
+	// transition.
+	pollInterval = 30 * time.Second
+
+	// statusChangeTimeout bounds how long we wait for the service to reach the
+	// desired lifecycle state, end-to-end.
+	statusChangeTimeout = 60 * time.Minute
 )
 
 // PrivateEndpointService is the scope resource implementation.
@@ -103,10 +136,17 @@ func (p *PrivateEndpointService) Create(ctx context.Context, req resource.Create
 
 	err = p.waitUntilStatusChanges(ctx, true, organizationId, projectId, clusterId)
 	if err != nil {
+		// Terminal enableFailed: clean up the orphaned infra and remove the
+		// resource so the next apply performs a clean re-create.
+		if stderrors.Is(err, errors.ErrPrivateEndpointServiceEnableFailed) {
+			p.handleFailedEnable(ctx, &resp.State, &resp.Diagnostics, organizationId, projectId, clusterId, err)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error could not enable private endpoint service",
 			"Error could not enable private endpoint service, unexpected error: "+err.Error(),
 		)
+		return
 	}
 
 	refreshedState, err := p.getServiceState(ctx, organizationId, projectId, clusterId)
@@ -166,7 +206,13 @@ func (p *PrivateEndpointService) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	diags = resp.State.Set(ctx, &refreshedState)
+	if refreshedState.Status.ValueString() == statusEnableFailed {
+		tflog.Info(ctx, "private endpoint service is in enableFailed state; removing from state to force re-create")
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	diags = resp.State.Set(ctx, refreshedState)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -219,6 +265,16 @@ func (p *PrivateEndpointService) Update(ctx context.Context, req resource.Update
 		config.ProjectId.ValueString(),
 		config.ClusterId.ValueString())
 	if err != nil {
+		// An enable-flavored update that fails terminally is recovered the same
+		// way as Create: clean up and remove from state for a clean retry.
+		if config.Enabled.ValueBool() && stderrors.Is(err, errors.ErrPrivateEndpointServiceEnableFailed) {
+			p.handleFailedEnable(ctx, &resp.State, &resp.Diagnostics,
+				config.OrganizationId.ValueString(),
+				config.ProjectId.ValueString(),
+				config.ClusterId.ValueString(),
+				err)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error "+status+" private endpoint service",
 			"Error "+status+"private endpoint service, unexpected error: "+err.Error(),
@@ -300,12 +356,26 @@ func (p *PrivateEndpointService) Delete(ctx context.Context, req resource.Delete
 
 	err = p.waitUntilStatusChanges(ctx, false, organizationId, projectId, clusterId)
 	if err != nil {
+		// On a terminal disableFailed we fail fast and keep the resource in state
+		// (Terraform retains a resource whose Delete errors). The correct retry
+		// for a failed disable is another destroy, which Terraform performs
+		// naturally on the next run.
+		if stderrors.Is(err, errors.ErrPrivateEndpointServiceDisableFailed) {
+			resp.Diagnostics.AddError(
+				"Private endpoint service disable failed",
+				fmt.Sprintf(
+					"Disable failed for cluster %s: %s. The resource has been kept in state; "+
+						"re-run terraform destroy to retry, and contact Couchbase Capella Support if it persists.",
+					clusterId, err.Error(),
+				),
+			)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error could not disable private endpoint service",
 			"Error could not disable private endpoint service, unexpected error: "+err.Error(),
 		)
 	}
-
 }
 
 // Configure It adds the provider configured api to the private endpoint service resource.
@@ -353,16 +423,130 @@ func initializePrivateEndpointServicePlan(plan providerschema.PrivateEndpointSer
 	if plan.Enabled.IsNull() || plan.Enabled.IsUnknown() {
 		plan.Enabled = types.BoolNull()
 	}
+	// status is computed; never persist an unknown value to state.
+	if plan.Status.IsNull() || plan.Status.IsUnknown() {
+		plan.Status = types.StringNull()
+	}
 	return plan
 }
 
-// waitUntilStatusChanges terraform will wait until the service status changes on the cluster.
+// waitUntilStatusChanges waits until the service reaches the desired state on the
+// cluster. When the API reports an explicit lifecycle status it keeps polling on
+// transient ones (enabling/disabling/unknown) and fails fast on terminal ones
+// (enableFailed/disableFailed) — but only once it has seen evidence the current
+// operation is in flight, so a residual terminal state from a prior attempt is
+// not mistaken for failure of the operation we just issued. When the status is
+// absent — which happens on GCP, when the private endpoint status feature flag
+// is disabled, or on older control planes — it falls back to the Enabled
+// boolean, preserving the previous behavior. The overall timeout remains as a
+// backstop.
 func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, finalState bool, organizationId, projectId, clusterId string) error {
 	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, time.Minute*60)
+	ctx, cancel = context.WithTimeout(ctx, statusChangeTimeout)
 	defer cancel()
 
-	timer := time.NewTimer(time.Minute * 1)
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	// sawInFlight flips true once we observe any status other than the
+	// terminal-failure ones, which is our evidence that the backend has
+	// progressed past whatever residual state was present before our POST.
+	// Until then, a reported enableFailed/disableFailed could be stale and is
+	// treated as transient.
+	var sawInFlight bool
+
+	// lastTerminalFailure records a terminal-failure status we observed but
+	// deferred on because sawInFlight was still false (i.e. it might have been
+	// residual from a prior attempt). If the backend never transitions and we
+	// hit the overall timeout, this lets us surface the typed failure error so
+	// the caller still routes to cleanup, instead of a generic timeout that
+	// would leave orphaned infra behind and skip state removal.
+	var lastTerminalFailure error
+
+	for {
+		select {
+		case <-ctx.Done():
+			// If the operation appeared stuck at a terminal failure the whole
+			// time (sawInFlight never flipped), trust that failure now rather
+			// than returning a generic timeout — the generic timeout does not
+			// route to handleFailedEnable, so cleanup/state-removal would be
+			// skipped.
+			if lastTerminalFailure != nil {
+				return lastTerminalFailure
+			}
+			return errors.ErrPrivateEndpointServiceTimeout
+
+		case <-timer.C:
+			response, err := p.getServiceStatus(ctx, organizationId, projectId, clusterId)
+			if err != nil {
+				// If our deadline expired mid-request, surface the typed
+				// timeout rather than the raw context error — the select may
+				// race with ctx.Done() when both are ready.
+				if ctx.Err() != nil {
+					if lastTerminalFailure != nil {
+						return lastTerminalFailure
+					}
+					return errors.ErrPrivateEndpointServiceTimeout
+				}
+				return err
+			}
+
+			// Status is absent on GCP, when the status feature flag is disabled,
+			// or on older control planes: fall back to the Enabled boolean,
+			// preserving the previous behavior.
+			if response.Status == nil {
+				if response.Enabled == finalState {
+					return nil
+				}
+				timer.Reset(pollInterval)
+				continue
+			}
+
+			switch *response.Status {
+			case statusEnableFailed:
+				if sawInFlight {
+					return errors.ErrPrivateEndpointServiceEnableFailed
+				}
+				// Possibly-stale: defer, but remember it so a never-transitioning
+				// enableFailed is still routed to cleanup on timeout.
+				lastTerminalFailure = errors.ErrPrivateEndpointServiceEnableFailed
+			case statusDisableFailed:
+				if sawInFlight {
+					return errors.ErrPrivateEndpointServiceDisableFailed
+				}
+				lastTerminalFailure = errors.ErrPrivateEndpointServiceDisableFailed
+			case statusEnabling, statusDisabling, statusUnknown:
+				sawInFlight = true
+				// The backend progressed, so any earlier terminal status was
+				// genuinely stale; a later stall is a real transition timeout.
+				lastTerminalFailure = nil
+			case statusEnabled, statusDisabled, statusIdle:
+				sawInFlight = true
+				lastTerminalFailure = nil
+				if response.Enabled == finalState {
+					return nil
+				}
+			}
+			timer.Reset(pollInterval)
+		}
+	}
+}
+
+// waitUntilCleanedUp waits for the backend to finish tearing down a failed enable
+// after a disable (DELETE) has been issued. It succeeds once the service reaches
+// disabled/idle (or reports disabled via the boolean when status is absent — on
+// GCP, with the status feature flag disabled, or on older control planes) and
+// fails fast if the teardown itself reports disableFailed. It is bounded by
+// cleanupTimeout so a stuck cleanup does not block apply indefinitely.
+func (p *PrivateEndpointService) waitUntilCleanedUp(ctx context.Context, organizationId, projectId, clusterId string) error {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, cleanupTimeout)
+	defer cancel()
+
+	// Fire immediately so a terminal disableFailed (or post-teardown 404) is
+	// observed without paying a pollInterval delay.
+	timer := time.NewTimer(0)
+	defer timer.Stop()
 
 	for {
 		select {
@@ -372,15 +556,83 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 		case <-timer.C:
 			response, err := p.getServiceStatus(ctx, organizationId, projectId, clusterId)
 			if err != nil {
+				// A post-teardown 404 means cleanup finished — the service no
+				// longer exists on the backend, which is the success condition.
+				if resourceNotFound, _ := api.CheckResourceNotFoundError(err); resourceNotFound {
+					return nil
+				}
 				return err
 			}
 
-			if response.Enabled == finalState {
+			if response.Status != nil {
+				switch *response.Status {
+				case statusDisableFailed:
+					return errors.ErrPrivateEndpointServiceDisableFailed
+				case statusDisabled, statusIdle:
+					return nil
+				}
+				// enableFailed/disabling/etc: cleanup still in progress, keep polling.
+			} else if !response.Enabled {
 				return nil
 			}
-			timer.Reset(time.Minute * 1)
+			timer.Reset(pollInterval)
 		}
 	}
+}
+
+// cleanupFailedEnable issues a disable (DELETE) to trigger backend teardown of a
+// failed enable and waits for the teardown to complete. The backend allows
+// disable from the enableFailed state specifically so this orphaned infra can be
+// cleaned up.
+func (p *PrivateEndpointService) cleanupFailedEnable(ctx context.Context, organizationId, projectId, clusterId string) error {
+	url := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/privateEndpointService",
+		p.HostURL,
+		organizationId,
+		projectId,
+		clusterId,
+	)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodDelete, SuccessStatus: http.StatusAccepted}
+	if _, err := p.ClientV1.ExecuteWithRetry(ctx, cfg, nil, p.Token, nil); err != nil {
+		return fmt.Errorf("could not trigger cleanup of failed enable: %w", err)
+	}
+
+	return p.waitUntilCleanedUp(ctx, organizationId, projectId, clusterId)
+}
+
+// handleFailedEnable performs recovery for a terminal enableFailed:
+// it triggers backend cleanup of the orphaned resources, removes the resource
+// from state so the next apply performs a clean re-create, and surfaces an
+// actionable error. State is removed even when cleanup itself fails, because
+// leaving a permanently-failed resource in state recreates the stuck-pipeline
+// problem; the loud error directs escalation for the rare orphaned-infra case.
+func (p *PrivateEndpointService) handleFailedEnable(ctx context.Context, state *tfsdk.State, diags *diag.Diagnostics, organizationId, projectId, clusterId string, cause error) {
+	tflog.Error(ctx, "private endpoint service enablement failed; triggering cleanup and removing from state")
+
+	cleanupErr := p.cleanupFailedEnable(ctx, organizationId, projectId, clusterId)
+	state.RemoveResource(ctx)
+
+	if cleanupErr != nil {
+		diags.AddError(
+			"Private endpoint service enablement failed and automatic cleanup did not complete",
+			fmt.Sprintf(
+				"Enablement failed for cluster %s: %s. Automatic cleanup of the failed resources did not complete: %s. "+
+					"There may be orphaned resources in your cloud account; please contact Couchbase Capella Support. "+
+					"The resource has been removed from state; re-run terraform apply to retry enablement.",
+				clusterId, cause.Error(), cleanupErr.Error(),
+			),
+		)
+		return
+	}
+
+	diags.AddError(
+		"Private endpoint service enablement failed",
+		fmt.Sprintf(
+			"Enablement failed for cluster %s: %s. The failed resources were cleaned up automatically and the resource "+
+				"has been removed from state; re-run terraform apply to retry enablement.",
+			clusterId, cause.Error(),
+		),
+	)
 }
 
 // getServiceStatus retrieves current private endpoint service status.
@@ -419,6 +671,10 @@ func (p *PrivateEndpointService) getServiceState(ctx context.Context, organizati
 		ProjectId:      types.StringValue(projectId),
 		ClusterId:      types.StringValue(clusterId),
 		Enabled:        types.BoolValue(response.Enabled),
+		Status:         types.StringNull(),
+	}
+	if response.Status != nil {
+		state.Status = types.StringValue(*response.Status)
 	}
 
 	return &state, nil

--- a/internal/resources/private_endpoint_service_schema.go
+++ b/internal/resources/private_endpoint_service_schema.go
@@ -22,8 +22,17 @@ func PrivateEndpointServiceSchema() schema.Schema {
 		PlanModifiers: []planmodifier.Bool{custommodifier.BlockCreateWhenEnabledSetToFalse()},
 	})
 
+	capellaschema.AddAttr(attrs, "status", privateEndpointServiceBuilder, &schema.StringAttribute{
+		Computed: true,
+	})
+
 	return schema.Schema{
-		MarkdownDescription: "This resource allows you to manage the private endpoint service for an operational cluster. The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. This enables secure access to your cluster without exposing traffic to the public internet.",
-		Attributes:          attrs,
+		MarkdownDescription: "This resource allows you to manage the private endpoint service for an operational cluster. " +
+			"The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. " +
+			"This enables secure access to your cluster without exposing traffic to the public internet.\n\n" +
+			"~> **Enablement failure handling:** If enablement terminally fails (`status` = `enableFailed`), the provider automatically issues a cleanup request to tear down the partially provisioned service and then removes the resource from Terraform state before the apply errors out. " +
+			"This is intentional: the resource disappearing from state is expected, and the next `terraform apply` performs a clean re-create. " +
+			"If the automatic cleanup cannot complete, the error will say so — contact Couchbase Capella Support to check for orphaned resources in your cloud account.",
+		Attributes: attrs,
 	}
 }

--- a/internal/resources/private_endpoint_service_test.go
+++ b/internal/resources/private_endpoint_service_test.go
@@ -1,0 +1,430 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"gotest.tools/assert"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+const (
+	testOrgID     = "org-1"
+	testProjectID = "proj-1"
+	testClusterID = "cluster-1"
+)
+
+// fakeBackend is an in-memory control-plane stand-in for the private endpoint
+// service API. It records every request it receives and answers GET status
+// polls from a scripted queue of responses (the final entry repeats once the
+// queue is drained) so tests can drive the poll loop deterministically.
+type fakeBackend struct {
+	mu sync.Mutex
+
+	// statuses is the queue of GET /privateEndpointService responses. The last
+	// element is returned for any poll beyond the queue length.
+	statuses []api.GetPrivateEndpointServiceStatusResponse
+
+	// deleteStatus is the HTTP status returned for DELETE requests.
+	deleteStatus int
+	// deleteBody is the body returned for DELETE requests (used to simulate an
+	// API error on cleanup).
+	deleteBody string
+
+	// recorded request methods, in order.
+	methods []string
+	getIdx  int
+}
+
+func (b *fakeBackend) counts() (gets, deletes int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, m := range b.methods {
+		switch m {
+		case http.MethodGet:
+			gets++
+		case http.MethodDelete:
+			deletes++
+		}
+	}
+	return gets, deletes
+}
+
+func (b *fakeBackend) handler(w http.ResponseWriter, r *http.Request) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.methods = append(b.methods, r.Method)
+
+	switch r.Method {
+	case http.MethodDelete:
+		status := b.deleteStatus
+		if status == 0 {
+			status = http.StatusAccepted
+		}
+		w.WriteHeader(status)
+		if b.deleteBody != "" {
+			_, _ = w.Write([]byte(b.deleteBody))
+		}
+	case http.MethodGet:
+		idx := b.getIdx
+		if idx >= len(b.statuses) {
+			idx = len(b.statuses) - 1
+		}
+		b.getIdx++
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(b.statuses[idx])
+	default:
+		// Treat POST (enable) as accepted.
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+// newTestResource wires a PrivateEndpointService to an httptest server backed
+// by the supplied fakeBackend.
+func newTestResource(t *testing.T, b *fakeBackend) *PrivateEndpointService {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(b.handler))
+	t.Cleanup(srv.Close)
+
+	return &PrivateEndpointService{
+		Data: &providerschema.Data{
+			ClientV1: &api.Client{Client: srv.Client()},
+			HostURL:  srv.URL,
+		},
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+// fastPolling shrinks the package-level poll timing for the duration of a test
+// so the poll loops resolve in milliseconds rather than seconds.
+func fastPolling(t *testing.T) {
+	t.Helper()
+	origPoll, origCleanup, origStatus := pollInterval, cleanupTimeout, statusChangeTimeout
+	pollInterval = time.Millisecond
+	cleanupTimeout = 2 * time.Second
+	statusChangeTimeout = 2 * time.Second
+	t.Cleanup(func() {
+		pollInterval = origPoll
+		cleanupTimeout = origCleanup
+		statusChangeTimeout = origStatus
+	})
+}
+
+func TestWaitUntilStatusChanges(t *testing.T) {
+	fastPolling(t)
+
+	tests := []struct {
+		name       string
+		finalState bool
+		statuses   []api.GetPrivateEndpointServiceStatusResponse
+		wantErr    error
+	}{
+		{
+			// A terminal enableFailed that is present from the first poll and
+			// never transitions cannot be told apart from a stale one while it
+			// is happening, so the loop keeps polling. But on the overall
+			// timeout we trust the persistent terminal status and surface the
+			// typed failure (not a generic timeout) so the caller still routes
+			// to cleanup / state removal instead of leaving orphaned infra.
+			name:       "enableFailed stuck without any progress surfaces enableFailed on timeout",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: strPtr(statusEnableFailed)},
+			},
+			wantErr: errors.ErrPrivateEndpointServiceEnableFailed,
+		},
+		{
+			// Symmetric case on the disable path.
+			name:       "disableFailed stuck without any progress surfaces disableFailed on timeout",
+			finalState: false,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: strPtr(statusDisableFailed)},
+			},
+			wantErr: errors.ErrPrivateEndpointServiceDisableFailed,
+		},
+		{
+			// Once the backend shows progress (enabling) the earlier terminal
+			// status was genuinely stale, so a later stall is a real transition
+			// timeout — NOT a failure. This proves the deferred-failure latch is
+			// cleared when sawInFlight flips.
+			name:       "stale enableFailed then stuck enabling times out generically",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: strPtr(statusEnableFailed)},
+				{Enabled: false, Status: strPtr(statusEnabling)},
+			},
+			wantErr: errors.ErrPrivateEndpointServiceTimeout,
+		},
+		{
+			name:       "transient enabling resolves to enabled",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: strPtr(statusEnabling)},
+				{Enabled: false, Status: strPtr(statusUnknown)},
+				{Enabled: true, Status: strPtr(statusEnabled)},
+			},
+			wantErr: nil,
+		},
+		{
+			name:       "transient disabling resolves to disabled",
+			finalState: false,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: strPtr(statusDisabling)},
+				{Enabled: false, Status: strPtr(statusDisabled)},
+			},
+			wantErr: nil,
+		},
+		{
+			name:       "older control plane falls back to enabled boolean",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: nil},
+				{Enabled: true, Status: nil},
+			},
+			wantErr: nil,
+		},
+		{
+			name:       "resolved status but wrong boolean keeps polling until match",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				// Status says enabled but the boolean has not flipped yet, so the
+				// loop must keep polling rather than return early.
+				{Enabled: false, Status: strPtr(statusEnabled)},
+				{Enabled: true, Status: strPtr(statusEnabled)},
+			},
+			wantErr: nil,
+		},
+		{
+			// Reproduces the stale-state race: a prior failed attempt left the
+			// backend in enableFailed; our POST has been accepted but the GET we
+			// fire immediately afterward may still see the residual terminal
+			// state before the new enable job is observed. The poll must wait
+			// for evidence the current operation is in flight (a transient
+			// state) before short-circuiting on a terminal status.
+			name:       "stale enableFailed before current operation in flight resolves to enabled",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: strPtr(statusEnableFailed)},
+				{Enabled: false, Status: strPtr(statusEnabling)},
+				{Enabled: true, Status: strPtr(statusEnabled)},
+			},
+			wantErr: nil,
+		},
+		{
+			// Symmetric case on the disable path.
+			name:       "stale disableFailed before current operation in flight resolves to disabled",
+			finalState: false,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: strPtr(statusDisableFailed)},
+				{Enabled: true, Status: strPtr(statusDisabling)},
+				{Enabled: false, Status: strPtr(statusDisabled)},
+			},
+			wantErr: nil,
+		},
+		{
+			// After we have evidence the current operation is in flight, a
+			// terminal status IS authoritative — the existing fail-fast
+			// behavior must be preserved.
+			name:       "enableFailed after transient enabling is terminal",
+			finalState: true,
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: false, Status: strPtr(statusEnabling)},
+				{Enabled: false, Status: strPtr(statusEnableFailed)},
+			},
+			wantErr: errors.ErrPrivateEndpointServiceEnableFailed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &fakeBackend{statuses: tc.statuses}
+			p := newTestResource(t, b)
+
+			err := p.waitUntilStatusChanges(context.Background(), tc.finalState, testOrgID, testProjectID, testClusterID)
+
+			if tc.wantErr != nil {
+				assert.Assert(t, stderrors.Is(err, tc.wantErr), "got %v, want %v", err, tc.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}
+
+func TestWaitUntilCleanedUp(t *testing.T) {
+	fastPolling(t)
+
+	tests := []struct {
+		name     string
+		statuses []api.GetPrivateEndpointServiceStatusResponse
+		wantErr  error
+	}{
+		{
+			name: "reaches disabled after teardown",
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: strPtr(statusEnableFailed)},
+				{Enabled: false, Status: strPtr(statusDisabling)},
+				{Enabled: false, Status: strPtr(statusDisabled)},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "teardown reports disableFailed",
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: strPtr(statusDisableFailed)},
+			},
+			wantErr: errors.ErrPrivateEndpointServiceDisableFailed,
+		},
+		{
+			name: "older control plane resolves via enabled boolean",
+			statuses: []api.GetPrivateEndpointServiceStatusResponse{
+				{Enabled: true, Status: nil},
+				{Enabled: false, Status: nil},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &fakeBackend{statuses: tc.statuses}
+			p := newTestResource(t, b)
+
+			err := p.waitUntilCleanedUp(context.Background(), testOrgID, testProjectID, testClusterID)
+
+			if tc.wantErr != nil {
+				assert.Assert(t, stderrors.Is(err, tc.wantErr), "got %v, want %v", err, tc.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}
+
+func TestCleanupFailedEnableIssuesDelete(t *testing.T) {
+	fastPolling(t)
+
+	b := &fakeBackend{
+		statuses: []api.GetPrivateEndpointServiceStatusResponse{
+			{Enabled: false, Status: strPtr(statusDisabled)},
+		},
+	}
+	p := newTestResource(t, b)
+
+	err := p.cleanupFailedEnable(context.Background(), testOrgID, testProjectID, testClusterID)
+	assert.NilError(t, err)
+
+	_, deletes := b.counts()
+	assert.Equal(t, deletes, 1, "cleanup must issue exactly one DELETE on the user's behalf")
+}
+
+func TestCleanupFailedEnablePropagatesDeleteError(t *testing.T) {
+	fastPolling(t)
+
+	b := &fakeBackend{
+		deleteStatus: http.StatusInternalServerError,
+		deleteBody:   `{"code":4000,"message":"boom","httpStatusCode":500}`,
+	}
+	p := newTestResource(t, b)
+
+	err := p.cleanupFailedEnable(context.Background(), testOrgID, testProjectID, testClusterID)
+	assert.Assert(t, err != nil, "a failed DELETE must surface an error")
+
+	gets, _ := b.counts()
+	assert.Equal(t, gets, 0, "must not poll for cleanup completion when the DELETE itself failed")
+}
+
+func TestHandleFailedEnableCleansUpAndRemovesState(t *testing.T) {
+	fastPolling(t)
+
+	b := &fakeBackend{
+		statuses: []api.GetPrivateEndpointServiceStatusResponse{
+			{Enabled: false, Status: strPtr(statusDisabled)},
+		},
+	}
+	p := newTestResource(t, b)
+
+	state := &tfsdk.State{Schema: PrivateEndpointServiceSchema()}
+	var diags diag.Diagnostics
+
+	p.handleFailedEnable(context.Background(), state, &diags,
+		testOrgID, testProjectID, testClusterID, errors.ErrPrivateEndpointServiceEnableFailed)
+
+	_, deletes := b.counts()
+	assert.Equal(t, deletes, 1, "must issue a DELETE to clean up the failed enable")
+	assert.Assert(t, state.Raw.IsNull(), "resource must be removed from state for a clean re-create")
+	assert.Equal(t, diags.HasError(), true, "must surface an actionable error")
+	assert.Equal(t, diags.Errors()[0].Summary(), "Private endpoint service enablement failed")
+}
+
+func TestHandleFailedEnableRemovesStateEvenWhenCleanupFails(t *testing.T) {
+	fastPolling(t)
+
+	// DELETE fails, so automatic cleanup cannot complete.
+	b := &fakeBackend{
+		deleteStatus: http.StatusInternalServerError,
+		deleteBody:   `{"code":4000,"message":"boom","httpStatusCode":500}`,
+	}
+	p := newTestResource(t, b)
+
+	state := &tfsdk.State{Schema: PrivateEndpointServiceSchema()}
+	var diags diag.Diagnostics
+
+	p.handleFailedEnable(context.Background(), state, &diags,
+		testOrgID, testProjectID, testClusterID, errors.ErrPrivateEndpointServiceEnableFailed)
+
+	assert.Assert(t, state.Raw.IsNull(), "state must be removed even when cleanup fails to avoid a wedged resource")
+	assert.Equal(t, diags.HasError(), true)
+	assert.Equal(t, diags.Errors()[0].Summary(),
+		"Private endpoint service enablement failed and automatic cleanup did not complete")
+}
+
+func TestGetServiceState(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      api.GetPrivateEndpointServiceStatusResponse
+		wantEnabled bool
+		wantStatus  string
+		wantNull    bool
+	}{
+		{
+			name:        "maps status when present",
+			status:      api.GetPrivateEndpointServiceStatusResponse{Enabled: true, Status: strPtr(statusEnabled)},
+			wantEnabled: true,
+			wantStatus:  statusEnabled,
+		},
+		{
+			name:        "leaves status null for older control plane",
+			status:      api.GetPrivateEndpointServiceStatusResponse{Enabled: true, Status: nil},
+			wantEnabled: true,
+			wantNull:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &fakeBackend{statuses: []api.GetPrivateEndpointServiceStatusResponse{tc.status}}
+			p := newTestResource(t, b)
+
+			got, err := p.getServiceState(context.Background(), testOrgID, testProjectID, testClusterID)
+			assert.NilError(t, err)
+			assert.Equal(t, got.Enabled.ValueBool(), tc.wantEnabled)
+			assert.Equal(t, got.Status.IsNull(), tc.wantNull)
+			if !tc.wantNull {
+				assert.Equal(t, got.Status.ValueString(), tc.wantStatus)
+			}
+		})
+	}
+}

--- a/internal/resources/private_endpoints.go
+++ b/internal/resources/private_endpoints.go
@@ -157,8 +157,11 @@ func (p *PrivateEndpoint) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	if refreshedState.Status.ValueString() == "rejected" {
-		tflog.Info(ctx, "private endpoint association is rejected; removing from state to force re-association")
+	// Both rejected and failed associations are terminal and cannot recover in
+	// place, so remove them from state to force a clean re-association on the
+	// next apply rather than leaving a stuck resource.
+	if s := refreshedState.Status.ValueString(); s == "rejected" || s == "failed" {
+		tflog.Info(ctx, "private endpoint association is "+s+"; removing from state to force re-association")
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/resources/private_endpoints_schema.go
+++ b/internal/resources/private_endpoints_schema.go
@@ -1,7 +1,9 @@
 package resources
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
@@ -14,7 +16,10 @@ func PrivateEndpointsSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", privateEndpointsBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "project_id", privateEndpointsBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "cluster_id", privateEndpointsBuilder, requiredUUIDStringAttribute())
-	capellaschema.AddAttr(attrs, "endpoint_id", privateEndpointsBuilder, stringAttribute([]string{required, requiresReplace}))
+	capellaschema.AddAttr(attrs, "endpoint_id", privateEndpointsBuilder, stringAttribute(
+		[]string{required, requiresReplace},
+		validator.String(stringvalidator.LengthAtLeast(1)),
+	))
 	capellaschema.AddAttr(attrs, "status", privateEndpointsBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "service_name", privateEndpointsBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "private_endpoint_dns", privateEndpointsBuilder, stringAttribute([]string{computed}), "GetPrivateEndpointsResponse")

--- a/internal/resources/snapshot_backup_schedule.go
+++ b/internal/resources/snapshot_backup_schedule.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -95,7 +94,7 @@ func (s *SnapshotBackupSchedule) Create(ctx context.Context, req resource.Create
 	}
 
 	var refreshedState *providerschema.SnapshotBackupSchedule
-	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan.StartTime.ValueString())
+	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId)
 	if err != nil {
 		tflog.Debug(ctx, "Error getting snapshot backup schedule after upsert", map[string]interface{}{
 			"organizationId": organizationId,
@@ -154,7 +153,7 @@ func (s *SnapshotBackupSchedule) Read(ctx context.Context, req resource.ReadRequ
 		clusterId      = IDs[providerschema.ClusterId]
 	)
 
-	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, state.StartTime.ValueString())
+	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Getting Snapshot Backup Schedule in Capella",
@@ -214,7 +213,7 @@ func (s *SnapshotBackupSchedule) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId, plan.StartTime.ValueString())
+	snapshotBackupSchedule, err := s.getSnapshotBackupSchedule(ctx, organizationId, projectId, clusterId)
 	if err != nil {
 		tflog.Debug(ctx, "Error getting snapshot backup schedule after upsert", map[string]interface{}{
 			"organizationId": organizationId,
@@ -331,7 +330,7 @@ func (s *SnapshotBackupSchedule) upsertSnapshotBackupSchedule(ctx context.Contex
 }
 
 // getSnapshotBackupSchedule retrieves the snapshot backup schedule for a cluster.
-func (s *SnapshotBackupSchedule) getSnapshotBackupSchedule(ctx context.Context, organizationId, projectId, clusterId string, startTimeString string) (*snapshot_backup_schedule.SnapshotBackupSchedule, error) {
+func (s *SnapshotBackupSchedule) getSnapshotBackupSchedule(ctx context.Context, organizationId, projectId, clusterId string) (*snapshot_backup_schedule.SnapshotBackupSchedule, error) {
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/cloudsnapshotbackupschedule", s.HostURL, organizationId, projectId, clusterId)
 	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
 	backupScheduleResp, err := s.ClientV1.ExecuteWithRetry(
@@ -362,40 +361,7 @@ func (s *SnapshotBackupSchedule) getSnapshotBackupSchedule(ctx context.Context, 
 		return nil, err
 	}
 
-	snapshotBackupSchedule.StartTime, err = s.getStartTime(ctx, startTimeString, &snapshotBackupSchedule)
-	if err != nil {
-		return nil, err
-	}
-
 	return &snapshotBackupSchedule, nil
-}
-
-// getStartTime compares the start time of the current state with the start time of the actual resource, and returns the resource's start time only if it is different.
-// This ensures that the resource storing an equivalent start time does not cause the state to be unnecessarily updated.
-func (s *SnapshotBackupSchedule) getStartTime(ctx context.Context, currentStartTimeString string, snapshotBackupSchedule *snapshot_backup_schedule.SnapshotBackupSchedule) (string, error) {
-	newStartTime, err := time.Parse(time.RFC3339, snapshotBackupSchedule.StartTime)
-	if err != nil {
-		tflog.Debug(ctx, "Error parsing updated start time", map[string]interface{}{
-			"snapshotBackupSchedule.StartTime": snapshotBackupSchedule.StartTime,
-			"err":                              err,
-		})
-		return "", err
-	}
-	if currentStartTimeString == "" {
-		return newStartTime.Format(time.RFC3339), nil
-	}
-	currentStartTime, err := time.Parse(time.RFC3339, currentStartTimeString)
-	if err != nil {
-		tflog.Debug(ctx, "Error parsing current start time", map[string]interface{}{
-			"currentStartTimeString": currentStartTimeString,
-			"err":                    err,
-		})
-		return "", err
-	}
-	if currentStartTime.Equal(newStartTime) {
-		return currentStartTimeString, nil
-	}
-	return newStartTime.Format(time.RFC3339), nil
 }
 
 func (s *SnapshotBackupSchedule) convertCopyToRegions(ctx context.Context, copyToRegionsSet types.Set) ([]string, error) {

--- a/internal/resources/snapshot_backup_schedule_schema.go
+++ b/internal/resources/snapshot_backup_schedule_schema.go
@@ -19,7 +19,7 @@ func SnapshotBackupScheduleSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "cluster_id", snapshotBackupScheduleBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "interval", snapshotBackupScheduleBuilder, int64Attribute(required))
 	capellaschema.AddAttr(attrs, "retention", snapshotBackupScheduleBuilder, int64Attribute(required))
-	capellaschema.AddAttr(attrs, "start_time", snapshotBackupScheduleBuilder, stringDefaultAttribute(time.Now().Truncate(time.Hour).Format(time.RFC3339), optional, computed))
+	capellaschema.AddAttr(attrs, "start_time", snapshotBackupScheduleBuilder, rfc3339DefaultAttribute(time.Now().Truncate(time.Hour).Format(time.RFC3339), optional, computed))
 	capellaschema.AddAttr(attrs, "copy_to_regions", snapshotBackupScheduleBuilder, stringSetAttribute(optional))
 
 	return schema.Schema{

--- a/internal/schema/appservice.go
+++ b/internal/schema/appservice.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 
@@ -97,11 +98,20 @@ func NewAppService(
 		},
 		ClusterId:    types.StringValue(appService.ClusterId),
 		CurrentState: types.StringValue(string(appService.CurrentState)),
-		Version:      types.StringValue(appService.Version),
+		Version:      types.StringValue(truncateToMajorMinor(appService.Version)),
 		Audit:        auditObject,
 		Etag:         types.StringValue(appService.Etag),
 	}
 	return &newAppService
+}
+
+// truncateToMajorMinor reduces a fully-expanded app service version such as "4.0.5-1.0.0" to its major.minor form ("4.0")
+func truncateToMajorMinor(version string) string {
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) < 2 {
+		return version
+	}
+	return parts[0] + "." + parts[1]
 }
 
 // Validate is used to verify that IDs have been properly imported.

--- a/internal/schema/network_peer.go
+++ b/internal/schema/network_peer.go
@@ -210,13 +210,19 @@ func NewNetworkPeer(ctx context.Context, networkPeer *network_peer_api.GetNetwor
 
 	newProviderConfig, err := morphToProviderConfig(networkPeer)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errors.ErrConvertingProviderConfig, err)
+		return nil, fmt.Errorf("%w: %w", errors.ErrConvertingProviderConfig, err)
 	}
 	newNetworkPeer.ProviderConfig = &newProviderConfig
 
 	if networkPeer.Status.State != nil {
 		state := *networkPeer.Status.State
-		reasoning := *networkPeer.Status.Reasoning
+		var reasoning string
+		if networkPeer.Status.Reasoning != nil {
+			reasoning = *networkPeer.Status.Reasoning
+		}
+		if state == "failed" && reasoning == "" {
+			reasoning = "Network peering failed. Remove this resource with 'terraform destroy' before retrying."
+		}
 		status := PeeringStatus{
 			State:     types.StringValue(state),
 			Reasoning: types.StringValue(reasoning),
@@ -230,7 +236,7 @@ func NewNetworkPeer(ctx context.Context, networkPeer *network_peer_api.GetNetwor
 
 	newCommands, err := MorphCommands(networkPeer.Commands)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errors.ErrConvertingCidr, err)
+		return nil, fmt.Errorf("%w: %w", errors.ErrConvertingCidr, err)
 	}
 
 	newNetworkPeer.Commands = newCommands
@@ -239,22 +245,28 @@ func NewNetworkPeer(ctx context.Context, networkPeer *network_peer_api.GetNetwor
 }
 
 // morphToProviderConfig is used to convert ProviderConfig from json.RawMessage format to ProviderConfig type.
+// Returns an empty ProviderConfig with no error when the providerConfig field is null or empty
+// (which occurs for network peers in a failed state).
 func morphToProviderConfig(networkPeer *network_peer_api.GetNetworkPeeringRecordResponse) (ProviderConfig, error) {
 	var newProviderConfig ProviderConfig
 
+	if len(networkPeer.ProviderConfig) == 0 || string(networkPeer.ProviderConfig) == "null" {
+		return newProviderConfig, nil
+	}
+
 	aws, err := networkPeer.AsAWS()
 	if err != nil {
-		return ProviderConfig{}, fmt.Errorf("%s: %w", errors.ErrReadingAWSConfig, err)
+		return ProviderConfig{}, fmt.Errorf("%w: %w", errors.ErrReadingAWSConfig, err)
 	}
 
 	gcp, err := networkPeer.AsGCP()
 	if err != nil {
-		return ProviderConfig{}, fmt.Errorf("%s: %w", errors.ErrReadingGCPConfig, err)
+		return ProviderConfig{}, fmt.Errorf("%w: %w", errors.ErrReadingGCPConfig, err)
 	}
 
 	azure, err := networkPeer.AsAZURE()
 	if err != nil {
-		return ProviderConfig{}, fmt.Errorf("%s: %w", errors.ErrReadingAzureConfig, err)
+		return ProviderConfig{}, fmt.Errorf("%w: %w", errors.ErrReadingAzureConfig, err)
 	}
 
 	switch {
@@ -287,7 +299,7 @@ func morphToProviderConfig(networkPeer *network_peer_api.GetNetworkPeeringRecord
 		}
 		return newProviderConfig, nil
 	default:
-		return ProviderConfig{}, fmt.Errorf("%s: %w", errors.ErrReadingProviderConfig, err)
+		return newProviderConfig, fmt.Errorf("%w: unable to determine provider type from config fields", errors.ErrReadingProviderConfig)
 	}
 
 }
@@ -319,19 +331,30 @@ func MorphCommands(commands []string) (basetypes.SetValue, error) {
 
 // NewNetworkPeerData create new network peer data object.
 func NewNetworkPeerData(networkPeer *network_peer_api.GetNetworkPeeringRecordResponse, organizationId, projectId, clusterId string, auditObject basetypes.ObjectValue) (*NetworkPeerData, error) {
+	var state, reasoning string
+	if networkPeer.Status.State != nil {
+		state = *networkPeer.Status.State
+	}
+	if networkPeer.Status.Reasoning != nil {
+		reasoning = *networkPeer.Status.Reasoning
+	}
+	if state == "failed" && reasoning == "" {
+		reasoning = "Network peering failed. Remove this resource with 'terraform destroy' before retrying."
+	}
+
 	newNetworkPeerData := NetworkPeerData{
 		Id:    types.StringValue(networkPeer.Id.String()),
 		Name:  types.StringValue(networkPeer.Name),
 		Audit: auditObject,
 		Status: PeeringStatus{
-			State:     types.StringValue(*networkPeer.Status.State),
-			Reasoning: types.StringValue(*networkPeer.Status.Reasoning),
+			State:     types.StringValue(state),
+			Reasoning: types.StringValue(reasoning),
 		},
 	}
 
 	newProviderConfig, err := morphToProviderConfig(networkPeer)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errors.ErrConvertingProviderConfig, err)
+		return nil, fmt.Errorf("%w: %w", errors.ErrConvertingProviderConfig, err)
 	}
 	newNetworkPeerData.ProviderConfig = newProviderConfig
 

--- a/internal/schema/network_peer_test.go
+++ b/internal/schema/network_peer_test.go
@@ -1,12 +1,19 @@
 package schema
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
+	network_peer_api "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/network_peer"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
 
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNetworkPeerSchemaValidate(t *testing.T) {
@@ -67,4 +74,77 @@ func TestNetworkPeerSchemaValidate(t *testing.T) {
 			assert.Equal(t, test.expectedOrganizationId, IDs[OrganizationId])
 		})
 	}
+}
+
+func TestMorphToProviderConfig_NilProviderConfig(t *testing.T) {
+	resp := &network_peer_api.GetNetworkPeeringRecordResponse{
+		ProviderConfig: nil,
+	}
+	cfg, err := morphToProviderConfig(resp)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.AWSConfig)
+	assert.Nil(t, cfg.GCPConfig)
+	assert.Nil(t, cfg.AzureConfig)
+}
+
+func TestMorphToProviderConfig_NullProviderConfig(t *testing.T) {
+	resp := &network_peer_api.GetNetworkPeeringRecordResponse{
+		ProviderConfig: json.RawMessage("null"),
+	}
+	cfg, err := morphToProviderConfig(resp)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.AWSConfig)
+	assert.Nil(t, cfg.GCPConfig)
+	assert.Nil(t, cfg.AzureConfig)
+}
+
+func TestNewNetworkPeer_NilReasoning(t *testing.T) {
+	state := "failed"
+	resp := &network_peer_api.GetNetworkPeeringRecordResponse{
+		Id:             uuid.New(),
+		Name:           "test-peer",
+		ProviderType:   "aws",
+		ProviderConfig: nil,
+		Status: network_peer_api.PeeringStatus{
+			State:     &state,
+			Reasoning: nil,
+		},
+	}
+
+	auditObj, _ := types.ObjectValueFrom(context.Background(), map[string]attr.Type{}, nil)
+
+	peer, err := NewNetworkPeer(context.Background(), resp, "org-1", "proj-1", "clust-1", auditObj)
+	require.NoError(t, err)
+	assert.Equal(t, "test-peer", peer.Name.ValueString())
+
+	// Status should be set with default failure reasoning
+	assert.False(t, peer.Status.IsNull())
+	var status PeeringStatus
+	diags := peer.Status.As(context.Background(), &status, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+	assert.Equal(t, "failed", status.State.ValueString())
+	assert.Equal(t, "Network peering failed. Remove this resource with 'terraform destroy' before retrying.", status.Reasoning.ValueString())
+}
+
+func TestNewNetworkPeer_NilProviderConfigAndNilReasoning(t *testing.T) {
+	state := "failed"
+	resp := &network_peer_api.GetNetworkPeeringRecordResponse{
+		Id:             uuid.New(),
+		Name:           "failed-peer",
+		ProviderType:   "aws",
+		ProviderConfig: json.RawMessage("null"),
+		Status: network_peer_api.PeeringStatus{
+			State:     &state,
+			Reasoning: nil,
+		},
+	}
+
+	auditObj, _ := types.ObjectValueFrom(context.Background(), map[string]attr.Type{}, nil)
+
+	peer, err := NewNetworkPeer(context.Background(), resp, "org-1", "proj-1", "clust-1", auditObj)
+	require.NoError(t, err)
+	assert.NotNil(t, peer.ProviderConfig)
+	assert.Nil(t, peer.ProviderConfig.AWSConfig)
+	assert.Nil(t, peer.ProviderConfig.GCPConfig)
+	assert.Nil(t, peer.ProviderConfig.AzureConfig)
 }

--- a/internal/schema/private_endpoint_service.go
+++ b/internal/schema/private_endpoint_service.go
@@ -22,6 +22,13 @@ type PrivateEndpointService struct {
 
 	// Enabled indicates if private endpoint service is enabled/disabled on cluster.
 	Enabled types.Bool `tfsdk:"enabled"`
+
+	// Status is the lifecycle state of the private endpoint service derived from
+	// the most recent enable/disable/update operation. Terminal states are
+	// enableFailed and disableFailed; transient states are enabling, disabling,
+	// and unknown; idle means no operation has run. It may be empty when the
+	// control plane does not report a status.
+	Status types.String `tfsdk:"status"`
 }
 
 // Validate is used to verify that IDs have been properly imported.

--- a/internal/schema/snapshot_backup_schedule.go
+++ b/internal/schema/snapshot_backup_schedule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -13,13 +14,13 @@ import (
 )
 
 type SnapshotBackupSchedule struct {
-	OrganizationID types.String `tfsdk:"organization_id"`
-	ProjectID      types.String `tfsdk:"project_id"`
-	ClusterID      types.String `tfsdk:"cluster_id"`
-	Interval       types.Int64  `tfsdk:"interval"`
-	Retention      types.Int64  `tfsdk:"retention"`
-	StartTime      types.String `tfsdk:"start_time"`
-	CopyToRegions  types.Set    `tfsdk:"copy_to_regions"`
+	OrganizationID types.String      `tfsdk:"organization_id"`
+	ProjectID      types.String      `tfsdk:"project_id"`
+	ClusterID      types.String      `tfsdk:"cluster_id"`
+	Interval       types.Int64       `tfsdk:"interval"`
+	Retention      types.Int64       `tfsdk:"retention"`
+	StartTime      timetypes.RFC3339 `tfsdk:"start_time"`
+	CopyToRegions  types.Set         `tfsdk:"copy_to_regions"`
 }
 
 func (s SnapshotBackupSchedule) AttributeTypes() map[string]attr.Type {
@@ -29,12 +30,17 @@ func (s SnapshotBackupSchedule) AttributeTypes() map[string]attr.Type {
 		"cluster_id":      types.StringType,
 		"interval":        types.Int64Type,
 		"retention":       types.Int64Type,
-		"start_time":      types.StringType,
+		"start_time":      timetypes.RFC3339Type{},
 		"copy_to_regions": types.SetType{ElemType: types.StringType},
 	}
 }
 
 func NewSnapshotBackupSchedule(ctx context.Context, scheduleResp snapshot_backup_schedule.SnapshotBackupSchedule, organizationID, projectID, clusterID string) (*SnapshotBackupSchedule, error) {
+	startTime, diags := timetypes.NewRFC3339PointerValue(&scheduleResp.StartTime)
+	if diags.HasError() {
+		return nil, fmt.Errorf("error converting startTime: %s", diags.Errors())
+	}
+
 	copyToRegions, diags := types.SetValueFrom(ctx, types.StringType, scheduleResp.CopyToRegions)
 	if diags.HasError() {
 		return nil, fmt.Errorf("copyToRegions set error")
@@ -46,7 +52,7 @@ func NewSnapshotBackupSchedule(ctx context.Context, scheduleResp snapshot_backup
 		ClusterID:      types.StringValue(clusterID),
 		Interval:       types.Int64Value(scheduleResp.Interval),
 		Retention:      types.Int64Value(scheduleResp.Retention),
-		StartTime:      types.StringValue(scheduleResp.StartTime),
+		StartTime:      startTime,
 		CopyToRegions:  copyToRegions,
 	}
 	return &snapshotBackupSchedule, nil

--- a/internal/schema/validator/cloud_provider_region_validator.go
+++ b/internal/schema/validator/cloud_provider_region_validator.go
@@ -1,0 +1,81 @@
+package validator
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ validator.Object = (*cloudProviderRegionValidator)(nil)
+
+// CloudProviderRegion returns an object validator for a cloud_provider block that
+// rejects a region not supported for the configured provider type. allowed maps a
+// provider type (e.g. "aws", matching the type enum's casing) to its supported
+// region codes. The check is skipped when type or region is null/unknown, or when
+// the provider type is absent from the map (its own enum validator reports that).
+func CloudProviderRegion(allowed map[string][]string) validator.Object {
+	return &cloudProviderRegionValidator{allowed: allowed}
+}
+
+type cloudProviderRegionValidator struct {
+	allowed map[string][]string
+}
+
+func (v *cloudProviderRegionValidator) Description(_ context.Context) string {
+	return v.MarkdownDescription(context.Background())
+}
+
+func (v *cloudProviderRegionValidator) MarkdownDescription(_ context.Context) string {
+	return "region must be one of the supported regions for the configured cloud provider type"
+}
+
+func (v *cloudProviderRegionValidator) ValidateObject(_ context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	attrs := req.ConfigValue.Attributes()
+
+	providerType, ok := stringValue(attrs["type"])
+	if !ok {
+		return
+	}
+	region, ok := stringValue(attrs["region"])
+	if !ok {
+		return
+	}
+
+	regions, ok := v.allowed[providerType]
+	if !ok {
+		// Unknown provider type — the type attribute's own enum validator reports it.
+		return
+	}
+
+	if slices.Contains(regions, region) {
+		return
+	}
+
+	sorted := append([]string(nil), regions...)
+	sort.Strings(sorted)
+	resp.Diagnostics.AddAttributeError(
+		req.Path.AtName("region"),
+		"Unsupported Region",
+		fmt.Sprintf("region %q is not supported for cloud provider %q. Supported regions are: %s.",
+			region, providerType, strings.Join(sorted, ", ")),
+	)
+}
+
+// stringValue returns the string and true only when value is a known, non-null
+// String; otherwise it returns false so the caller can skip validation.
+func stringValue(value any) (string, bool) {
+	s, ok := value.(types.String)
+	if !ok || s.IsNull() || s.IsUnknown() {
+		return "", false
+	}
+	return s.ValueString(), true
+}

--- a/internal/schema/validator/cloud_provider_region_validator_test.go
+++ b/internal/schema/validator/cloud_provider_region_validator_test.go
@@ -1,0 +1,97 @@
+package validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestCloudProviderRegion(t *testing.T) {
+	allowed := map[string][]string{
+		"aws":   {"us-west-2", "eu-west-1"},
+		"azure": {"eastus", "swedencentral"},
+	}
+
+	objectType := map[string]attr.Type{
+		"type":   types.StringType,
+		"region": types.StringType,
+	}
+
+	tests := []struct {
+		name      string
+		provider  attr.Value
+		region    attr.Value
+		wantError bool
+	}{
+		{
+			name:     "supported region",
+			provider: types.StringValue("aws"),
+			region:   types.StringValue("us-west-2"),
+		},
+		{
+			name:      "unsupported region",
+			provider:  types.StringValue("aws"),
+			region:    types.StringValue("us-east-99"),
+			wantError: true,
+		},
+		{
+			name:     "unknown provider type is skipped (its enum validator reports it)",
+			provider: types.StringValue("gcp"),
+			region:   types.StringValue("anything"),
+		},
+		{
+			name:     "unknown region value is skipped",
+			provider: types.StringValue("aws"),
+			region:   types.StringUnknown(),
+		},
+		{
+			name:     "null region value is skipped",
+			provider: types.StringValue("aws"),
+			region:   types.StringNull(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj, diags := types.ObjectValue(objectType, map[string]attr.Value{
+				"type":   tc.provider,
+				"region": tc.region,
+			})
+			if diags.HasError() {
+				t.Fatalf("failed to build object: %v", diags)
+			}
+
+			resp := &validator.ObjectResponse{}
+			CloudProviderRegion(allowed).ValidateObject(
+				context.Background(),
+				validator.ObjectRequest{ConfigValue: obj},
+				resp,
+			)
+
+			if got := resp.Diagnostics.HasError(); got != tc.wantError {
+				t.Errorf("HasError() = %v, want %v (diags: %v)", got, tc.wantError, resp.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestCloudProviderRegion_NullObjectSkipped(t *testing.T) {
+	obj := types.ObjectNull(map[string]attr.Type{
+		"type":   types.StringType,
+		"region": types.StringType,
+	})
+
+	resp := &validator.ObjectResponse{}
+	CloudProviderRegion(map[string][]string{"aws": {"us-west-2"}}).ValidateObject(
+		context.Background(),
+		validator.ObjectRequest{ConfigValue: obj},
+		resp,
+	)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("expected null object to be skipped, got: %v", resp.Diagnostics)
+	}
+}

--- a/templates/guides/1.9.1-upgrade-guide.md
+++ b/templates/guides/1.9.1-upgrade-guide.md
@@ -1,0 +1,62 @@
+---
+layout: "couchbase-capella"
+page_title: "Couchbase Capella Provider 1.9.1: Upgrade and Information Guide"
+sidebar_current: "docs-couchbase-capella-guides-191-upgrade-guide"
+description: |-
+Couchbase Capella Provider 1.9.1: Upgrade and Information Guide
+---
+
+# Couchbase Capella Provider 1.9.1: Upgrade and Information Guide
+
+Here is a list of what's new in 1.9.1
+
+## Enhancements
+
+This release adds plan-time validation across several resources so that invalid configuration is caught during `terraform plan` instead of failing at apply time:
+
+* Validate the free-tier cluster region before apply [#645](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/645)
+* Reject unsupported `provider_type` values on network peers [#660](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/660)
+* Reject an empty private endpoint `endpoint_id` at plan time [#663](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/663)
+* Reject short private endpoint command VPC IDs at plan time [#659](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/659)
+* Validate RFC3339 format for `start_time` in the snapshot backup schedule resource [#665](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/665)
+* Validate days, time boundaries, and duplicate/missing days for the cluster on/off schedule [#630](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/630), [#631](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/631), [#635](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/635)
+* Validate UUIDs for cluster on/off schedule data source IDs [#632](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/632)
+* Automatically attach enum validators for named-enum fields [#638](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/638)
+
+## Reliability Improvements
+
+* Fail fast and auto-recover from private endpoint service failed states [#647](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/647)
+* Add handling for service unavailable errors so transient failures are surfaced cleanly [#649](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/649)
+* Improve network peer error handling and state management [#639](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/639)
+* Handle app endpoint deletion and forbidden errors across resource operations [#634](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/634)
+
+## Bug Fixes
+
+* Fix `provider_type` being erased on network peer import/read [#643](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/643)
+* Fix the `couchbase-capella_network_peers` data source so reads no longer fail with a value conversion error [#666](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/666)
+* Fix enum lookup for nested fields [#650](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/650)
+
+## Breaking Changes
+
+WARNING: **ACTION REQUIRED**
+
+The output schema of the `couchbase-capella_network_peers` data source changed as part of [#666](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/pull/666). This is a breaking change for any configuration that reads this data source's output:
+
+* `provider_config` changed from a string to a nested object exposing `aws_config`, `gcp_config`, and `azure_config`. Update any reference that treated `provider_config` as a string to read the appropriate nested field instead (for example, `provider_config.aws_config.vpc_id`).
+* The `provider_type` and `commands` attributes were removed. Remove references to them, otherwise `terraform plan` will fail with "Unsupported attribute" errors.
+
+Only the `couchbase-capella_network_peers` data source is affected. The `couchbase-capella_network_peer` resource schema is unchanged, so no state migration is required.
+
+See the [network peer examples](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/tree/main/examples/network_peer) for the corrected shape.
+
+## Changes
+
+There are no deprecations as part of this release.
+
+1.9.1 includes validation enhancements, reliability improvements, and bug fixes, along with one breaking change to the `couchbase-capella_network_peers` data source output described above. See the [CHANGELOG](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/blob/master/CHANGELOG.md) for more specific information.
+
+### Helpful Links
+
+- [Getting Started with the Terraform Provider](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/blob/master/examples/getting_started)
+- [Capella Management API v4.0](https://docs.couchbase.com/cloud/management-api-reference/index.html)
+- [See Specific Examples](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/blob/master/examples)


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-136056

## Description

AV-136056 Merge 'main' into feature/AV-128959-eventing-functions

* main: (20 commits)
  [AV-135369] Allow App Service to be deployed with a specific version (#671)
  [AV-132949] June Release v1.9.1 (#676)
  [AV-134634] Fix - Fail fast and auto-recover from private endpoint service failed states (#647)
  [AV-131920] Update network peer documentation to reflect changes in provider configuration attributes (#672)
  [AV-135236] Validate RFC3339 Format for start_time in Snapshot Backup Schedule Resource (#665)
  [AV-131920] Refactor network peer schema to enhance provider configuration attributes (#666)
  [AV-132168] Reject unsupported network peer provider_type (#660)
  [AV-132169] Reject empty private endpoint endpoint_id at plan time (#663)
  [AV-132167] Reject short private endpoint command VPC IDs at plan time (#659)
  [AV-134866] Fix flaky app_endpoint tests by sharing bucket via collections (#655)
  [AV-129960] Add handling for service unavailable errors (#649)
  [AV-132154] Fix enum lookup for nested fields (#650)
  [AV-132148] Validate free-tier cluster region at plan time (#645)
  [AV-132944] Add audit log export and settings validation coverage (#626)
  [AV-129893] Enhance network peer error handling and state management (#639)
  [AV-131924] Fix provider_type erased on import/read (#643)
  [AV-134037] Auto-attach enum validators for -to-named-enum fields (#638)
  [AV-128971] Add certificate datasource tests; provision DM cluster lazily (#637)
  [AV-132908] Serialize cloud_snapshot_restore acceptance tests (#629)
  [AV-127227] Handle app endpoint deletion and forbidden errors in various resource operations (#634)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [x] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments


[AV-135369]: https://couchbasecloud.atlassian.net/browse/AV-135369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132949]: https://couchbasecloud.atlassian.net/browse/AV-132949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-134634]: https://couchbasecloud.atlassian.net/browse/AV-134634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-131920]: https://couchbasecloud.atlassian.net/browse/AV-131920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-135236]: https://couchbasecloud.atlassian.net/browse/AV-135236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-131920]: https://couchbasecloud.atlassian.net/browse/AV-131920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AV-132168]: https://couchbasecloud.atlassian.net/browse/AV-132168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AV-132169]: https://couchbasecloud.atlassian.net/browse/AV-132169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ