### PR TITLE
[AV-137114] Retry once before treating enableFailed/disableFailed as terminal

### DIFF
--- a/internal/resources/private_endpoint_service.go
+++ b/internal/resources/private_endpoint_service.go
@@ -467,6 +467,18 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 	// would leave orphaned infra behind and skip state removal.
 	var lastTerminalFailure error
 
+	// transientFailure gates whether a terminal-failure status observed while
+	// sawInFlight is true gets returned right away or deferred once more. A
+	// single enableFailed/disableFailed sighting can be a transient blip
+	// (e.g. a timeout on the backend's side) that clears up on the backend's
+	// own automatic retry, so we don't want to fail the resource on it
+	// immediately. It starts true, so the first sighting is given the benefit
+	// of the doubt and just flips it to false; only if the same terminal
+	// status is still being reported on the next poll (after another
+	// pollInterval backoff) do we treat it as a real, non-transient failure
+	// and return the error.
+	var transientFailure = true
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -509,18 +521,32 @@ func (p *PrivateEndpointService) waitUntilStatusChanges(ctx context.Context, fin
 			switch *response.Status {
 			case statusEnableFailed:
 				if sawInFlight {
-					return errors.ErrPrivateEndpointServiceEnableFailed
+					// Already given the benefit of the doubt once; seeing the
+					// same failure again means it wasn't a transient blip.
+					if !transientFailure {
+						return errors.ErrPrivateEndpointServiceEnableFailed
+					}
+					transientFailure = false
 				}
 				// Possibly-stale: defer, but remember it so a never-transitioning
 				// enableFailed is still routed to cleanup on timeout.
 				lastTerminalFailure = errors.ErrPrivateEndpointServiceEnableFailed
 			case statusDisableFailed:
 				if sawInFlight {
-					return errors.ErrPrivateEndpointServiceDisableFailed
+					// Already given the benefit of the doubt once; seeing the
+					// same failure again means it wasn't a transient blip.
+					if !transientFailure {
+						return errors.ErrPrivateEndpointServiceDisableFailed
+					}
+					transientFailure = false
 				}
 				lastTerminalFailure = errors.ErrPrivateEndpointServiceDisableFailed
 			case statusEnabling, statusDisabling, statusUnknown:
 				sawInFlight = true
+				// Reset so a future terminal-failure sighting is treated as a
+				// fresh, isolated one (needs to repeat again before we trust
+				// it) rather than immediately confirming a stale prior one.
+				transientFailure = true
 				// The backend progressed, so any earlier terminal status was
 				// genuinely stale; a later stall is a real transition timeout.
 				lastTerminalFailure = nil


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-137114

## Description
<!-- What does this change do? Why is it needed? -->

- waitUntilStatusChanges now requires the same terminal-failure status (enableFailed/disableFailed) to be observed on two consecutive polls (~30s apart) before treating it as a real failure, instead of failing on the first in-flight sighting. This avoids surfacing a false failure, and the resulting cleanup/state-removal, for a transient backend blip (e.g. a timeout) that clears up on the backend's own automatic retry. 

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [X] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
The changes were tested by adding a delay to the creation of NLB and reducing the context of the so in first pass it will not have enough time to check the status of the NLB to turn active. But the second pass i.e on retry, the delay will cause the second pass have enough time to check the status of the NLB to become active.

Before Fix =>
<img width="1481" height="363" alt="Screenshot 2026-07-21 at 11 23 33 AM" src="https://github.com/user-attachments/assets/dbac7f5d-b93e-4c0d-997a-b51c6b8bff28" />

After Fix =>
<img width="1445" height="206" alt="Screenshot 2026-07-21 at 12 02 52 PM" src="https://github.com/user-attachments/assets/d274b83a-ac1b-4d03-b2a7-9ed72a386b79" />

  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments