### PR TITLE
[AV-135982] Document re-supplying URL binding secrets after import

### DIFF
--- a/examples/eventing_function/README.md
+++ b/examples/eventing_function/README.md
@@ -329,3 +329,15 @@ The resources that were imported are shown above. These resources are now in
 your Terraform state and will henceforth be managed by Terraform.
 ```
 
+### Re-supplying URL binding secrets after import
+
+If the imported function has a URL binding that uses authentication (`type = "basic"`, `"digest"` or `"bearer"`), its secret (`password` for `basic`/`digest`, or `bearer_token` for `bearer`) is redacted by the Capella API. As a result, the secret is **not** populated in the Terraform state on import, and the first `terraform plan` after import shows it being added from your configuration:
+
+```
+  ~ authentication = {
+      + password = (sensitive value)
+    }
+```
+
+Re-supply the secret in your configuration (it must match the value already configured on the function) and run `terraform apply` to reconcile the state. Subsequent plans will then show no changes.
+


### PR DESCRIPTION
## Jira

* AV-135982

## Description

Adds a section to the eventing function example README explaining how to re-supply redacted URL binding secrets (`password` for basic/digest, `bearer_token` for bearer) after import so the first plan/apply reconciles cleanly.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [x] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [x] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

  Documentation-only change

</details>

## Further comments
