### PR TITLE
[AV-136360] Expose service_name on private_endpoint_service data source

### DIFF
--- a/docs/data-sources/private_endpoint_service.md
+++ b/docs/data-sources/private_endpoint_service.md
@@ -32,6 +32,6 @@ data "couchbase-capella_private_endpoint_service" "service_status" {
 ### Read-Only
 
 - `enabled` (Boolean) - Returns true if private endpoint is enabled
-- `service_name` (String) - AWS private DNS service name
+- `service_name` (String) - Cloud provider endpoint service name (for AWS PrivateLink, the VPC endpoint service name like `com.amazonaws.vpce.<region>.vpce-svc-...`)
 - `status` (String) - status of the private endpoint
  - **Valid Values**: `idle`, `unknown`, `enabling`, `enabled`, `enableFailed`, `disabling`, `disabled`, `disableFailed`

--- a/docs/data-sources/private_endpoint_service.md
+++ b/docs/data-sources/private_endpoint_service.md
@@ -32,6 +32,6 @@ data "couchbase-capella_private_endpoint_service" "service_status" {
 ### Read-Only
 
 - `enabled` (Boolean) - Returns true if private endpoint is enabled
-- `service_name` (String) - Cloud provider endpoint service name (for AWS PrivateLink, the VPC endpoint service name like `com.amazonaws.vpce.<region>.vpce-svc-...`)
+- `service_name` (String) - Endpoint service name that customer endpoints connect to. For AWS, the VPC endpoint service name (e.g. `com.amazonaws.vpce.us-east-1.vpce-svc-1234`); for Azure, the Private Link Service resource ID (e.g. `/subscriptions/.../providers/Microsoft.Network/privateLinkServices/<name>`). Not currently returned for GCP.
 - `status` (String) - status of the private endpoint
  - **Valid Values**: `idle`, `unknown`, `enabling`, `enabled`, `enableFailed`, `disabling`, `disabled`, `disableFailed`

--- a/docs/data-sources/private_endpoint_service.md
+++ b/docs/data-sources/private_endpoint_service.md
@@ -32,5 +32,6 @@ data "couchbase-capella_private_endpoint_service" "service_status" {
 ### Read-Only
 
 - `enabled` (Boolean) - Returns true if private endpoint is enabled
+- `service_name` (String) - AWS private DNS service name
 - `status` (String) - status of the private endpoint
  - **Valid Values**: `idle`, `unknown`, `enabling`, `enabled`, `enableFailed`, `disabling`, `disabled`, `disableFailed`

--- a/docs/resources/private_endpoint_service.md
+++ b/docs/resources/private_endpoint_service.md
@@ -36,6 +36,7 @@ resource "couchbase-capella_private_endpoint_service" "new_service" {
 
 ### Read-Only
 
+- `service_name` (String) - AWS private DNS service name
 - `status` (String) - status of the private endpoint
  - **Valid Values**: `idle`, `unknown`, `enabling`, `enabled`, `enableFailed`, `disabling`, `disabled`, `disableFailed`
 

--- a/docs/resources/private_endpoint_service.md
+++ b/docs/resources/private_endpoint_service.md
@@ -36,7 +36,7 @@ resource "couchbase-capella_private_endpoint_service" "new_service" {
 
 ### Read-Only
 
-- `service_name` (String) - AWS private DNS service name
+- `service_name` (String) - Endpoint service name that customer endpoints connect to. For AWS, the VPC endpoint service name (e.g. `com.amazonaws.vpce.us-east-1.vpce-svc-1234`); for Azure, the Private Link Service resource ID (e.g. `/subscriptions/.../providers/Microsoft.Network/privateLinkServices/<name>`). Not currently returned for GCP.
 - `status` (String) - status of the private endpoint
  - **Valid Values**: `idle`, `unknown`, `enabling`, `enabled`, `enableFailed`, `disabling`, `disabled`, `disableFailed`
 

--- a/internal/api/private_endpoint_service.go
+++ b/internal/api/private_endpoint_service.go
@@ -12,12 +12,13 @@ type GetPrivateEndpointServiceStatusResponse struct {
 	// case callers fall back to the Enabled boolean.
 	Status *string `json:"status,omitempty"`
 
-	// ServiceName is the CSP endpoint service name that customer VPC/VNET
-	// endpoints connect to (for AWS, the VPC endpoint service name). It is
-	// available once the private endpoint service is enabled so it can be fed
-	// directly into the customer-side endpoint resource. It is optional and
-	// best-effort: it is omitted when the service is not enabled or when the
-	// name cannot be determined.
+	// ServiceName is the endpoint service name that customer VPC/VNET endpoints
+	// connect to. For AWS it is the VPC endpoint service name; for Azure it is
+	// the Private Link Service resource ID. It is available once the private
+	// endpoint service is enabled so it can be fed directly into the
+	// customer-side endpoint resource. It is optional and best-effort: it is
+	// omitted when the service is not enabled, when the name cannot be
+	// determined, and for GCP clusters (not currently returned).
 	ServiceName *string `json:"serviceName,omitempty"`
 
 	PrivateDns string `json:"privateDns"`

--- a/internal/api/private_endpoint_service.go
+++ b/internal/api/private_endpoint_service.go
@@ -12,5 +12,13 @@ type GetPrivateEndpointServiceStatusResponse struct {
 	// case callers fall back to the Enabled boolean.
 	Status *string `json:"status,omitempty"`
 
+	// ServiceName is the CSP endpoint service name that customer VPC/VNET
+	// endpoints connect to (for AWS, the VPC endpoint service name). It is
+	// available once the private endpoint service is enabled so it can be fed
+	// directly into the customer-side endpoint resource. It is optional and
+	// best-effort: it is omitted when the service is not enabled, when the name
+	// cannot be determined, and on older control planes.
+	ServiceName *string `json:"serviceName,omitempty"`
+
 	PrivateDns string `json:"privateDns"`
 }

--- a/internal/api/private_endpoint_service.go
+++ b/internal/api/private_endpoint_service.go
@@ -16,8 +16,8 @@ type GetPrivateEndpointServiceStatusResponse struct {
 	// endpoints connect to (for AWS, the VPC endpoint service name). It is
 	// available once the private endpoint service is enabled so it can be fed
 	// directly into the customer-side endpoint resource. It is optional and
-	// best-effort: it is omitted when the service is not enabled, when the name
-	// cannot be determined, and on older control planes.
+	// best-effort: it is omitted when the service is not enabled or when the
+	// name cannot be determined.
 	ServiceName *string `json:"serviceName,omitempty"`
 
 	PrivateDns string `json:"privateDns"`

--- a/internal/datasources/private_endpoint_service.go
+++ b/internal/datasources/private_endpoint_service.go
@@ -96,6 +96,10 @@ func (p *PrivateEndpointService) Read(ctx context.Context, req datasource.ReadRe
 	if privateEndpointServiceStatus.Status != nil {
 		state.Status = types.StringValue(*privateEndpointServiceStatus.Status)
 	}
+	state.ServiceName = types.StringNull()
+	if privateEndpointServiceStatus.ServiceName != nil {
+		state.ServiceName = types.StringValue(*privateEndpointServiceStatus.ServiceName)
+	}
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/datasources/private_endpoint_service_schema.go
+++ b/internal/datasources/private_endpoint_service_schema.go
@@ -17,6 +17,7 @@ func PrivateEndpointServiceSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "cluster_id", privateEndpointServiceBuilder, requiredString())
 	capellaschema.AddAttr(attrs, "enabled", privateEndpointServiceBuilder, computedBool())
 	capellaschema.AddAttr(attrs, "status", privateEndpointServiceBuilder, computedString())
+	capellaschema.AddAttr(attrs, "service_name", privateEndpointServiceBuilder, computedString())
 
 	return schema.Schema{
 		MarkdownDescription: "The data source to retrieve private endpoint service information for a cluster.",

--- a/internal/resources/private_endpoint_service.go
+++ b/internal/resources/private_endpoint_service.go
@@ -427,6 +427,10 @@ func initializePrivateEndpointServicePlan(plan providerschema.PrivateEndpointSer
 	if plan.Status.IsNull() || plan.Status.IsUnknown() {
 		plan.Status = types.StringNull()
 	}
+	// service_name is computed; never persist an unknown value to state.
+	if plan.ServiceName.IsNull() || plan.ServiceName.IsUnknown() {
+		plan.ServiceName = types.StringNull()
+	}
 	return plan
 }
 
@@ -672,9 +676,13 @@ func (p *PrivateEndpointService) getServiceState(ctx context.Context, organizati
 		ClusterId:      types.StringValue(clusterId),
 		Enabled:        types.BoolValue(response.Enabled),
 		Status:         types.StringNull(),
+		ServiceName:    types.StringNull(),
 	}
 	if response.Status != nil {
 		state.Status = types.StringValue(*response.Status)
+	}
+	if response.ServiceName != nil {
+		state.ServiceName = types.StringValue(*response.ServiceName)
 	}
 
 	return &state, nil

--- a/internal/resources/private_endpoint_service_schema.go
+++ b/internal/resources/private_endpoint_service_schema.go
@@ -26,6 +26,10 @@ func PrivateEndpointServiceSchema() schema.Schema {
 		Computed: true,
 	})
 
+	capellaschema.AddAttr(attrs, "service_name", privateEndpointServiceBuilder, &schema.StringAttribute{
+		Computed: true,
+	})
+
 	return schema.Schema{
 		MarkdownDescription: "This resource allows you to manage the private endpoint service for an operational cluster. " +
 			"The private endpoint service must be enabled before you can create private endpoints to connect your Cloud Service Provider's private network (VPC/VNET) to your operational cluster. " +

--- a/internal/schema/private_endpoint_service.go
+++ b/internal/schema/private_endpoint_service.go
@@ -29,6 +29,14 @@ type PrivateEndpointService struct {
 	// and unknown; idle means no operation has run. It may be empty when the
 	// control plane does not report a status.
 	Status types.String `tfsdk:"status"`
+
+	// ServiceName is the CSP endpoint service name that customer VPC/VNET
+	// endpoints connect to (for AWS, the VPC endpoint service name, e.g.
+	// com.amazonaws.vpce.us-east-1.vpce-svc-1234). It is populated once the
+	// service is enabled and can be fed directly into an aws_vpc_endpoint
+	// resource. It may be empty on older control planes or when the name cannot
+	// be determined.
+	ServiceName types.String `tfsdk:"service_name"`
 }
 
 // Validate is used to verify that IDs have been properly imported.

--- a/internal/schema/private_endpoint_service.go
+++ b/internal/schema/private_endpoint_service.go
@@ -30,12 +30,13 @@ type PrivateEndpointService struct {
 	// control plane does not report a status.
 	Status types.String `tfsdk:"status"`
 
-	// ServiceName is the CSP endpoint service name that customer VPC/VNET
-	// endpoints connect to (for AWS, the VPC endpoint service name, e.g.
-	// com.amazonaws.vpce.us-east-1.vpce-svc-1234). It is populated once the
-	// service is enabled and can be fed directly into an aws_vpc_endpoint
-	// resource. It may be empty when the service is not enabled or when the
-	// name cannot be determined.
+	// ServiceName is the endpoint service name that customer endpoints connect
+	// to. For AWS it is the VPC endpoint service name (e.g.
+	// com.amazonaws.vpce.us-east-1.vpce-svc-1234); for Azure it is the Private
+	// Link Service resource ID. It is populated once the service is enabled and
+	// can be fed directly into the customer-side endpoint resource. It may be
+	// empty when the service is not enabled, when the name cannot be
+	// determined, and for GCP clusters (not currently returned).
 	ServiceName types.String `tfsdk:"service_name"`
 }
 

--- a/internal/schema/private_endpoint_service.go
+++ b/internal/schema/private_endpoint_service.go
@@ -34,8 +34,8 @@ type PrivateEndpointService struct {
 	// endpoints connect to (for AWS, the VPC endpoint service name, e.g.
 	// com.amazonaws.vpce.us-east-1.vpce-svc-1234). It is populated once the
 	// service is enabled and can be fed directly into an aws_vpc_endpoint
-	// resource. It may be empty on older control planes or when the name cannot
-	// be determined.
+	// resource. It may be empty when the service is not enabled or when the
+	// name cannot be determined.
 	ServiceName types.String `tfsdk:"service_name"`
 }
 


### PR DESCRIPTION
## Jira

* [AV-136360](https://couchbasecloud.atlassian.net/browse/AV-136360) (CBSE-22797 — PepsiCo)

## Description

PepsiCo needs to provision an AWS PrivateLink private endpoint fully automated in a single `terraform apply` (0 manual intervention). The customer-side `aws_vpc_endpoint` resource requires the Capella VPC endpoint **service name** as input, but until now the provider only exposed it buried in a CLI command string or on the `couchbase-capella_private_endpoints` resource — which only knows it *after* an endpoint already exists (chicken-and-egg).

This change exposes `service_name` as a computed attribute on the `couchbase-capella_private_endpoint_service` data source, read from the new `serviceName` field on the service-status API. Because the service name is available as soon as the service is enabled (before any endpoint exists), customers can now chain the full setup in one apply:

```hcl
resource "couchbase-capella_private_endpoint_service" "svc" {
  organization_id = var.organization_id
  project_id      = var.project_id
  cluster_id      = var.cluster_id
  enabled         = true
}

data "couchbase-capella_private_endpoint_service" "svc_status" {
  organization_id = var.organization_id
  project_id      = var.project_id
  cluster_id      = var.cluster_id
  depends_on      = [couchbase-capella_private_endpoint_service.svc]
}

resource "aws_vpc_endpoint" "capella" {
  vpc_id            = var.vpc_id
  service_name      = data.couchbase-capella_private_endpoint_service.svc_status.service_name # NEW
  vpc_endpoint_type = "Interface"
  subnet_ids        = var.subnet_ids
}

resource "couchbase-capella_private_endpoints" "accept" {
  organization_id = var.organization_id
  project_id      = var.project_id
  cluster_id      = var.cluster_id
  endpoint_id     = aws_vpc_endpoint.capella.id
  lifecycle { replace_triggered_by = [aws_vpc_endpoint.capella] }
}
```

Requires the paired backend change (adds `serviceName` to `GET .../privateEndpointService`). The attribute is optional/best-effort: empty on older control planes or when the name cannot be determined.

## Type of Change

- [x] New feature (non-breaking change which adds functionality).
- [x] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence?

- [x] Manually tested
- [x] Unit tested

### Testing

<details open>
  <summary>Testing</summary>

Built from this branch via `dev_overrides` and run against `cbclocal` (with the paired backend branch) targeting a cluster that had the private endpoint service enabled:

```
$ terraform apply -auto-approve
data.couchbase-capella_private_endpoint_service.svc: Read complete after 2s

Outputs:
enabled      = true
service_name = "com.amazonaws.vpce.us-east-1.vpce-svc-007d9544ed35392e0"
status       = "enabled"
```

This matches the raw API response exactly, confirming the full path (backend → API field → provider attribute → HCL reference).

Unit: `TestAllSchemasUseAddAttrPattern` (schema-pattern guard) passes; `go build`/`go vet` clean; docs regenerated via `make build-docs`.

</details>

## Further comments

Mirrors the existing `status` attribute on this data source (same optional/best-effort pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AV-136360]: https://couchbasecloud.atlassian.net/browse/AV-136360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ