### PR TITLE
[AV-137842] Do not set computed attr to null if provided by user

### DIFF
--- a/internal/resources/eventing_function.go
+++ b/internal/resources/eventing_function.go
@@ -124,10 +124,8 @@ func (e *EventingFunction) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	// Read the function back to populate computed attributes with their server-assigned values.
-	// The plan is passed forward so URL binding secrets and the State verb are preserved.
 	refreshedState, err := e.retrieveEventingFunction(ctx, organizationId, projectId, clusterId, name, &plan)
 	if err != nil {
-		// The function was created, so do not error out and orphan it; fall back to the plan.
 		resp.Diagnostics.AddWarning(
 			"Error reading eventing function after create",
 			"Eventing function was created but could not be read back: "+api.ParseError(err),
@@ -151,12 +149,8 @@ func (e *EventingFunction) Create(ctx context.Context, req resource.CreateReques
 func setEventingFunctionComputedAttributesToNull(ctx context.Context, plan *providerschema.EventingFunctionResource) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if plan.EventSource == nil {
-		nullKeyspaceComputedAttributes(plan.EventSource)
-	}
-	if plan.EventMetadataStorage == nil {
-		nullKeyspaceComputedAttributes(plan.EventMetadataStorage)
-	}
+	setComputedAttributesInKeyspaceToNull(plan.EventSource)
+	setComputedAttributesInKeyspaceToNull(plan.EventMetadataStorage)
 
 	attrTypes := providerschema.EventingFunctionSettings{}.AttributeTypes()
 	if plan.Settings.IsNull() || plan.Settings.IsUnknown() {
@@ -203,14 +197,21 @@ func setEventingFunctionComputedAttributesToNull(ctx context.Context, plan *prov
 	return diags
 }
 
-// nullKeyspaceComputedAttributes sets the computed scope and collection of a keyspace to null. It is a
-// no-op for a nil keyspace.
-func nullKeyspaceComputedAttributes(k *providerschema.EventingFunctionKeyspace) {
+// setComputedAttributesInKeyspaceToNull sets the computed scope and collection of a keyspace to null,
+// only if not set by the user.
+func setComputedAttributesInKeyspaceToNull(k *providerschema.EventingFunctionKeyspace) {
+	// this should not be nil as keyspace is required in the schema
 	if k == nil {
 		return
 	}
-	k.Scope = types.StringNull()
-	k.Collection = types.StringNull()
+
+	if k.Scope.IsNull() || k.Scope.IsUnknown() {
+		k.Scope = types.StringNull()
+	}
+
+	if k.Collection.IsNull() || k.Collection.IsUnknown() {
+		k.Collection = types.StringNull()
+	}
 }
 
 // eventingValueChanged determines if scalar values are different.

--- a/internal/resources/eventing_function.go
+++ b/internal/resources/eventing_function.go
@@ -151,8 +151,12 @@ func (e *EventingFunction) Create(ctx context.Context, req resource.CreateReques
 func setEventingFunctionComputedAttributesToNull(ctx context.Context, plan *providerschema.EventingFunctionResource) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	nullKeyspaceComputedAttributes(plan.EventSource)
-	nullKeyspaceComputedAttributes(plan.EventMetadataStorage)
+	if plan.EventSource == nil {
+		nullKeyspaceComputedAttributes(plan.EventSource)
+	}
+	if plan.EventMetadataStorage == nil {
+		nullKeyspaceComputedAttributes(plan.EventMetadataStorage)
+	}
 
 	attrTypes := providerschema.EventingFunctionSettings{}.AttributeTypes()
 	if plan.Settings.IsNull() || plan.Settings.IsUnknown() {


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-137842

## Description

when creating an eventing function with large payload, tf reports error `Provider produced inconsistent result after apply`.  this is due to the provider incorrectly nulling attributes configured by the user.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  
validation in ticket

</details>

## Further comments