### PR TITLE
[AV-136886] Add Data API configuration resource

### DIFF
--- a/internal/api/data_api/data_api.go
+++ b/internal/api/data_api/data_api.go
@@ -7,7 +7,7 @@ type UpdateDataApiRequest struct {
 	EnableDataApi bool `json:"enableDataApi"`
 
 	// EnableNetworkPeering enables or disables network peering when the Data API is enabled.
-	EnableNetworkPeering bool `json:"enableNetworkPeering"`
+	EnableNetworkPeering *bool `json:"enableNetworkPeering"`
 }
 
 // GetDataApiStatusResponse is the response received from the Capella V4 Public API when retrieving

--- a/internal/api/data_api/data_api.go
+++ b/internal/api/data_api/data_api.go
@@ -1,0 +1,31 @@
+package data_api
+
+// UpdateDataApiRequest is the payload sent to the Capella V4 Public API when enabling or disabling
+// the Data API and network peering on a cluster.
+type UpdateDataApiRequest struct {
+	// EnableDataApi enables or disables the Data API for the cluster.
+	EnableDataApi bool `json:"enableDataApi"`
+
+	// EnableNetworkPeering enables or disables network peering when the Data API is enabled.
+	EnableNetworkPeering bool `json:"enableNetworkPeering"`
+}
+
+// GetDataApiStatusResponse is the response received from the Capella V4 Public API when retrieving
+// the Data API and network peering status of a cluster.
+type GetDataApiStatusResponse struct {
+	// Enabled indicates whether the Data API is enabled or disabled on the cluster.
+	Enabled bool `json:"enabled"`
+
+	// State is the current status of the Data API.
+	State State `json:"state"`
+
+	// EnabledForNetworkPeering indicates whether network peering was enabled or disabled for the Data API.
+	EnabledForNetworkPeering bool `json:"enabledForNetworkPeering"`
+
+	// StateForNetworkPeering is the current status of network peering for the Data API.
+	StateForNetworkPeering State `json:"stateForNetworkPeering"`
+
+	// ConnectionString is the connection string for the Data API service.
+	// If the Data API is not enabled, this is an empty string.
+	ConnectionString string `json:"connectionString"`
+}

--- a/internal/api/data_api/data_api.go
+++ b/internal/api/data_api/data_api.go
@@ -7,7 +7,7 @@ type UpdateDataApiRequest struct {
 	EnableDataApi bool `json:"enableDataApi"`
 
 	// EnableNetworkPeering enables or disables network peering when the Data API is enabled.
-	EnableNetworkPeering *bool `json:"enableNetworkPeering"`
+	EnableNetworkPeering bool `json:"enableNetworkPeering"`
 }
 
 // GetDataApiStatusResponse is the response received from the Capella V4 Public API when retrieving

--- a/internal/api/data_api/state.go
+++ b/internal/api/data_api/state.go
@@ -1,0 +1,21 @@
+package data_api
+
+type State string
+
+const (
+	Enabled     State = "enabled"
+	Disabled    State = "disabled"
+	Enabling    State = "enabling"
+	Disabling   State = "disabling"
+	Configuring State = "configuring"
+)
+
+// IsFinalState checks whether the Data API or its network peering has finished transitioning and reached a final state
+func IsFinalState(state State) bool {
+	switch state {
+	case Enabled, Disabled:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -335,5 +335,6 @@ func (p *capellaProvider) Resources(_ context.Context) []func() resource.Resourc
 		resources.NewAppEndpointLoggingConfig,
 		resources.NewAppEndpointResync,
 		resources.NewClusterDeletionProtection,
+		resources.NewDataApi,
 	}
 }

--- a/internal/resources/data_api.go
+++ b/internal/resources/data_api.go
@@ -219,7 +219,7 @@ func (d *DataApi) ImportState(ctx context.Context, req resource.ImportStateReque
 func (d *DataApi) updateDataApi(ctx context.Context, plan providerschema.DataApi) error {
 	updateRequest := data_api.UpdateDataApiRequest{
 		EnableDataApi:        plan.EnableDataApi.ValueBool(),
-		EnableNetworkPeering: plan.EnableNetworkPeering.ValueBool(),
+		EnableNetworkPeering: plan.EnableNetworkPeering.ValueBoolPointer(),
 	}
 
 	url := fmt.Sprintf(
@@ -258,6 +258,9 @@ func (d *DataApi) checkDataApiStatus(ctx context.Context, organizationId, projec
 		statusResp, err := d.getDataApiStatus(ctx, organizationId, projectId, clusterId)
 		switch {
 		case err != nil:
+			if resourceNotFound, _ := api.CheckResourceNotFoundError(err); resourceNotFound {
+				return nil, err
+			}
 			tflog.Info(ctx, "retrying after error polling Data API status", map[string]interface{}{"error": err.Error()})
 		case data_api.IsFinalState(statusResp.State) && data_api.IsFinalState(statusResp.StateForNetworkPeering):
 			tflog.Debug(ctx, "data api has reached a final state", map[string]interface{}{

--- a/internal/resources/data_api.go
+++ b/internal/resources/data_api.go
@@ -18,9 +18,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = (*DataApi)(nil)
-	_ resource.ResourceWithConfigure   = (*DataApi)(nil)
-	_ resource.ResourceWithImportState = (*DataApi)(nil)
+	_ resource.Resource                   = (*DataApi)(nil)
+	_ resource.ResourceWithConfigure      = (*DataApi)(nil)
+	_ resource.ResourceWithImportState    = (*DataApi)(nil)
+	_ resource.ResourceWithValidateConfig = (*DataApi)(nil)
 )
 
 const errorMessageWhileDataApiUpdate = "There is an error during the Data API configuration update. Please check in Capella to see if any" +
@@ -48,6 +49,31 @@ func (d *DataApi) Metadata(_ context.Context, req resource.MetadataRequest, resp
 // Schema defines the schema for the Data API configuration resource.
 func (d *DataApi) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = DataApiSchema()
+}
+
+// ValidateConfig rejects enabling network peering while the Data API is disabled, as the Capella API does
+// not allow this combination.
+func (d *DataApi) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config providerschema.DataApi
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Defer validation until Terraform resolves expressions that determine these attribute values.
+	if config.EnableDataApi.IsNull() || config.EnableDataApi.IsUnknown() ||
+		config.EnableNetworkPeering.IsNull() || config.EnableNetworkPeering.IsUnknown() {
+		return
+	}
+
+	if !config.EnableDataApi.ValueBool() && config.EnableNetworkPeering.ValueBool() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("enable_network_peering"),
+			"Invalid Data API Configuration",
+			"Network peering cannot be enabled while the Data API is disabled. "+
+				"Set enable_data_api to true to enable network peering.",
+		)
+	}
 }
 
 // Configure adds the provider configured client to the Data API configuration resource.
@@ -219,7 +245,7 @@ func (d *DataApi) ImportState(ctx context.Context, req resource.ImportStateReque
 func (d *DataApi) updateDataApi(ctx context.Context, plan providerschema.DataApi) error {
 	updateRequest := data_api.UpdateDataApiRequest{
 		EnableDataApi:        plan.EnableDataApi.ValueBool(),
-		EnableNetworkPeering: plan.EnableNetworkPeering.ValueBoolPointer(),
+		EnableNetworkPeering: plan.EnableNetworkPeering.ValueBool(),
 	}
 
 	url := fmt.Sprintf(

--- a/internal/resources/data_api.go
+++ b/internal/resources/data_api.go
@@ -1,0 +1,311 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/data_api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+var (
+	_ resource.Resource                = (*DataApi)(nil)
+	_ resource.ResourceWithConfigure   = (*DataApi)(nil)
+	_ resource.ResourceWithImportState = (*DataApi)(nil)
+)
+
+const errorMessageWhileDataApiUpdate = "There is an error during the Data API configuration update. Please check in Capella to see if any" +
+	" hanging resources have been created, unexpected error: "
+
+const errorMessageAfterDataApiUpdate = "Data API configuration update has been processed, but encountered an error while checking the current" +
+	" state of the Data API. Please run `terraform plan` after 1-2 minutes to know the" +
+	" current state. Additionally, run `terraform apply --refresh-only` to update" +
+	" the state from remote, unexpected error: "
+
+// DataApi is the Data API configuration resource implementation.
+type DataApi struct {
+	*providerschema.Data
+}
+
+func NewDataApi() resource.Resource {
+	return &DataApi{}
+}
+
+// Metadata returns the Data API configuration resource type name.
+func (d *DataApi) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_data_api"
+}
+
+// Schema defines the schema for the Data API configuration resource.
+func (d *DataApi) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = DataApiSchema()
+}
+
+// Configure adds the provider configured client to the Data API configuration resource.
+func (d *DataApi) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	data, ok := req.ProviderData.(*providerschema.Data)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *ProviderSourceData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.Data = data
+}
+
+// Create updates a clusters data API configuration and adds it to the state.
+func (d *DataApi) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan providerschema.DataApi
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var (
+		organizationId = plan.OrganizationId.ValueString()
+		projectId      = plan.ProjectId.ValueString()
+		clusterId      = plan.ClusterId.ValueString()
+	)
+
+	err := d.updateDataApi(ctx, plan)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating Data API configuration",
+			errorMessageWhileDataApiUpdate+api.ParseError(err),
+		)
+		return
+	}
+
+	refreshedState, err := d.checkDataApiStatus(ctx, organizationId, projectId, clusterId)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating Data API configuration",
+			errorMessageAfterDataApiUpdate+api.ParseError(err),
+		)
+		return
+	}
+
+	// Set state to fully populated data
+	diags = resp.State.Set(ctx, refreshedState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read retrieves the Data API and network peering status.
+func (d *DataApi) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state providerschema.DataApi
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	IDs, err := state.Validate()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Capella Data API Configuration",
+			"Could not read Capella Data API configuration: "+err.Error(),
+		)
+		return
+	}
+
+	var (
+		organizationId = IDs[providerschema.OrganizationId]
+		projectId      = IDs[providerschema.ProjectId]
+		clusterId      = IDs[providerschema.ClusterId]
+	)
+
+	statusResp, err := d.getDataApiStatus(ctx, organizationId, projectId, clusterId)
+	if err != nil {
+		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
+		if resourceNotFound {
+			tflog.Info(ctx, "cluster not found, removing resource from state file")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading Capella Data API Configuration",
+			"Could not read Capella Data API configuration: "+errString,
+		)
+		return
+	}
+
+	refreshedState := providerschema.NewDataApi(organizationId, projectId, clusterId, statusResp)
+
+	// Set refreshed state
+	diags = resp.State.Set(ctx, refreshedState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates the Data API configuration.
+func (d *DataApi) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan providerschema.DataApi
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var (
+		organizationId = plan.OrganizationId.ValueString()
+		projectId      = plan.ProjectId.ValueString()
+		clusterId      = plan.ClusterId.ValueString()
+	)
+
+	err := d.updateDataApi(ctx, plan)
+	if err != nil {
+		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
+		if resourceNotFound {
+			tflog.Info(ctx, "cluster not found, removing resource from state file")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error updating Data API configuration",
+			errorMessageWhileDataApiUpdate+errString,
+		)
+		return
+	}
+
+	refreshedState, err := d.checkDataApiStatus(ctx, organizationId, projectId, clusterId)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating Data API configuration",
+			errorMessageAfterDataApiUpdate+api.ParseError(err),
+		)
+		return
+	}
+
+	// Set state to fully populated data
+	diags = resp.State.Set(ctx, refreshedState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete is a no-op operation because the Data API configuration cannot be deleted. The Data API and network peering are left in their current state on the cluster.
+func (d *DataApi) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {
+	// No-op operation.
+}
+
+func (d *DataApi) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("cluster_id"), req, resp)
+}
+
+// updateDataApi calls the update endpoint, which asynchronously enables or disables the Data API and network peering on the cluster.
+func (d *DataApi) updateDataApi(ctx context.Context, plan providerschema.DataApi) error {
+	updateRequest := data_api.UpdateDataApiRequest{
+		EnableDataApi:        plan.EnableDataApi.ValueBool(),
+		EnableNetworkPeering: plan.EnableNetworkPeering.ValueBool(),
+	}
+
+	url := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/dataAPI",
+		d.HostURL,
+		plan.OrganizationId.ValueString(),
+		plan.ProjectId.ValueString(),
+		plan.ClusterId.ValueString(),
+	)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodPut, SuccessStatus: http.StatusAccepted}
+	_, err := d.ClientV1.ExecuteWithRetry(
+		ctx,
+		cfg,
+		updateRequest,
+		d.Token,
+		nil,
+	)
+
+	return err
+}
+
+// checkDataApiStatus polls the Data API status until both the Data API and its network peering reach a final state,
+// then returns the refreshed resource state.
+// Polls up to 30 minutes, with a 15-second interval between polls to allow for the asynchronous operation to complete.
+func (d *DataApi) checkDataApiStatus(ctx context.Context, organizationId, projectId, clusterId string) (*providerschema.DataApi, error) {
+	const timeout = time.Minute * 30
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		statusResp, err := d.getDataApiStatus(ctx, organizationId, projectId, clusterId)
+		switch {
+		case err != nil:
+			tflog.Info(ctx, "retrying after error polling Data API status", map[string]interface{}{"error": err.Error()})
+		case data_api.IsFinalState(statusResp.State) && data_api.IsFinalState(statusResp.StateForNetworkPeering):
+			tflog.Debug(ctx, "data api has reached a final state", map[string]interface{}{
+				"state_for_data_api":        statusResp.State,
+				"state_for_network_peering": statusResp.StateForNetworkPeering,
+			})
+			return providerschema.NewDataApi(organizationId, projectId, clusterId, statusResp), nil
+		default:
+			tflog.Info(ctx, "waiting for Data API to finish transitioning to a final state", map[string]interface{}{
+				"state_for_data_api":        statusResp.State,
+				"state_for_network_peering": statusResp.StateForNetworkPeering,
+			})
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out while waiting for data API state to finish transitioning to a final state: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (d *DataApi) getDataApiStatus(ctx context.Context, organizationId, projectId, clusterId string) (*data_api.GetDataApiStatusResponse, error) {
+	url := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/dataAPI",
+		d.HostURL,
+		organizationId,
+		projectId,
+		clusterId,
+	)
+
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := d.ClientV1.ExecuteWithRetry(
+		ctx,
+		cfg,
+		nil,
+		d.Token,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errors.ErrExecutingRequest, err)
+	}
+
+	statusResp := data_api.GetDataApiStatusResponse{}
+	err = json.Unmarshal(response.Body, &statusResp)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errors.ErrUnmarshallingResponse, err)
+	}
+
+	return &statusResp, nil
+}

--- a/internal/resources/data_api_schema.go
+++ b/internal/resources/data_api_schema.go
@@ -1,0 +1,27 @@
+package resources
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+
+	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+var dataApiBuilder = capellaschema.NewSchemaBuilder("dataApi")
+
+func DataApiSchema() schema.Schema {
+	attrs := make(map[string]schema.Attribute)
+
+	capellaschema.AddAttr(attrs, "organization_id", dataApiBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "project_id", dataApiBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "cluster_id", dataApiBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "enable_data_api", dataApiBuilder, boolAttribute(required))
+	capellaschema.AddAttr(attrs, "enable_network_peering", dataApiBuilder, boolAttribute(optional, computed, useStateForUnknown))
+	capellaschema.AddAttr(attrs, "state_for_data_api", dataApiBuilder, stringAttribute([]string{computed}))
+	capellaschema.AddAttr(attrs, "state_for_network_peering", dataApiBuilder, stringAttribute([]string{computed}))
+	capellaschema.AddAttr(attrs, "connection_string", dataApiBuilder, stringAttribute([]string{computed, useStateForUnknown}))
+
+	return schema.Schema{
+		MarkdownDescription: "This resource allows you to enable or disable the Data API and network peering for an operational cluster.",
+		Attributes:          attrs,
+	}
+}

--- a/internal/resources/data_api_schema.go
+++ b/internal/resources/data_api_schema.go
@@ -15,7 +15,7 @@ func DataApiSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "project_id", dataApiBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "cluster_id", dataApiBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "enable_data_api", dataApiBuilder, boolAttribute(required))
-	capellaschema.AddAttr(attrs, "enable_network_peering", dataApiBuilder, boolAttribute(optional, computed, useStateForUnknown))
+	capellaschema.AddAttr(attrs, "enable_network_peering", dataApiBuilder, boolDefaultAttribute(false, optional, computed))
 	capellaschema.AddAttr(attrs, "state_for_data_api", dataApiBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "state_for_network_peering", dataApiBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "connection_string", dataApiBuilder, stringAttribute([]string{computed, useStateForUnknown}))

--- a/internal/schema/data_api.go
+++ b/internal/schema/data_api.go
@@ -1,0 +1,53 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/data_api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+)
+
+// DataApi maps the couchbase-capella_data_api resource and data source schema data.
+type DataApi struct {
+	OrganizationId         types.String `tfsdk:"organization_id"`
+	ProjectId              types.String `tfsdk:"project_id"`
+	ClusterId              types.String `tfsdk:"cluster_id"`
+	EnableDataApi          types.Bool   `tfsdk:"enable_data_api"`
+	EnableNetworkPeering   types.Bool   `tfsdk:"enable_network_peering"`
+	StateForDataApi        types.String `tfsdk:"state_for_data_api"`
+	StateForNetworkPeering types.String `tfsdk:"state_for_network_peering"`
+	ConnectionString       types.String `tfsdk:"connection_string"`
+}
+
+// NewDataApi morphs the Data API status response into the schema struct.
+func NewDataApi(organizationId, projectId, clusterId string, status *data_api.GetDataApiStatusResponse) *DataApi {
+	return &DataApi{
+		OrganizationId:         types.StringValue(organizationId),
+		ProjectId:              types.StringValue(projectId),
+		ClusterId:              types.StringValue(clusterId),
+		EnableDataApi:          types.BoolValue(status.Enabled),
+		EnableNetworkPeering:   types.BoolValue(status.EnabledForNetworkPeering),
+		StateForDataApi:        types.StringValue(string(status.State)),
+		StateForNetworkPeering: types.StringValue(string(status.StateForNetworkPeering)),
+		ConnectionString:       types.StringValue(status.ConnectionString),
+	}
+}
+
+// Validate is used to verify that IDs have been properly imported.
+func (d *DataApi) Validate() (map[Attr]string, error) {
+	state := map[Attr]basetypes.StringValue{
+		OrganizationId: d.OrganizationId,
+		ProjectId:      d.ProjectId,
+		ClusterId:      d.ClusterId,
+	}
+
+	IDs, err := validateSchemaState(state)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errors.ErrValidatingResource, err)
+	}
+
+	return IDs, nil
+}

--- a/internal/schema/data_api.go
+++ b/internal/schema/data_api.go
@@ -44,7 +44,7 @@ func (d *DataApi) Validate() (map[Attr]string, error) {
 		ClusterId:      d.ClusterId,
 	}
 
-	IDs, err := validateSchemaState(state)
+	IDs, err := validateSchemaState(state, ClusterId)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errors.ErrValidatingResource, err)
 	}


### PR DESCRIPTION
## Jira

* AV-136886

## Description

Adds the `couchbase-capella_data_api` resource, which enables or disables the Data API and network peering on a cluster via the V4 Public API. 

* Design doc: https://docs.google.com/document/d/1VyYhp-YVc-EpDu-TRTFDyPyJIwszvrw2aItHVJk9vIY
* IDEA ticket: https://jira.issues.couchbase.com/browse/IDEA-1718

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

Acceptance tests being added in future PR.

Enable data API with network peering
```
resource "couchbase-capella_data_api" "test" {
  organization_id = local.organization_id
  project_id      = local.project_id
  cluster_id      = local.cluster_id

  enable_data_api        = true
  enable_network_peering = true
}

output "resource_state" {
  value = {
    enable_data_api           = couchbase-capella_data_api.test.enable_data_api
    enable_network_peering    = couchbase-capella_data_api.test.enable_network_peering
    state_for_data_api        = couchbase-capella_data_api.test.state_for_data_api
    state_for_network_peering = couchbase-capella_data_api.test.state_for_network_peering
    connection_string         = couchbase-capella_data_api.test.connection_string
  }
}

$ terraform apply
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # couchbase-capella_data_api.test will be created
  + resource "couchbase-capella_data_api" "test" {
      + cluster_id                = "f059c81c-2a4e-492c-bf37-e35d9e7da74f"
      + connection_string         = (known after apply)
      + enable_data_api           = true
      + enable_network_peering    = true
      + organization_id           = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
      + project_id                = "c09035e8-3971-4b79-a6ec-bccd9056041f"
      + state_for_data_api        = (known after apply)
      + state_for_network_peering = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_state    = {
      + connection_string         = (known after apply)
      + enable_data_api           = true
      + enable_network_peering    = true
      + state_for_data_api        = (known after apply)
      + state_for_network_peering = (known after apply)
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

couchbase-capella_data_api.test: Creating...
couchbase-capella_data_api.test: Still creating... [00m10s elapsed]
...
couchbase-capella_data_api.test: Still creating... [08m00s elapsed]
couchbase-capella_data_api.test: Creation complete after 8m1s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_state = {
  "connection_string" = "https://yeevnfghgseef8ey.data.sandbox.nonprod-project-avengers.com"
  "enable_data_api" = true
  "enable_network_peering" = true
  "state_for_data_api" = "enabled"
  "state_for_network_peering" = "enabled"
}
```

Set networking peering to false
```
...
  enable_network_peering = false
...

$ terraform apply
...
Plan: 0 to add, 1 to change, 0 to destroy.
...
couchbase-capella_data_api.test: Modifying...
couchbase-capella_data_api.test: Still modifying... [00m10s elapsed]
...
couchbase-capella_data_api.test: Still modifying... [01m00s elapsed]
couchbase-capella_data_api.test: Modifications complete after 1m0s

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

resource_state = {
  "connection_string" = "https://yeevnfghgseef8ey.data.sandbox.nonprod-project-avengers.com"
  "enable_data_api" = true
  "enable_network_peering" = false
  "state_for_data_api" = "enabled"
  "state_for_network_peering" = "disabled"
}
```

Import
```
$ terraform import couchbase-capella_data_api.test cluster_id=f059c81c-2a4e-492c-bf37-e35d9e7da74f,project_id=c09035e8-3971-4b79-a6ec-bccd9056041f,organization_id=adb4fb4c-1d98-4287-ac33-230742d2cc76
couchbase-capella_data_api.test: Importing from ID "cluster_id=f059c81c-2a4e-492c-bf37-e35d9e7da74f,project_id=c09035e8-3971-4b79-a6ec-bccd9056041f,organization_id=adb4fb4c-1d98-4287-ac33-230742d2cc76"...
couchbase-capella_data_api.test: Import prepared!
  Prepared couchbase-capella_data_api for import
couchbase-capella_data_api.test: Refreshing state...

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```


Terraform destroy no-ops
```
$ terraform destroy

couchbase-capella_data_api.test: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # couchbase-capella_data_api.test will be destroyed
  - resource "couchbase-capella_data_api" "test" {
      - cluster_id                = "f059c81c-2a4e-492c-bf37-e35d9e7da74f" -> null
      - connection_string         = "https://yeevnfghgseef8ey.data.sandbox.nonprod-project-avengers.com" -> null
      - enable_data_api           = true -> null
      - enable_network_peering    = false -> null
      - organization_id           = "adb4fb4c-1d98-4287-ac33-230742d2cc76" -> null
      - project_id                = "c09035e8-3971-4b79-a6ec-bccd9056041f" -> null
      - state_for_data_api        = "enabled" -> null
      - state_for_network_peering = "disabled" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - resource_state = {
      - connection_string         = "https://yeevnfghgseef8ey.data.sandbox.nonprod-project-avengers.com"
      - enable_data_api           = true
      - enable_network_peering    = false
      - state_for_data_api        = "enabled"
      - state_for_network_peering = "disabled"
    } -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

couchbase-capella_data_api.test: Destroying...
couchbase-capella_data_api.test: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```

<img width="2545" height="1297" alt="image" src="https://github.com/user-attachments/assets/f6ae0711-92c5-4ce9-ae15-abeb4059ebc9" />


More comprehensive testing has been done locally



</details>

## Further comments


