### PR TITLE
[AV-134985] Add support for INCLUDE MISSING modifier in index key parsing

### DIFF
--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -406,24 +406,7 @@ func (g *GSI) Read(ctx context.Context, req resource.ReadRequest, resp *resource
 		state.IndexName = types.StringValue(indexName)
 		state.Status = types.StringValue(index.Status)
 
-		// Fetch the full DDL definition to get index keys with modifiers
-		// like INCLUDE MISSING, which are not present in SecExprs.
-		indexKeys := index.SecExprs
-		definition, err := g.getIndexDefinition(
-			ctx,
-			organizationID,
-			projectID,
-			clusterID,
-			bucketName,
-			scopeName,
-			collectionName,
-			indexName,
-		)
-		if err == nil && definition != "" {
-			if parsed, parseErr := parseIndexKeysFromDefinition(definition); parseErr == nil && len(parsed) == len(indexKeys) {
-				indexKeys = parsed
-			}
-		}
+		indexKeys := g.resolveIndexKeys(ctx, index.SecExprs, organizationID, projectID, clusterID, bucketName, scopeName, collectionName, indexName)
 
 		var keys []attr.Value
 		for _, key := range indexKeys {
@@ -816,6 +799,49 @@ func (g *GSI) getIndexDefinition(
 	return "", fmt.Errorf("index definition not found for %s", indexName)
 }
 
+// resolveIndexKeys attempts to enrich SecExprs with key modifiers (INCLUDE MISSING,
+// DESC, ASC) by fetching and parsing the full DDL definition. If any step fails it
+// logs a warning and returns the original SecExprs unchanged.
+func (g *GSI) resolveIndexKeys(
+	ctx context.Context, secExprs []string, organizationID, projectID, clusterID, bucketName, scopeName, collectionName, indexName string,
+) []string {
+	definition, err := g.getIndexDefinition(ctx, organizationID, projectID, clusterID, bucketName, scopeName, collectionName, indexName)
+	if err != nil {
+		tflog.Warn(ctx, "failed to fetch index DDL definition, falling back to SecExprs", map[string]any{
+			"index": indexName,
+			"error": err.Error(),
+		})
+		return secExprs
+	}
+
+	if definition == "" {
+		tflog.Warn(ctx, "index DDL definition was empty, falling back to SecExprs", map[string]any{
+			"index": indexName,
+		})
+		return secExprs
+	}
+
+	parsed, parseErr := parseIndexKeysFromDefinition(definition)
+	if parseErr != nil {
+		tflog.Warn(ctx, "failed to parse index keys from DDL definition, falling back to SecExprs", map[string]any{
+			"index": indexName,
+			"error": parseErr.Error(),
+		})
+		return secExprs
+	}
+
+	if len(parsed) != len(secExprs) {
+		tflog.Warn(ctx, "parsed key count does not match SecExprs count, falling back to SecExprs", map[string]any{
+			"index":          indexName,
+			"parsed_count":   len(parsed),
+			"secexprs_count": len(secExprs),
+		})
+		return secExprs
+	}
+
+	return mergeModifiers(secExprs, parsed)
+}
+
 // parseIndexKeysFromDefinition extracts index key expressions from a CREATE INDEX
 // DDL statement. Unlike SecExprs from the API, the DDL includes key modifiers
 // such as INCLUDE MISSING, DESC, and ASC.
@@ -894,4 +920,35 @@ func parseIndexKeysFromDefinition(definition string) ([]string, error) {
 	}
 
 	return keys, nil
+}
+
+// indexKeyModifiers are suffixes that appear after the base expression in a
+// DDL key definition but are absent from SecExprs. Ordered longest-first so
+// composite modifiers match before their sub-strings.
+var indexKeyModifiers = []string{
+	"INCLUDE MISSING",
+	"DESC",
+	"ASC",
+}
+
+// mergeModifiers preserves the original SecExprs formatting and appends any
+// trailing modifier found in the corresponding parsed DDL key. This avoids
+// introducing formatting diffs (backtick style, spacing) while still capturing
+// modifiers like INCLUDE MISSING that SecExprs omits.
+func mergeModifiers(secExprs, ddlKeys []string) []string {
+	merged := make([]string, len(secExprs))
+	for i, expr := range secExprs {
+		merged[i] = expr
+		if i >= len(ddlKeys) {
+			continue
+		}
+		ddlUpper := strings.ToUpper(strings.TrimSpace(ddlKeys[i]))
+		for _, mod := range indexKeyModifiers {
+			if strings.HasSuffix(ddlUpper, mod) {
+				merged[i] = expr + " " + mod
+				break
+			}
+		}
+	}
+	return merged
 }

--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -402,7 +402,11 @@ func (g *GSI) Read(ctx context.Context, req resource.ReadRequest, resp *resource
 		state.BucketName = types.StringValue(bucketName)
 		state.ScopeName = types.StringValue(scopeName)
 		state.CollectionName = types.StringValue(collectionName)
-		state.IsPrimary = types.BoolValue(index.IsPrimary)
+		// configs omit is_primary for secondary indexes, so import false as
+		// null to avoid a spurious diff.
+		if index.IsPrimary {
+			state.IsPrimary = types.BoolValue(true)
+		}
 		state.IndexName = types.StringValue(indexName)
 		state.Status = types.StringValue(index.Status)
 
@@ -425,10 +429,18 @@ func (g *GSI) Read(ctx context.Context, req resource.ReadRequest, resp *resource
 
 		state.IndexKeys = keyList
 		// TODO:  set partition by.
-		state.Where = types.StringValue(index.Where)
+		// where is empty for indexes without a WHERE clause; import it as
+		// null since where requires replacement when changed.
+		if index.Where != "" {
+			state.Where = types.StringValue(index.Where)
+		}
 		state.With = &providerschema.WithOptions{}
 		state.With.NumReplica = types.Int64Value(int64(index.NumReplica))
-		state.With.NumPartition = types.Int64Value(int64(index.NumPartition))
+		// num_partition is 0 for non-partitioned indexes, which is invalid
+		// per the schema validator (at least 1), so import it as null.
+		if index.NumPartition > 0 {
+			state.With.NumPartition = types.Int64Value(int64(index.NumPartition))
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
@@ -641,43 +653,28 @@ func (g *GSI) ValidateConfig(
 	}
 }
 
-// postQueryServiceStatement sends a statement to the query service and returns
-// the raw response.
-func (g *GSI) postQueryServiceStatement(
-	ctx context.Context, organizationID, projectID, clusterID, statement string,
-) (*api.Response, error) {
+func (g *GSI) executeGsiDdl(ctx context.Context, plan *providerschema.GsiDefinition, ddl string) error {
 	uri := fmt.Sprintf(
 		"%s/v4/organizations/%s/projects/%s/clusters/%s/queryService/indexes",
 		g.HostURL,
-		organizationID,
-		projectID,
-		clusterID,
+		plan.OrganizationId.ValueString(),
+		plan.ProjectId.ValueString(),
+		plan.ClusterId.ValueString(),
 	)
 
 	cfg := api.EndpointCfg{Url: uri, Method: http.MethodPost, SuccessStatus: http.StatusOK}
-	ddlRequest := api.IndexDDLRequest{Definition: statement}
+	ddlRequest := api.IndexDDLRequest{Definition: ddl}
 
 	if err := api.Limiter.Wait(ctx); err != nil {
 		// do not block if rate limiter fails
 		tflog.Error(ctx, "rate limiter error: "+err.Error())
 	}
-
-	return g.ClientV1.ExecuteWithRetry(
+	response, err := g.ClientV1.ExecuteWithRetry(
 		ctx,
 		cfg,
 		ddlRequest,
 		g.Token,
 		nil,
-	)
-}
-
-func (g *GSI) executeGsiDdl(ctx context.Context, plan *providerschema.GsiDefinition, ddl string) error {
-	response, err := g.postQueryServiceStatement(
-		ctx,
-		plan.OrganizationId.ValueString(),
-		plan.ProjectId.ValueString(),
-		plan.ClusterId.ValueString(),
-		ddl,
 	)
 	switch {
 	case err == nil:
@@ -767,26 +764,58 @@ func (g *GSI) getQueryIndex(
 	return &index, nil
 }
 
-// getIndexKeysFromSystemIndexes fetches an index's keys from system:indexes
-// via the query service. Unlike the indexer's SecExprs, the query service's
-// index_key field retains key modifiers such as INCLUDE MISSING, DESC and
-// VECTOR.
-func (g *GSI) getIndexKeysFromSystemIndexes(
+// getIndexDefinition fetches the CREATE INDEX DDL statement for a specific
+// index from the list definitions endpoint. Unlike the SecExprs field of the
+// get index endpoint, the DDL retains key modifiers such as INCLUDE MISSING,
+// DESC and VECTOR.
+func (g *GSI) getIndexDefinition(
 	ctx context.Context, organizationID, projectID, clusterID, bucketName, scopeName, collectionName, indexName string,
-) ([]string, error) {
-	query := buildSystemIndexesQuery(bucketName, scopeName, collectionName, indexName)
+) (string, error) {
+	uri := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/queryService/indexes?bucket=%s&scope=%s&collection=%s",
+		g.HostURL,
+		organizationID,
+		projectID,
+		clusterID,
+		url.QueryEscape(bucketName),
+		url.QueryEscape(scopeName),
+		url.QueryEscape(collectionName),
+	)
 
-	response, err := g.postQueryServiceStatement(ctx, organizationID, projectID, clusterID, query)
-	if err != nil {
-		return nil, err
+	if err := api.Limiter.Wait(ctx); err != nil {
+		// do not block if rate limiter fails
+		tflog.Error(ctx, "rate limiter error: "+err.Error())
 	}
 
-	return extractIndexKeys(response.Body)
+	cfg := api.EndpointCfg{Url: uri, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := g.ClientV1.ExecuteWithRetry(
+		ctx,
+		cfg,
+		nil,
+		g.Token,
+		nil,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	var list api.ListIndexDefinitionsResponse
+	if err = json.Unmarshal(response.Body, &list); err != nil {
+		return "", err
+	}
+
+	for _, def := range list.Definitions {
+		if def.IndexName == indexName {
+			return def.Definition, nil
+		}
+	}
+
+	return "", fmt.Errorf("index definition not found for %s", indexName)
 }
 
-// resolveIndexKeys returns index keys including key modifiers by querying
-// system:indexes. If the lookup fails it logs a warning and falls back to the
-// indexer's SecExprs, which lack modifiers.
+// resolveIndexKeys returns index keys including key modifiers by extracting
+// them from the index DDL definition. If any step fails it logs a warning and
+// falls back to the indexer's SecExprs, which lack modifiers.
 func (g *GSI) resolveIndexKeys(
 	ctx context.Context, secExprs []string, organizationID, projectID, clusterID, bucketName, scopeName, collectionName, indexName string,
 ) []string {
@@ -795,11 +824,20 @@ func (g *GSI) resolveIndexKeys(
 		return secExprs
 	}
 
-	indexKeys, err := g.getIndexKeysFromSystemIndexes(
+	definition, err := g.getIndexDefinition(
 		ctx, organizationID, projectID, clusterID, bucketName, scopeName, collectionName, indexName,
 	)
 	if err != nil {
-		tflog.Warn(ctx, "failed to get index keys from system:indexes, falling back to SecExprs", map[string]any{
+		tflog.Warn(ctx, "failed to fetch index DDL definition, falling back to SecExprs", map[string]any{
+			"index": indexName,
+			"error": err.Error(),
+		})
+		return secExprs
+	}
+
+	indexKeys, err := parseIndexKeysFromDDL(definition)
+	if err != nil {
+		tflog.Warn(ctx, "failed to extract index keys from DDL definition, falling back to SecExprs", map[string]any{
 			"index": indexName,
 			"error": err.Error(),
 		})
@@ -807,10 +845,10 @@ func (g *GSI) resolveIndexKeys(
 	}
 
 	if len(indexKeys) != len(secExprs) {
-		tflog.Warn(ctx, "system:indexes key count does not match SecExprs count, falling back to SecExprs", map[string]any{
-			"index":           indexName,
-			"index_key_count": len(indexKeys),
-			"secexprs_count":  len(secExprs),
+		tflog.Warn(ctx, "extracted key count does not match SecExprs count, falling back to SecExprs", map[string]any{
+			"index":          indexName,
+			"extracted":      len(indexKeys),
+			"secexprs_count": len(secExprs),
 		})
 		return secExprs
 	}
@@ -818,61 +856,93 @@ func (g *GSI) resolveIndexKeys(
 	return indexKeys
 }
 
-// escapeN1QLString escapes a value for embedding in a double-quoted N1QL
-// string literal.
-func escapeN1QLString(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	return strings.ReplaceAll(s, `"`, `\"`)
-}
-
-// buildSystemIndexesQuery builds a system:indexes lookup for a single index.
-// Indexes on the default collection can appear in the legacy form where
-// keyspace_id is the bucket name and bucket_id/scope_id are missing, so the
-// filter accepts both forms when scope and collection are "_default".
-func buildSystemIndexesQuery(bucketName, scopeName, collectionName, indexName string) string {
-	keyspaceFilter := fmt.Sprintf(
-		`(i.bucket_id = "%s" AND i.scope_id = "%s" AND i.keyspace_id = "%s")`,
-		escapeN1QLString(bucketName),
-		escapeN1QLString(scopeName),
-		escapeN1QLString(collectionName),
+// parseIndexKeysFromDDL extracts the index key expressions from a CREATE INDEX
+// DDL statement, verbatim. The key list is the first top-level parenthesized
+// group (only backticked identifiers precede it in canonical DDL), and keys
+// are separated by top-level commas. The scan skips quoted regions -- backtick
+// identifiers and string literals -- so delimiters inside them are ignored.
+// No key modifier is interpreted, so INCLUDE MISSING, DESC, VECTOR and any
+// future modifiers pass through unchanged.
+func parseIndexKeysFromDDL(definition string) ([]string, error) {
+	var (
+		inBacktick, inSingle, inDouble bool
+		depth                          int
+		segStart                       = -1
+		keys                           []string
 	)
-	if scopeName == "_default" && collectionName == "_default" {
-		keyspaceFilter = fmt.Sprintf(
-			`(%s OR (i.bucket_id IS MISSING AND i.keyspace_id = "%s"))`,
-			keyspaceFilter,
-			escapeN1QLString(bucketName),
-		)
+
+	for i := 0; i < len(definition); i++ {
+		c := definition[i]
+
+		switch {
+		case inBacktick:
+			if c == '`' {
+				// a doubled backtick is an escaped backtick inside an identifier.
+				if i+1 < len(definition) && definition[i+1] == '`' {
+					i++
+				} else {
+					inBacktick = false
+				}
+			}
+		case inSingle, inDouble:
+			quote := byte('\'')
+			if inDouble {
+				quote = '"'
+			}
+			switch c {
+			case '\\':
+				i++ // skip the escaped character
+			case quote:
+				// a doubled quote is an escaped quote inside a string literal.
+				if i+1 < len(definition) && definition[i+1] == quote {
+					i++
+				} else {
+					inSingle, inDouble = false, false
+				}
+			}
+		default:
+			switch c {
+			case '`':
+				inBacktick = true
+			case '\'':
+				inSingle = true
+			case '"':
+				inDouble = true
+			case '(':
+				depth++
+				if depth == 1 && segStart == -1 {
+					segStart = i + 1
+				}
+			case ')':
+				if depth == 0 {
+					return nil, fmt.Errorf("unbalanced parentheses in index DDL definition")
+				}
+				depth--
+				if depth == 0 {
+					// end of the key list; ignore trailing clauses (WHERE, WITH, ...).
+					key := strings.TrimSpace(definition[segStart:i])
+					if key != "" {
+						keys = append(keys, key)
+					}
+					if len(keys) == 0 {
+						return nil, fmt.Errorf("empty index key list in index DDL definition")
+					}
+					return keys, nil
+				}
+			case ',':
+				if depth == 1 {
+					key := strings.TrimSpace(definition[segStart:i])
+					if key != "" {
+						keys = append(keys, key)
+					}
+					segStart = i + 1
+				}
+			}
+		}
 	}
 
-	// "using" is a reserved word in N1QL so it must be escaped with backticks.
-	return fmt.Sprintf(
-		"SELECT RAW i.index_key FROM system:indexes AS i WHERE i.name = \"%s\" AND i.`using` = \"gsi\" AND %s",
-		escapeN1QLString(indexName),
-		keyspaceFilter,
-	)
-}
-
-// systemIndexesResponse is the query service response for the system:indexes
-// lookup. SELECT RAW i.index_key makes each result row the index_key array
-// itself.
-type systemIndexesResponse struct {
-	Results [][]string       `json:"results"`
-	Errors  []api.QueryError `json:"errors,omitempty"`
-}
-
-func extractIndexKeys(body []byte) ([]string, error) {
-	var queryResponse systemIndexesResponse
-	if err := json.Unmarshal(body, &queryResponse); err != nil {
-		return nil, err
+	if segStart == -1 {
+		return nil, fmt.Errorf("no index key list found in index DDL definition")
 	}
-
-	if len(queryResponse.Errors) > 0 {
-		return nil, errors.New(queryResponse.Errors[0].Msg)
-	}
-
-	if len(queryResponse.Results) == 0 || len(queryResponse.Results[0]) == 0 {
-		return nil, fmt.Errorf("index keys not found in system:indexes")
-	}
-
-	return queryResponse.Results[0], nil
+	return nil, fmt.Errorf("unbalanced parentheses in index DDL definition")
 }

--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -641,28 +641,43 @@ func (g *GSI) ValidateConfig(
 	}
 }
 
-func (g *GSI) executeGsiDdl(ctx context.Context, plan *providerschema.GsiDefinition, ddl string) error {
+// postQueryServiceStatement sends a statement to the query service and returns
+// the raw response.
+func (g *GSI) postQueryServiceStatement(
+	ctx context.Context, organizationID, projectID, clusterID, statement string,
+) (*api.Response, error) {
 	uri := fmt.Sprintf(
 		"%s/v4/organizations/%s/projects/%s/clusters/%s/queryService/indexes",
 		g.HostURL,
-		plan.OrganizationId.ValueString(),
-		plan.ProjectId.ValueString(),
-		plan.ClusterId.ValueString(),
+		organizationID,
+		projectID,
+		clusterID,
 	)
 
 	cfg := api.EndpointCfg{Url: uri, Method: http.MethodPost, SuccessStatus: http.StatusOK}
-	ddlRequest := api.IndexDDLRequest{Definition: ddl}
+	ddlRequest := api.IndexDDLRequest{Definition: statement}
 
 	if err := api.Limiter.Wait(ctx); err != nil {
 		// do not block if rate limiter fails
 		tflog.Error(ctx, "rate limiter error: "+err.Error())
 	}
-	response, err := g.ClientV1.ExecuteWithRetry(
+
+	return g.ClientV1.ExecuteWithRetry(
 		ctx,
 		cfg,
 		ddlRequest,
 		g.Token,
 		nil,
+	)
+}
+
+func (g *GSI) executeGsiDdl(ctx context.Context, plan *providerschema.GsiDefinition, ddl string) error {
+	response, err := g.postQueryServiceStatement(
+		ctx,
+		plan.OrganizationId.ValueString(),
+		plan.ProjectId.ValueString(),
+		plan.ClusterId.ValueString(),
+		ddl,
 	)
 	switch {
 	case err == nil:
@@ -752,203 +767,112 @@ func (g *GSI) getQueryIndex(
 	return &index, nil
 }
 
-// getIndexDefinition fetches the CREATE INDEX DDL statement for a specific index
-// from the list definitions endpoint. The DDL includes key modifiers such as
-// INCLUDE MISSING that are not present in the SecExprs field.
-func (g *GSI) getIndexDefinition(
+// getIndexKeysFromSystemIndexes fetches an index's keys from system:indexes
+// via the query service. Unlike the indexer's SecExprs, the query service's
+// index_key field retains key modifiers such as INCLUDE MISSING, DESC and
+// VECTOR.
+func (g *GSI) getIndexKeysFromSystemIndexes(
 	ctx context.Context, organizationID, projectID, clusterID, bucketName, scopeName, collectionName, indexName string,
-) (string, error) {
-	uri := fmt.Sprintf(
-		"%s/v4/organizations/%s/projects/%s/clusters/%s/queryService/indexes?bucket=%s&scope=%s&collection=%s",
-		g.HostURL,
-		organizationID,
-		projectID,
-		clusterID,
-		url.QueryEscape(bucketName),
-		url.QueryEscape(scopeName),
-		url.QueryEscape(collectionName),
-	)
+) ([]string, error) {
+	query := buildSystemIndexesQuery(bucketName, scopeName, collectionName, indexName)
 
-	if err := api.Limiter.Wait(ctx); err != nil {
-		tflog.Error(ctx, "rate limiter error: "+err.Error())
-	}
-
-	cfg := api.EndpointCfg{Url: uri, Method: http.MethodGet, SuccessStatus: http.StatusOK}
-	response, err := g.ClientV1.ExecuteWithRetry(
-		ctx,
-		cfg,
-		nil,
-		g.Token,
-		nil,
-	)
+	response, err := g.postQueryServiceStatement(ctx, organizationID, projectID, clusterID, query)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	var list api.ListIndexDefinitionsResponse
-	if err = json.Unmarshal(response.Body, &list); err != nil {
-		return "", err
-	}
-
-	for _, def := range list.Definitions {
-		if def.IndexName == indexName {
-			return def.Definition, nil
-		}
-	}
-
-	return "", fmt.Errorf("index definition not found for %s", indexName)
+	return extractIndexKeys(response.Body)
 }
 
-// resolveIndexKeys attempts to enrich SecExprs with key modifiers (INCLUDE MISSING,
-// DESC, ASC) by fetching and parsing the full DDL definition. If any step fails it
-// logs a warning and returns the original SecExprs unchanged.
+// resolveIndexKeys returns index keys including key modifiers by querying
+// system:indexes. If the lookup fails it logs a warning and falls back to the
+// indexer's SecExprs, which lack modifiers.
 func (g *GSI) resolveIndexKeys(
 	ctx context.Context, secExprs []string, organizationID, projectID, clusterID, bucketName, scopeName, collectionName, indexName string,
 ) []string {
-	definition, err := g.getIndexDefinition(ctx, organizationID, projectID, clusterID, bucketName, scopeName, collectionName, indexName)
+	// primary indexes have no index keys.
+	if len(secExprs) == 0 {
+		return secExprs
+	}
+
+	indexKeys, err := g.getIndexKeysFromSystemIndexes(
+		ctx, organizationID, projectID, clusterID, bucketName, scopeName, collectionName, indexName,
+	)
 	if err != nil {
-		tflog.Warn(ctx, "failed to fetch index DDL definition, falling back to SecExprs", map[string]any{
+		tflog.Warn(ctx, "failed to get index keys from system:indexes, falling back to SecExprs", map[string]any{
 			"index": indexName,
 			"error": err.Error(),
 		})
 		return secExprs
 	}
 
-	if definition == "" {
-		tflog.Warn(ctx, "index DDL definition was empty, falling back to SecExprs", map[string]any{
-			"index": indexName,
+	if len(indexKeys) != len(secExprs) {
+		tflog.Warn(ctx, "system:indexes key count does not match SecExprs count, falling back to SecExprs", map[string]any{
+			"index":           indexName,
+			"index_key_count": len(indexKeys),
+			"secexprs_count":  len(secExprs),
 		})
 		return secExprs
 	}
 
-	parsed, parseErr := parseIndexKeysFromDefinition(definition)
-	if parseErr != nil {
-		tflog.Warn(ctx, "failed to parse index keys from DDL definition, falling back to SecExprs", map[string]any{
-			"index": indexName,
-			"error": parseErr.Error(),
-		})
-		return secExprs
-	}
-
-	if len(parsed) != len(secExprs) {
-		tflog.Warn(ctx, "parsed key count does not match SecExprs count, falling back to SecExprs", map[string]any{
-			"index":          indexName,
-			"parsed_count":   len(parsed),
-			"secexprs_count": len(secExprs),
-		})
-		return secExprs
-	}
-
-	return mergeModifiers(secExprs, parsed)
+	return indexKeys
 }
 
-// parseIndexKeysFromDefinition extracts index key expressions from a CREATE INDEX
-// DDL statement. Unlike SecExprs from the API, the DDL includes key modifiers
-// such as INCLUDE MISSING, DESC, and ASC.
-func parseIndexKeysFromDefinition(definition string) ([]string, error) {
-	// Primary indexes have no key list; any '(' after the ON clause belongs
-	// to something else (e.g., a WHERE predicate), so bail out early.
-	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(definition)), "CREATE PRIMARY INDEX") {
-		return nil, fmt.Errorf("primary index definitions have no index keys")
-	}
-
-	// Find the key list which starts after ON <keyspace>( in the DDL.
-	// The keyspace reference (e.g., `bucket`.`scope`.`collection`) does not
-	// contain parentheses, so the first '(' after ON marks the key list start.
-	onIdx := strings.Index(strings.ToUpper(definition), " ON ")
-	if onIdx == -1 {
-		return nil, fmt.Errorf("could not find ON clause in definition")
-	}
-
-	// Find the opening parenthesis of the key list.
-	keyStart := strings.Index(definition[onIdx:], "(")
-	if keyStart == -1 {
-		return nil, fmt.Errorf("could not find key list opening parenthesis")
-	}
-	keyStart += onIdx
-
-	// Find the matching closing parenthesis, tracking depth for nested parens.
-	depth := 0
-	keyEnd := -1
-	for i := keyStart; i < len(definition); i++ {
-		switch definition[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-			if depth == 0 {
-				keyEnd = i
-			}
-		}
-		if keyEnd != -1 {
-			break
-		}
-	}
-
-	if keyEnd == -1 {
-		return nil, fmt.Errorf("could not find matching closing parenthesis for key list")
-	}
-
-	// Extract the content between the parentheses.
-	keysContent := definition[keyStart+1 : keyEnd]
-
-	// Split by top-level commas (commas not inside nested parentheses).
-	var keys []string
-	depth = 0
-	start := 0
-	for i := 0; i < len(keysContent); i++ {
-		switch keysContent[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-		case ',':
-			if depth == 0 {
-				key := strings.TrimSpace(keysContent[start:i])
-				if key != "" {
-					keys = append(keys, key)
-				}
-				start = i + 1
-			}
-		}
-	}
-
-	// Add the last key.
-	lastKey := strings.TrimSpace(keysContent[start:])
-	if lastKey != "" {
-		keys = append(keys, lastKey)
-	}
-
-	return keys, nil
+// escapeN1QLString escapes a value for embedding in a double-quoted N1QL
+// string literal.
+func escapeN1QLString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	return strings.ReplaceAll(s, `"`, `\"`)
 }
 
-// indexKeyModifiers are suffixes that appear after the base expression in a
-// DDL key definition but are absent from SecExprs. Ordered longest-first so
-// composite modifiers match before their sub-strings.
-var indexKeyModifiers = []string{
-	"INCLUDE MISSING",
-	"DESC",
-	"ASC",
+// buildSystemIndexesQuery builds a system:indexes lookup for a single index.
+// Indexes on the default collection can appear in the legacy form where
+// keyspace_id is the bucket name and bucket_id/scope_id are missing, so the
+// filter accepts both forms when scope and collection are "_default".
+func buildSystemIndexesQuery(bucketName, scopeName, collectionName, indexName string) string {
+	keyspaceFilter := fmt.Sprintf(
+		`(i.bucket_id = "%s" AND i.scope_id = "%s" AND i.keyspace_id = "%s")`,
+		escapeN1QLString(bucketName),
+		escapeN1QLString(scopeName),
+		escapeN1QLString(collectionName),
+	)
+	if scopeName == "_default" && collectionName == "_default" {
+		keyspaceFilter = fmt.Sprintf(
+			`(%s OR (i.bucket_id IS MISSING AND i.keyspace_id = "%s"))`,
+			keyspaceFilter,
+			escapeN1QLString(bucketName),
+		)
+	}
+
+	// "using" is a reserved word in N1QL so it must be escaped with backticks.
+	return fmt.Sprintf(
+		"SELECT RAW i.index_key FROM system:indexes AS i WHERE i.name = \"%s\" AND i.`using` = \"gsi\" AND %s",
+		escapeN1QLString(indexName),
+		keyspaceFilter,
+	)
 }
 
-// mergeModifiers preserves the original SecExprs formatting and appends any
-// trailing modifier found in the corresponding parsed DDL key. This avoids
-// introducing formatting diffs (backtick style, spacing) while still capturing
-// modifiers like INCLUDE MISSING that SecExprs omits.
-func mergeModifiers(secExprs, ddlKeys []string) []string {
-	merged := make([]string, len(secExprs))
-	for i, expr := range secExprs {
-		merged[i] = expr
-		if i >= len(ddlKeys) {
-			continue
-		}
-		ddlUpper := strings.ToUpper(strings.TrimSpace(ddlKeys[i]))
-		for _, mod := range indexKeyModifiers {
-			if strings.HasSuffix(ddlUpper, mod) {
-				merged[i] = expr + " " + mod
-				break
-			}
-		}
+// systemIndexesResponse is the query service response for the system:indexes
+// lookup. SELECT RAW i.index_key makes each result row the index_key array
+// itself.
+type systemIndexesResponse struct {
+	Results [][]string       `json:"results"`
+	Errors  []api.QueryError `json:"errors,omitempty"`
+}
+
+func extractIndexKeys(body []byte) ([]string, error) {
+	var queryResponse systemIndexesResponse
+	if err := json.Unmarshal(body, &queryResponse); err != nil {
+		return nil, err
 	}
-	return merged
+
+	if len(queryResponse.Errors) > 0 {
+		return nil, errors.New(queryResponse.Errors[0].Msg)
+	}
+
+	if len(queryResponse.Results) == 0 || len(queryResponse.Results[0]) == 0 {
+		return nil, fmt.Errorf("index keys not found in system:indexes")
+	}
+
+	return queryResponse.Results[0], nil
 }

--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -846,7 +846,6 @@ func parseIndexKeysFromDefinition(definition string) ([]string, error) {
 			depth--
 			if depth == 0 {
 				keyEnd = i
-				break
 			}
 		}
 		if keyEnd != -1 {

--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -406,8 +406,27 @@ func (g *GSI) Read(ctx context.Context, req resource.ReadRequest, resp *resource
 		state.IndexName = types.StringValue(indexName)
 		state.Status = types.StringValue(index.Status)
 
+		// Fetch the full DDL definition to get index keys with modifiers
+		// like INCLUDE MISSING, which are not present in SecExprs.
+		indexKeys := index.SecExprs
+		definition, err := g.getIndexDefinition(
+			ctx,
+			organizationID,
+			projectID,
+			clusterID,
+			bucketName,
+			scopeName,
+			collectionName,
+			indexName,
+		)
+		if err == nil && definition != "" {
+			if parsed, parseErr := parseIndexKeysFromDefinition(definition); parseErr == nil && len(parsed) > 0 {
+				indexKeys = parsed
+			}
+		}
+
 		var keys []attr.Value
-		for _, key := range index.SecExprs {
+		for _, key := range indexKeys {
 			keys = append(keys, types.StringValue(key))
 		}
 
@@ -748,4 +767,126 @@ func (g *GSI) getQueryIndex(
 	}
 
 	return &index, nil
+}
+
+// getIndexDefinition fetches the CREATE INDEX DDL statement for a specific index
+// from the list definitions endpoint. The DDL includes key modifiers such as
+// INCLUDE MISSING that are not present in the SecExprs field.
+func (g *GSI) getIndexDefinition(
+	ctx context.Context, organizationID, projectID, clusterID, bucketName, scopeName, collectionName, indexName string,
+) (string, error) {
+	uri := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/queryService/indexes?bucket=%s&scope=%s&collection=%s",
+		g.HostURL,
+		organizationID,
+		projectID,
+		clusterID,
+		bucketName,
+		scopeName,
+		collectionName,
+	)
+
+	if err := api.Limiter.Wait(ctx); err != nil {
+		tflog.Error(ctx, "rate limiter error: "+err.Error())
+	}
+
+	cfg := api.EndpointCfg{Url: uri, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := g.ClientV1.ExecuteWithRetry(
+		ctx,
+		cfg,
+		nil,
+		g.Token,
+		nil,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	var list api.ListIndexDefinitionsResponse
+	if err = json.Unmarshal(response.Body, &list); err != nil {
+		return "", err
+	}
+
+	for _, def := range list.Definitions {
+		if def.IndexName == indexName {
+			return def.Definition, nil
+		}
+	}
+
+	return "", fmt.Errorf("index definition not found for %s", indexName)
+}
+
+// parseIndexKeysFromDefinition extracts index key expressions from a CREATE INDEX
+// DDL statement. Unlike SecExprs from the API, the DDL includes key modifiers
+// such as INCLUDE MISSING, DESC, and ASC.
+func parseIndexKeysFromDefinition(definition string) ([]string, error) {
+	// Find the key list which starts after ON <keyspace>( in the DDL.
+	// The keyspace reference (e.g., `bucket`.`scope`.`collection`) does not
+	// contain parentheses, so the first '(' after ON marks the key list start.
+	onIdx := strings.Index(strings.ToUpper(definition), " ON ")
+	if onIdx == -1 {
+		return nil, fmt.Errorf("could not find ON clause in definition")
+	}
+
+	// Find the opening parenthesis of the key list.
+	keyStart := strings.Index(definition[onIdx:], "(")
+	if keyStart == -1 {
+		return nil, fmt.Errorf("could not find key list opening parenthesis")
+	}
+	keyStart += onIdx
+
+	// Find the matching closing parenthesis, tracking depth for nested parens.
+	depth := 0
+	keyEnd := -1
+	for i := keyStart; i < len(definition); i++ {
+		switch definition[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				keyEnd = i
+				break
+			}
+		}
+		if keyEnd != -1 {
+			break
+		}
+	}
+
+	if keyEnd == -1 {
+		return nil, fmt.Errorf("could not find matching closing parenthesis for key list")
+	}
+
+	// Extract the content between the parentheses.
+	keysContent := definition[keyStart+1 : keyEnd]
+
+	// Split by top-level commas (commas not inside nested parentheses).
+	var keys []string
+	depth = 0
+	start := 0
+	for i := 0; i < len(keysContent); i++ {
+		switch keysContent[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				key := strings.TrimSpace(keysContent[start:i])
+				if key != "" {
+					keys = append(keys, key)
+				}
+				start = i + 1
+			}
+		}
+	}
+
+	// Add the last key.
+	lastKey := strings.TrimSpace(keysContent[start:])
+	if lastKey != "" {
+		keys = append(keys, lastKey)
+	}
+
+	return keys, nil
 }

--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -420,7 +420,7 @@ func (g *GSI) Read(ctx context.Context, req resource.ReadRequest, resp *resource
 			indexName,
 		)
 		if err == nil && definition != "" {
-			if parsed, parseErr := parseIndexKeysFromDefinition(definition); parseErr == nil && len(parsed) > 0 {
+			if parsed, parseErr := parseIndexKeysFromDefinition(definition); parseErr == nil && len(parsed) == len(indexKeys) {
 				indexKeys = parsed
 			}
 		}
@@ -781,9 +781,9 @@ func (g *GSI) getIndexDefinition(
 		organizationID,
 		projectID,
 		clusterID,
-		bucketName,
-		scopeName,
-		collectionName,
+		url.QueryEscape(bucketName),
+		url.QueryEscape(scopeName),
+		url.QueryEscape(collectionName),
 	)
 
 	if err := api.Limiter.Wait(ctx); err != nil {
@@ -820,6 +820,12 @@ func (g *GSI) getIndexDefinition(
 // DDL statement. Unlike SecExprs from the API, the DDL includes key modifiers
 // such as INCLUDE MISSING, DESC, and ASC.
 func parseIndexKeysFromDefinition(definition string) ([]string, error) {
+	// Primary indexes have no key list; any '(' after the ON clause belongs
+	// to something else (e.g., a WHERE predicate), so bail out early.
+	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(definition)), "CREATE PRIMARY INDEX") {
+		return nil, fmt.Errorf("primary index definitions have no index keys")
+	}
+
 	// Find the key list which starts after ON <keyspace>( in the DDL.
 	// The keyspace reference (e.g., `bucket`.`scope`.`collection`) does not
 	// contain parentheses, so the first '(' after ON marks the key list start.

--- a/internal/resources/gsi_test.go
+++ b/internal/resources/gsi_test.go
@@ -1,0 +1,102 @@
+package resources
+
+import (
+	"testing"
+)
+
+func TestParseIndexKeysFromDefinition(t *testing.T) {
+	tests := []struct {
+		name       string
+		definition string
+		wantKeys   []string
+		wantErr    bool
+	}{
+		{
+			name:       "single key with INCLUDE MISSING",
+			definition: "CREATE INDEX `repro_include_missing` ON `travel-sample`.`_default`.`_default`(`name` INCLUDE MISSING)",
+			wantKeys:   []string{"`name` INCLUDE MISSING"},
+		},
+		{
+			name:       "single key without modifier",
+			definition: "CREATE INDEX `idx1` ON `bucket`.`scope`.`collection`(`field1`)",
+			wantKeys:   []string{"`field1`"},
+		},
+		{
+			name:       "multiple keys with mixed modifiers",
+			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(`key1` INCLUDE MISSING, `key2`, `key3` INCLUDE MISSING)",
+			wantKeys:   []string{"`key1` INCLUDE MISSING", "`key2`", "`key3` INCLUDE MISSING"},
+		},
+		{
+			name:       "key with WHERE clause",
+			definition: "CREATE INDEX `user_notification_oktaId` ON `synergy_sv2_dev`(`oktaId` INCLUDE MISSING) WHERE (`type` = \"user_notification_status\")",
+			wantKeys:   []string{"`oktaId` INCLUDE MISSING"},
+		},
+		{
+			name:       "key with WITH clause",
+			definition: "CREATE INDEX `idx` ON `bucket`.`_default`.`_default`(`name` INCLUDE MISSING) WITH {\"num_replica\":1}",
+			wantKeys:   []string{"`name` INCLUDE MISSING"},
+		},
+		{
+			name:       "key with function expression",
+			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(LOWER(`name`) INCLUDE MISSING, `age`)",
+			wantKeys:   []string{"LOWER(`name`) INCLUDE MISSING", "`age`"},
+		},
+		{
+			name:       "key with nested function calls",
+			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(LOWER(TRIM(`name`)) INCLUDE MISSING)",
+			wantKeys:   []string{"LOWER(TRIM(`name`)) INCLUDE MISSING"},
+		},
+		{
+			name:       "key with DESC modifier",
+			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(`timestamp` DESC, `name` INCLUDE MISSING)",
+			wantKeys:   []string{"`timestamp` DESC", "`name` INCLUDE MISSING"},
+		},
+		{
+			name:       "key with PARTITION BY clause after keys",
+			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(`key1` INCLUDE MISSING, `key2`) PARTITION BY HASH(`key1`)",
+			wantKeys:   []string{"`key1` INCLUDE MISSING", "`key2`"},
+		},
+		{
+			name:       "single bucket keyspace",
+			definition: "CREATE INDEX `idx` ON `mybucket`(`field` INCLUDE MISSING)",
+			wantKeys:   []string{"`field` INCLUDE MISSING"},
+		},
+		{
+			name:       "array index expression",
+			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(ALL ARRAY `v`.`name` FOR `v` IN `items` END INCLUDE MISSING)",
+			wantKeys:   []string{"ALL ARRAY `v`.`name` FOR `v` IN `items` END INCLUDE MISSING"},
+		},
+		{
+			name:       "missing ON clause",
+			definition: "DROP INDEX `idx` ON `bucket`",
+			wantErr:    true,
+		},
+		{
+			name:       "primary index no keys",
+			definition: "CREATE PRIMARY INDEX `primary_idx` ON `bucket`.`scope`.`collection`",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseIndexKeysFromDefinition(tt.definition)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseIndexKeysFromDefinition() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.wantKeys) {
+				t.Errorf("parseIndexKeysFromDefinition() got %d keys, want %d keys\ngot:  %v\nwant: %v", len(got), len(tt.wantKeys), got, tt.wantKeys)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.wantKeys[i] {
+					t.Errorf("parseIndexKeysFromDefinition() key[%d] = %q, want %q", i, got[i], tt.wantKeys[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/resources/gsi_test.go
+++ b/internal/resources/gsi_test.go
@@ -6,102 +6,71 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuildSystemIndexesQuery(t *testing.T) {
+func TestParseIndexKeysFromDDL(t *testing.T) {
 	tests := []struct {
-		name           string
-		bucketName     string
-		scopeName      string
-		collectionName string
-		indexName      string
-		wantQuery      string
+		name       string
+		definition string
+		wantKeys   []string
+		wantErr    bool
 	}{
 		{
-			name:           "named scope and collection",
-			bucketName:     "source",
-			scopeName:      "s1",
-			collectionName: "c1",
-			indexName:      "user_notification_oktaId",
-			wantQuery: "SELECT RAW i.index_key FROM system:indexes AS i" +
-				" WHERE i.name = \"user_notification_oktaId\" AND i.`using` = \"gsi\"" +
-				` AND (i.bucket_id = "source" AND i.scope_id = "s1" AND i.keyspace_id = "c1")`,
+			name:       "single key with INCLUDE MISSING",
+			definition: "CREATE INDEX `repro_include_missing` ON `travel-sample`.`_default`.`_default`(`name` INCLUDE MISSING)",
+			wantKeys:   []string{"`name` INCLUDE MISSING"},
 		},
 		{
-			name:           "default scope and collection accepts legacy keyspace form",
-			bucketName:     "source",
-			scopeName:      "_default",
-			collectionName: "_default",
-			indexName:      "idx1",
-			wantQuery: "SELECT RAW i.index_key FROM system:indexes AS i" +
-				" WHERE i.name = \"idx1\" AND i.`using` = \"gsi\"" +
-				` AND ((i.bucket_id = "source" AND i.scope_id = "_default" AND i.keyspace_id = "_default")` +
-				` OR (i.bucket_id IS MISSING AND i.keyspace_id = "source"))`,
+			name:       "multiple keys with DESC and ASC",
+			definition: "CREATE INDEX `idx1` ON `b`.`s`.`c`(`c1` INCLUDE MISSING DESC, `c2`, `c3` ASC)",
+			wantKeys:   []string{"`c1` INCLUDE MISSING DESC", "`c2`", "`c3` ASC"},
 		},
 		{
-			name:           "names with quotes and backslashes are escaped",
-			bucketName:     `bu"cket`,
-			scopeName:      "s1",
-			collectionName: `col\1`,
-			indexName:      `idx"1`,
-			wantQuery: "SELECT RAW i.index_key FROM system:indexes AS i" +
-				" WHERE i.name = \"idx\\\"1\" AND i.`using` = \"gsi\"" +
-				` AND (i.bucket_id = "bu\"cket" AND i.scope_id = "s1" AND i.keyspace_id = "col\\1")`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			query := buildSystemIndexesQuery(tt.bucketName, tt.scopeName, tt.collectionName, tt.indexName)
-			assert.Equal(t, tt.wantQuery, query)
-		})
-	}
-}
-
-func TestExtractIndexKeys(t *testing.T) {
-	tests := []struct {
-		name     string
-		body     string
-		wantKeys []string
-		wantErr  bool
-	}{
-		{
-			name:     "single key with INCLUDE MISSING",
-			body:     "{\"results\": [[\"`oktaId` INCLUDE MISSING\"]], \"status\": \"success\"}",
-			wantKeys: []string{"`oktaId` INCLUDE MISSING"},
+			name:       "vector key passes through without modifier knowledge",
+			definition: "CREATE INDEX `vec_idx` ON `b`.`s`.`c`(`embedding` VECTOR, `category`)",
+			wantKeys:   []string{"`embedding` VECTOR", "`category`"},
 		},
 		{
-			name: "multiple keys with modifiers",
-			body: "{\"results\": [[\"`c1` INCLUDE MISSING DESC\", \"`c2`\", \"`v` VECTOR\"]]}",
+			name:       "array expression with nested parens and commas",
+			definition: "CREATE INDEX `arr_idx` ON `b`.`s`.`c`((ALL ARRAY FLATTEN_KEYS(`s`.`day` DESC, `s`.`flight`) FOR s IN `schedule` END), `type`)",
 			wantKeys: []string{
-				"`c1` INCLUDE MISSING DESC",
-				"`c2`",
-				"`v` VECTOR",
+				"(ALL ARRAY FLATTEN_KEYS(`s`.`day` DESC, `s`.`flight`) FOR s IN `schedule` END)",
+				"`type`",
 			},
 		},
 		{
-			name:    "query service returns errors",
-			body:    `{"errors": [{"msg": "syntax error - invalid statement"}]}`,
-			wantErr: true,
+			name:       "backticked identifier containing comma and paren",
+			definition: "CREATE INDEX `weird` ON `b`.`s`.`c`(`fie,ld(1`, `f2`)",
+			wantKeys:   []string{"`fie,ld(1`", "`f2`"},
 		},
 		{
-			name:    "no results",
-			body:    `{"results": [], "status": "success"}`,
-			wantErr: true,
+			name:       "string literal containing comma and paren",
+			definition: `CREATE INDEX ` + "`case_idx`" + ` ON ` + "`b`.`s`.`c`" + `(CASE WHEN ` + "`t`" + ` = "a,(b" THEN 1 ELSE 2 END, ` + "`f2`" + `)`,
+			wantKeys:   []string{`CASE WHEN ` + "`t`" + ` = "a,(b" THEN 1 ELSE 2 END`, "`f2`"},
 		},
 		{
-			name:    "empty index key",
-			body:    `{"results": [[]], "status": "success"}`,
-			wantErr: true,
+			name:       "trailing partition by, where and with clauses are ignored",
+			definition: "CREATE INDEX `idx2` ON `b`.`s`.`c`(`airline`, `destinationairport`) PARTITION BY HASH(`airline`) WHERE (`id` IN [1000, 2000]) WITH {\"num_replica\":1}",
+			wantKeys:   []string{"`airline`", "`destinationairport`"},
 		},
 		{
-			name:    "malformed response",
-			body:    `not json`,
-			wantErr: true,
+			name:       "primary index has no key list",
+			definition: "CREATE PRIMARY INDEX `#primary` ON `b`.`s`.`c`",
+			wantErr:    true,
+		},
+		{
+			name:       "unbalanced parentheses",
+			definition: "CREATE INDEX `broken` ON `b`.`s`.`c`(`f1`",
+			wantErr:    true,
+		},
+		{
+			name:       "empty key list",
+			definition: "CREATE INDEX `empty` ON `b`.`s`.`c`()",
+			wantErr:    true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			keys, err := extractIndexKeys([]byte(tt.body))
+			keys, err := parseIndexKeysFromDDL(tt.definition)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/internal/resources/gsi_test.go
+++ b/internal/resources/gsi_test.go
@@ -6,157 +6,108 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseIndexKeysFromDefinition(t *testing.T) {
+func TestBuildSystemIndexesQuery(t *testing.T) {
 	tests := []struct {
-		name       string
-		definition string
-		wantKeys   []string
-		wantErr    bool
+		name           string
+		bucketName     string
+		scopeName      string
+		collectionName string
+		indexName      string
+		wantQuery      string
 	}{
 		{
-			name:       "single key with INCLUDE MISSING",
-			definition: "CREATE INDEX `repro_include_missing` ON `travel-sample`.`_default`.`_default`(`name` INCLUDE MISSING)",
-			wantKeys:   []string{"`name` INCLUDE MISSING"},
+			name:           "named scope and collection",
+			bucketName:     "source",
+			scopeName:      "s1",
+			collectionName: "c1",
+			indexName:      "user_notification_oktaId",
+			wantQuery: "SELECT RAW i.index_key FROM system:indexes AS i" +
+				" WHERE i.name = \"user_notification_oktaId\" AND i.`using` = \"gsi\"" +
+				` AND (i.bucket_id = "source" AND i.scope_id = "s1" AND i.keyspace_id = "c1")`,
 		},
 		{
-			name:       "single key without modifier",
-			definition: "CREATE INDEX `idx1` ON `bucket`.`scope`.`collection`(`field1`)",
-			wantKeys:   []string{"`field1`"},
+			name:           "default scope and collection accepts legacy keyspace form",
+			bucketName:     "source",
+			scopeName:      "_default",
+			collectionName: "_default",
+			indexName:      "idx1",
+			wantQuery: "SELECT RAW i.index_key FROM system:indexes AS i" +
+				" WHERE i.name = \"idx1\" AND i.`using` = \"gsi\"" +
+				` AND ((i.bucket_id = "source" AND i.scope_id = "_default" AND i.keyspace_id = "_default")` +
+				` OR (i.bucket_id IS MISSING AND i.keyspace_id = "source"))`,
 		},
 		{
-			name:       "multiple keys with mixed modifiers",
-			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(`key1` INCLUDE MISSING, `key2`, `key3` INCLUDE MISSING)",
-			wantKeys:   []string{"`key1` INCLUDE MISSING", "`key2`", "`key3` INCLUDE MISSING"},
-		},
-		{
-			name:       "key with WHERE clause",
-			definition: "CREATE INDEX `user_notification_oktaId` ON `synergy_sv2_dev`(`oktaId` INCLUDE MISSING) WHERE (`type` = \"user_notification_status\")",
-			wantKeys:   []string{"`oktaId` INCLUDE MISSING"},
-		},
-		{
-			name:       "key with WITH clause",
-			definition: "CREATE INDEX `idx` ON `bucket`.`_default`.`_default`(`name` INCLUDE MISSING) WITH {\"num_replica\":1}",
-			wantKeys:   []string{"`name` INCLUDE MISSING"},
-		},
-		{
-			name:       "key with function expression",
-			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(LOWER(`name`) INCLUDE MISSING, `age`)",
-			wantKeys:   []string{"LOWER(`name`) INCLUDE MISSING", "`age`"},
-		},
-		{
-			name:       "key with nested function calls",
-			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(LOWER(TRIM(`name`)) INCLUDE MISSING)",
-			wantKeys:   []string{"LOWER(TRIM(`name`)) INCLUDE MISSING"},
-		},
-		{
-			name:       "key with DESC modifier",
-			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(`timestamp` DESC, `name` INCLUDE MISSING)",
-			wantKeys:   []string{"`timestamp` DESC", "`name` INCLUDE MISSING"},
-		},
-		{
-			name:       "key with PARTITION BY clause after keys",
-			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(`key1` INCLUDE MISSING, `key2`) PARTITION BY HASH(`key1`)",
-			wantKeys:   []string{"`key1` INCLUDE MISSING", "`key2`"},
-		},
-		{
-			name:       "single bucket keyspace",
-			definition: "CREATE INDEX `idx` ON `mybucket`(`field` INCLUDE MISSING)",
-			wantKeys:   []string{"`field` INCLUDE MISSING"},
-		},
-		{
-			name:       "array index expression",
-			definition: "CREATE INDEX `idx` ON `bucket`.`scope`.`collection`(ALL ARRAY `v`.`name` FOR `v` IN `items` END INCLUDE MISSING)",
-			wantKeys:   []string{"ALL ARRAY `v`.`name` FOR `v` IN `items` END INCLUDE MISSING"},
-		},
-		{
-			name:       "missing ON clause",
-			definition: "DROP INDEX `idx` ON `bucket`",
-			wantErr:    true,
-		},
-		{
-			name:       "primary index no keys",
-			definition: "CREATE PRIMARY INDEX `primary_idx` ON `bucket`.`scope`.`collection`",
-			wantErr:    true,
-		},
-		{
-			name:       "primary index with WHERE clause",
-			definition: "CREATE PRIMARY INDEX `primary_idx` ON `bucket`.`scope`.`collection` WHERE (`type` = \"user\")",
-			wantErr:    true,
+			name:           "names with quotes and backslashes are escaped",
+			bucketName:     `bu"cket`,
+			scopeName:      "s1",
+			collectionName: `col\1`,
+			indexName:      `idx"1`,
+			wantQuery: "SELECT RAW i.index_key FROM system:indexes AS i" +
+				" WHERE i.name = \"idx\\\"1\" AND i.`using` = \"gsi\"" +
+				` AND (i.bucket_id = "bu\"cket" AND i.scope_id = "s1" AND i.keyspace_id = "col\\1")`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseIndexKeysFromDefinition(tt.definition)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parseIndexKeysFromDefinition() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if tt.wantErr {
-				return
-			}
-			if len(got) != len(tt.wantKeys) {
-				t.Errorf("parseIndexKeysFromDefinition() got %d keys, want %d keys\ngot:  %v\nwant: %v", len(got), len(tt.wantKeys), got, tt.wantKeys)
-				return
-			}
-			for i := range got {
-				if got[i] != tt.wantKeys[i] {
-					t.Errorf("parseIndexKeysFromDefinition() key[%d] = %q, want %q", i, got[i], tt.wantKeys[i])
-				}
-			}
+			query := buildSystemIndexesQuery(tt.bucketName, tt.scopeName, tt.collectionName, tt.indexName)
+			assert.Equal(t, tt.wantQuery, query)
 		})
 	}
 }
 
-func TestMergeModifiers(t *testing.T) {
+func TestExtractIndexKeys(t *testing.T) {
 	tests := []struct {
 		name     string
-		secExprs []string
-		ddlKeys  []string
-		want     []string
+		body     string
+		wantKeys []string
+		wantErr  bool
 	}{
 		{
-			name:     "appends INCLUDE MISSING from DDL",
-			secExprs: []string{"`name`"},
-			ddlKeys:  []string{"`name` INCLUDE MISSING"},
-			want:     []string{"`name` INCLUDE MISSING"},
+			name:     "single key with INCLUDE MISSING",
+			body:     "{\"results\": [[\"`oktaId` INCLUDE MISSING\"]], \"status\": \"success\"}",
+			wantKeys: []string{"`oktaId` INCLUDE MISSING"},
 		},
 		{
-			name:     "appends DESC from DDL",
-			secExprs: []string{"`timestamp`"},
-			ddlKeys:  []string{"`timestamp` DESC"},
-			want:     []string{"`timestamp` DESC"},
+			name: "multiple keys with modifiers",
+			body: "{\"results\": [[\"`c1` INCLUDE MISSING DESC\", \"`c2`\", \"`v` VECTOR\"]]}",
+			wantKeys: []string{
+				"`c1` INCLUDE MISSING DESC",
+				"`c2`",
+				"`v` VECTOR",
+			},
 		},
 		{
-			name:     "no modifier leaves SecExprs unchanged",
-			secExprs: []string{"`field1`"},
-			ddlKeys:  []string{"`field1`"},
-			want:     []string{"`field1`"},
+			name:    "query service returns errors",
+			body:    `{"errors": [{"msg": "syntax error - invalid statement"}]}`,
+			wantErr: true,
 		},
 		{
-			name:     "mixed keys only some with modifiers",
-			secExprs: []string{"`key1`", "`key2`", "`key3`"},
-			ddlKeys:  []string{"`key1` INCLUDE MISSING", "`key2`", "`key3` DESC"},
-			want:     []string{"`key1` INCLUDE MISSING", "`key2`", "`key3` DESC"},
+			name:    "no results",
+			body:    `{"results": [], "status": "success"}`,
+			wantErr: true,
 		},
 		{
-			name:     "preserves SecExprs formatting when DDL differs",
-			secExprs: []string{"lower(`name`)"},
-			ddlKeys:  []string{"LOWER(`name`) INCLUDE MISSING"},
-			want:     []string{"lower(`name`) INCLUDE MISSING"},
+			name:    "empty index key",
+			body:    `{"results": [[]], "status": "success"}`,
+			wantErr: true,
 		},
 		{
-			name:     "empty slices",
-			secExprs: []string{},
-			ddlKeys:  []string{},
-			want:     []string{},
+			name:    "malformed response",
+			body:    `not json`,
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mergeModifiers(tt.secExprs, tt.ddlKeys)
-			assert.Equal(t, tt.want, got)
+			keys, err := extractIndexKeys([]byte(tt.body))
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantKeys, keys)
 		})
 	}
 }

--- a/internal/resources/gsi_test.go
+++ b/internal/resources/gsi_test.go
@@ -2,6 +2,8 @@ package resources
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseIndexKeysFromDefinition(t *testing.T) {
@@ -102,6 +104,59 @@ func TestParseIndexKeysFromDefinition(t *testing.T) {
 					t.Errorf("parseIndexKeysFromDefinition() key[%d] = %q, want %q", i, got[i], tt.wantKeys[i])
 				}
 			}
+		})
+	}
+}
+
+func TestMergeModifiers(t *testing.T) {
+	tests := []struct {
+		name     string
+		secExprs []string
+		ddlKeys  []string
+		want     []string
+	}{
+		{
+			name:     "appends INCLUDE MISSING from DDL",
+			secExprs: []string{"`name`"},
+			ddlKeys:  []string{"`name` INCLUDE MISSING"},
+			want:     []string{"`name` INCLUDE MISSING"},
+		},
+		{
+			name:     "appends DESC from DDL",
+			secExprs: []string{"`timestamp`"},
+			ddlKeys:  []string{"`timestamp` DESC"},
+			want:     []string{"`timestamp` DESC"},
+		},
+		{
+			name:     "no modifier leaves SecExprs unchanged",
+			secExprs: []string{"`field1`"},
+			ddlKeys:  []string{"`field1`"},
+			want:     []string{"`field1`"},
+		},
+		{
+			name:     "mixed keys only some with modifiers",
+			secExprs: []string{"`key1`", "`key2`", "`key3`"},
+			ddlKeys:  []string{"`key1` INCLUDE MISSING", "`key2`", "`key3` DESC"},
+			want:     []string{"`key1` INCLUDE MISSING", "`key2`", "`key3` DESC"},
+		},
+		{
+			name:     "preserves SecExprs formatting when DDL differs",
+			secExprs: []string{"lower(`name`)"},
+			ddlKeys:  []string{"LOWER(`name`) INCLUDE MISSING"},
+			want:     []string{"lower(`name`) INCLUDE MISSING"},
+		},
+		{
+			name:     "empty slices",
+			secExprs: []string{},
+			ddlKeys:  []string{},
+			want:     []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeModifiers(tt.secExprs, tt.ddlKeys)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/resources/gsi_test.go
+++ b/internal/resources/gsi_test.go
@@ -76,6 +76,11 @@ func TestParseIndexKeysFromDefinition(t *testing.T) {
 			definition: "CREATE PRIMARY INDEX `primary_idx` ON `bucket`.`scope`.`collection`",
 			wantErr:    true,
 		},
+		{
+			name:       "primary index with WHERE clause",
+			definition: "CREATE PRIMARY INDEX `primary_idx` ON `bucket`.`scope`.`collection` WHERE (`type` = \"user\")",
+			wantErr:    true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Jira

* AV-134985

## Description

During terraform import, the provider now fetches the full CREATE INDEX DDL statement from the list definitions endpoint and parses the index key expressions from it, preserving modifiers like INCLUDE MISSING that are absent from the SecExprs field returned by the single-index API endpoint. If the DDL fetch or parse fails, it gracefully falls back to the original SecExprs behavior, ensuring backward compatibility.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [x] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments