### PR TITLE
[AV-137441] Disable audit log settings

### DIFF
--- a/internal/api/audit_log_settings.go
+++ b/internal/api/audit_log_settings.go
@@ -8,8 +8,8 @@ package api
 //	- Project Manager
 //	To learn more, see [Organization, Project, and Database Access Overview](https://docs.couchbase.com/cloud/organizations/organization-projects-overview.html).
 type UpdateClusterAuditSettingsRequest struct {
-	DisabledUsers   AuditSettingsDisabledUsers `json:"disabledUsers"`
-	EnabledEventIDs []int32                    `json:"enabledEventIDs"`
+	DisabledUsers   AuditSettingsDisabledUsers `json:"disabledUsers,omitempty"`
+	EnabledEventIDs []int32                    `json:"enabledEventIDs,omitempty"`
 	AuditEnabled    bool                       `json:"auditEnabled"`
 }
 

--- a/internal/resources/audit_log_settings.go
+++ b/internal/resources/audit_log_settings.go
@@ -273,10 +273,49 @@ func (a *AuditLogSettings) Update(ctx context.Context, req resource.UpdateReques
 	}
 }
 
-func (a *AuditLogSettings) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// There is no V4 API to delete audit log settings, so we do a noop.
-	//
-	// The framework will automatically update the state file. See:
+// Delete disables audit logging for the cluster.
+func (a *AuditLogSettings) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state providerschema.ClusterAuditSettings
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var (
+		organizationId = state.OrganizationId.ValueString()
+		projectId      = state.ProjectId.ValueString()
+		clusterId      = state.ClusterId.ValueString()
+	)
+
+	auditLogUpdateRequest := api.UpdateClusterAuditSettingsRequest{
+		AuditEnabled: false,
+	}
+
+	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/auditLog", a.HostURL, organizationId, projectId, clusterId)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodPut, SuccessStatus: http.StatusNoContent}
+	_, err := a.ClientV1.ExecuteWithRetry(
+		ctx,
+		cfg,
+		auditLogUpdateRequest,
+		a.Token,
+		nil,
+	)
+
+	if err != nil {
+		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
+		if resourceNotFound {
+			tflog.Info(ctx, "resource doesn't exist in remote server removing resource from state file")
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error deleting audit log settings",
+			"Could not disable audit log settings, unexpected error: "+errString,
+		)
+		return
+	}
+
+	// The framework will automatically remove the resource from the state file. See:
 	// https://developer.hashicorp.com/terraform/plugin/framework/resources/delete#recommendations
 }
 


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-137441

## Description

the provider incorrectly does a noop on removing audit log settings

this can be disabled from V4 API as follows:

```
https put $host/v4/organizations/$orgId/projects/$projectId/clusters/$clusterId/auditLog \
                 -A bearer -a $token \
                 --raw '{ "auditEnabled": false }'
 ```

this PR fixes the delete handler for audit log settings resource

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  
validation in ticket

</details>

## Further comments