### PR TITLE
[AV-136889] Add Data API status data source

### DIFF
--- a/internal/datasources/data_api.go
+++ b/internal/datasources/data_api.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/data_api"
-	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
 
@@ -48,7 +47,7 @@ func (d *DataApi) Read(ctx context.Context, req datasource.ReadRequest, resp *da
 		return
 	}
 
-	err := d.validate(state)
+	IDs, err := state.Validate()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Capella Data API Status",
@@ -58,9 +57,9 @@ func (d *DataApi) Read(ctx context.Context, req datasource.ReadRequest, resp *da
 	}
 
 	var (
-		organizationId = state.OrganizationId.ValueString()
-		projectId      = state.ProjectId.ValueString()
-		clusterId      = state.ClusterId.ValueString()
+		organizationId = IDs[providerschema.OrganizationId]
+		projectId      = IDs[providerschema.ProjectId]
+		clusterId      = IDs[providerschema.ClusterId]
 	)
 
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/dataAPI", d.HostURL, organizationId, projectId, clusterId)
@@ -109,24 +108,11 @@ func (d *DataApi) Configure(_ context.Context, req datasource.ConfigureRequest, 
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *ProviderSourceData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *providerschema.Data, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
 	}
 
 	d.Data = data
-}
-
-func (d *DataApi) validate(state providerschema.DataApi) error {
-	if state.OrganizationId.IsNull() {
-		return errors.ErrOrganizationIdMissing
-	}
-	if state.ProjectId.IsNull() {
-		return errors.ErrProjectIdMissing
-	}
-	if state.ClusterId.IsNull() {
-		return errors.ErrClusterIdMissing
-	}
-	return nil
 }

--- a/internal/datasources/data_api.go
+++ b/internal/datasources/data_api.go
@@ -47,19 +47,10 @@ func (d *DataApi) Read(ctx context.Context, req datasource.ReadRequest, resp *da
 		return
 	}
 
-	IDs, err := state.Validate()
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Capella Data API Status",
-			"Could not read Data API status for cluster ID "+state.ClusterId.String()+": "+err.Error(),
-		)
-		return
-	}
-
 	var (
-		organizationId = IDs[providerschema.OrganizationId]
-		projectId      = IDs[providerschema.ProjectId]
-		clusterId      = IDs[providerschema.ClusterId]
+		organizationId = state.OrganizationId.ValueString()
+		projectId      = state.ProjectId.ValueString()
+		clusterId      = state.ClusterId.ValueString()
 	)
 
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/dataAPI", d.HostURL, organizationId, projectId, clusterId)

--- a/internal/datasources/data_api.go
+++ b/internal/datasources/data_api.go
@@ -1,0 +1,132 @@
+package datasources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/data_api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = (*DataApi)(nil)
+	_ datasource.DataSourceWithConfigure = (*DataApi)(nil)
+)
+
+// DataApi is the Data API status data source implementation.
+type DataApi struct {
+	*providerschema.Data
+}
+
+// NewDataApi is a helper function to simplify the provider implementation.
+func NewDataApi() datasource.DataSource {
+	return &DataApi{}
+}
+
+// Metadata returns the Data API status data source type name.
+func (d *DataApi) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_data_api"
+}
+
+func (d *DataApi) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = DataApiSchema()
+}
+
+// Read refreshes the Terraform state with the latest Data API and network peering status.
+func (d *DataApi) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state providerschema.DataApi
+	diags := req.Config.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := d.validate(state)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Capella Data API Status",
+			"Could not read Data API status for cluster ID "+state.ClusterId.String()+": "+err.Error(),
+		)
+		return
+	}
+
+	var (
+		organizationId = state.OrganizationId.ValueString()
+		projectId      = state.ProjectId.ValueString()
+		clusterId      = state.ClusterId.ValueString()
+	)
+
+	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/dataAPI", d.HostURL, organizationId, projectId, clusterId)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := d.ClientV1.ExecuteWithRetry(
+		ctx,
+		cfg,
+		nil,
+		d.Token,
+		nil,
+	)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Capella Data API Status",
+			"Could not read Data API status in cluster "+state.ClusterId.String()+": "+api.ParseError(err),
+		)
+		return
+	}
+
+	statusResp := data_api.GetDataApiStatusResponse{}
+	err = json.Unmarshal(response.Body, &statusResp)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Capella Data API Status",
+			"Could not read Data API status in cluster, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	refreshedState := providerschema.NewDataApi(organizationId, projectId, clusterId, &statusResp)
+
+	// Set state
+	diags = resp.State.Set(ctx, refreshedState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (d *DataApi) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	data, ok := req.ProviderData.(*providerschema.Data)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *ProviderSourceData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.Data = data
+}
+
+func (d *DataApi) validate(state providerschema.DataApi) error {
+	if state.OrganizationId.IsNull() {
+		return errors.ErrOrganizationIdMissing
+	}
+	if state.ProjectId.IsNull() {
+		return errors.ErrProjectIdMissing
+	}
+	if state.ClusterId.IsNull() {
+		return errors.ErrClusterIdMissing
+	}
+	return nil
+}

--- a/internal/datasources/data_api_schema.go
+++ b/internal/datasources/data_api_schema.go
@@ -1,0 +1,28 @@
+package datasources
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+
+	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+var dataApiBuilder = capellaschema.NewSchemaBuilder("dataApi")
+
+// DataApiSchema returns the schema for the DataApi data source.
+func DataApiSchema() schema.Schema {
+	attrs := make(map[string]schema.Attribute)
+
+	capellaschema.AddAttr(attrs, "organization_id", dataApiBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "project_id", dataApiBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "cluster_id", dataApiBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "enable_data_api", dataApiBuilder, computedBool())
+	capellaschema.AddAttr(attrs, "enable_network_peering", dataApiBuilder, computedBool())
+	capellaschema.AddAttr(attrs, "state_for_data_api", dataApiBuilder, computedString())
+	capellaschema.AddAttr(attrs, "state_for_network_peering", dataApiBuilder, computedString())
+	capellaschema.AddAttr(attrs, "connection_string", dataApiBuilder, computedString())
+
+	return schema.Schema{
+		MarkdownDescription: "The data source to retrieve the Data API and network peering status for an operational cluster.",
+		Attributes:          attrs,
+	}
+}

--- a/internal/datasources/data_api_schema.go
+++ b/internal/datasources/data_api_schema.go
@@ -12,9 +12,9 @@ var dataApiBuilder = capellaschema.NewSchemaBuilder("dataApi")
 func DataApiSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
 
-	capellaschema.AddAttr(attrs, "organization_id", dataApiBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "project_id", dataApiBuilder, requiredString())
-	capellaschema.AddAttr(attrs, "cluster_id", dataApiBuilder, requiredString())
+	capellaschema.AddAttr(attrs, "organization_id", dataApiBuilder, requiredUUIDString())
+	capellaschema.AddAttr(attrs, "project_id", dataApiBuilder, requiredUUIDString())
+	capellaschema.AddAttr(attrs, "cluster_id", dataApiBuilder, requiredUUIDString())
 	capellaschema.AddAttr(attrs, "enable_data_api", dataApiBuilder, computedBool())
 	capellaschema.AddAttr(attrs, "enable_network_peering", dataApiBuilder, computedBool())
 	capellaschema.AddAttr(attrs, "state_for_data_api", dataApiBuilder, computedString())

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -287,6 +287,7 @@ func (p *capellaProvider) DataSources(_ context.Context) []func() datasource.Dat
 		datasources.NewSnapshotBackupSchedule,
 		datasources.NewAppEndpointLoggingConfig,
 		datasources.NewAppServiceLogStreaming,
+		datasources.NewDataApi,
 	}
 }
 


### PR DESCRIPTION
## Jira

* AV-136889

## Description

Adds the `couchbase-capella_data_api` data source, which reads back the Data API and network peering status (and connection string) for an cluster.

Stacked on the resource PR (AV-136886), which introduces the shared API models and schema.

* Design doc: https://docs.google.com/document/d/1VyYhp-YVc-EpDu-TRTFDyPyJIwszvrw2aItHVJk9vIY
* IDEA ticket: https://jira.issues.couchbase.com/browse/IDEA-1718

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

Acceptance tests being added in future PR.

```
data "couchbase-capella_data_api" "test" {
  organization_id = local.organization_id
  project_id      = local.project_id
  cluster_id      = local.cluster_id
}

output "data_source_state" {
  value = {
    enable_data_api           = data.couchbase-capella_data_api.test.enable_data_api
    enable_network_peering    = data.couchbase-capella_data_api.test.enable_network_peering
    state_for_data_api        = data.couchbase-capella_data_api.test.state_for_data_api
    state_for_network_peering = data.couchbase-capella_data_api.test.state_for_network_peering
    connection_string         = data.couchbase-capella_data_api.test.connection_string
  }
}

$ terraform apply
...
data.couchbase-capella_data_api.test: Reading...
data.couchbase-capella_data_api.test: Read complete after 0s
...
Outputs:
data_source_state = {
  "connection_string" = "https://<redacted>.data.sandbox.nonprod-project-avengers.com"
  "enable_data_api" = true
  "enable_network_peering" = true
  "state_for_data_api" = "enabled"
  "state_for_network_peering" = "enabled"
}
```

</details>

## Further comments

