### PR TITLE
[AV-137141] Log resource IDs in acceptance test creation messages

### DIFF
--- a/acceptance_tests/app_endpoint_environment.go
+++ b/acceptance_tests/app_endpoint_environment.go
@@ -229,7 +229,7 @@ func waitForAppEndpointTestCluster(ctx context.Context, client *api.Client, dest
 				return err
 			}
 			if clusterResp.CurrentState == clusterapi.Healthy {
-				log.Print("app endpoint test cluster created")
+				log.Printf("app endpoint test cluster created - %s", appEndpointClusterId)
 				return nil
 			}
 		}
@@ -352,7 +352,7 @@ func waitForAppEndpointTestAppService(ctx context.Context, client *api.Client, d
 				return fmt.Errorf("error unmarshalling app service response: %w", err)
 			}
 			if appServiceResponse.CurrentState == appservice.Healthy {
-				log.Print("app endpoint test app service created")
+				log.Printf("app endpoint test app service created - %s", appEndpointAppServiceId)
 				return nil
 			}
 		}

--- a/acceptance_tests/app_service.go
+++ b/acceptance_tests/app_service.go
@@ -14,14 +14,14 @@ import (
 )
 
 func createAppService(ctx context.Context, client *api.Client) error {
-	var n int64 = 2	
+	var n int64 = 2
 	appServiceRequest := appservice.CreateAppServiceRequest{
 		Name: globalAppServiceName,
 		Compute: appservice.AppServiceCompute{
 			Cpu: 2,
 			Ram: 4,
 		},
-		Nodes:   &n,		
+		Nodes: &n,
 	}
 
 	url := fmt.Sprintf(

--- a/acceptance_tests/app_service.go
+++ b/acceptance_tests/app_service.go
@@ -107,7 +107,7 @@ func appServiceWait(ctx context.Context, client *api.Client, destroy bool) error
 			}
 
 			if appServiceResponse.CurrentState == appservice.Healthy {
-				log.Print("app service created")
+				log.Printf("app service created - %s", globalAppServiceId)
 				return nil
 			}
 		}

--- a/acceptance_tests/cluster.go
+++ b/acceptance_tests/cluster.go
@@ -266,7 +266,7 @@ func dmClusterWait(ctx context.Context, client *api.Client, destroy bool) error 
 			}
 
 			if clusterResp.CurrentState == clusterapi.Healthy {
-				log.Print("DM cluster created")
+				log.Printf("DM cluster created - %s", dmClusterId)
 				return nil
 			}
 		}
@@ -326,7 +326,7 @@ func clusterWait(ctx context.Context, client *api.Client, destroy bool) error {
 			}
 
 			if clusterResp.CurrentState == clusterapi.Healthy {
-				log.Print("cluster created")
+				log.Printf("cluster created - %s", globalClusterId)
 				return nil
 			}
 		}

--- a/acceptance_tests/project.go
+++ b/acceptance_tests/project.go
@@ -45,7 +45,7 @@ func createProject(ctx context.Context, client *api.Client) (bool, error) {
 		return false, err
 	}
 
-	log.Print("project created")
+	log.Printf("project created - %s", projectResponse.Id.String())
 	globalProjectId = projectResponse.Id.String()
 	return true, nil
 }


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-137141](https://jira.issues.couchbase.com/browse/AV-137141)

## Description

The acceptance test setup helpers logged "created" messages without the
IDs of the resources they created, making it hard to correlate a failed
or orphaned resource in Capella with a specific test run.

Append the resource ID to each creation log line for the project, global
cluster, DM cluster, global app service, and the app-endpoint test cluster
and app service. Bucket and snapshot-cluster messages already include their
IDs, so they are left unchanged.

This change appends the resource ID to each creation log line:

| Log message | ID added |
|-------------|----------|
| `project created - <projectId>` | `project.go` |
| `cluster created - <clusterId>` | `cluster.go` (global cluster) |
| `DM cluster created - <dmClusterId>` | `cluster.go` |
| `app service created - <appServiceId>` | `app_service.go` |
| `app endpoint test cluster created - <clusterId>` | `app_endpoint_environment.go` |
| `app endpoint test app service created - <appServiceId>` | `app_endpoint_environment.go` |

Bucket messages (`Created bucket: default (...)`) and the snapshot-cluster
message (`snapshot cluster ready: <id> ...`) already log their IDs, so they
were left unchanged. This is logging-only — no behavioral change to the tests
or the provider.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

2026/07/13 09:08:47 project created - 663dbb65-7cb1-4f57-a9b8-984eb59312b6
2026/07/13 09:11:48 cluster created - e4328317-23fe-4367-928b-adbffbf2c654
2026/07/13 09:12:49 bucket created
2026/07/13 09:12:49 Created bucket: default (ZGVmYXVsdA==)
2026/07/13 09:12:49 cluster created - e4328317-23fe-4367-928b-adbffbf2c654

## Further comments

[AV-137141]: https://couchbasecloud.atlassian.net/browse/AV-137141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ