### PR TITLE
[AV-136891] Add Data API data source acceptance tests

### DIFF
--- a/acceptance_tests/data_api_acceptance_test.go
+++ b/acceptance_tests/data_api_acceptance_test.go
@@ -154,6 +154,54 @@ func TestAccDataApiResourceInvalidUUIDs(t *testing.T) {
 	}
 }
 
+// TestAccDatasourceDataApiInvalidUUIDs verifies that each ID attribute rejects
+// non-UUID values via local schema validation, one attribute per subtest.
+func TestAccDatasourceDataApiInvalidUUIDs(t *testing.T) {
+	tests := []struct {
+		name           string
+		organizationID string
+		projectID      string
+		clusterID      string
+	}{
+		{
+			name:           "organization_id",
+			organizationID: "not-a-uuid",
+			projectID:      "11111111-1111-1111-1111-111111111111",
+			clusterID:      "22222222-2222-2222-2222-222222222222",
+		},
+		{
+			name:           "project_id",
+			organizationID: "00000000-0000-0000-0000-000000000000",
+			projectID:      "not-a-uuid",
+			clusterID:      "22222222-2222-2222-2222-222222222222",
+		},
+		{
+			name:           "cluster_id",
+			organizationID: "00000000-0000-0000-0000-000000000000",
+			projectID:      "11111111-1111-1111-1111-111111111111",
+			clusterID:      "not-a-uuid",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dsName := randomStringWithPrefix("tf_acc_data_api_ds_non_uuid_")
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccDataApiDatasourceIDsConfig(
+							dsName, test.organizationID, test.projectID, test.clusterID),
+						ExpectError: regexp.MustCompile(
+							`(?s)Invalid Attribute Value Match.*` + test.name + `.*must be a valid UUID`),
+					},
+				},
+			})
+		})
+	}
+}
+
 func testAccDataApiResourceConfig(resourceName string, enableDataApi, enableNetworkPeering bool) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -179,6 +227,18 @@ resource "couchbase-capella_data_api" "%[2]s" {
   enable_data_api = true
 }
 `, globalProviderBlock, resourceName, organizationID, projectID, clusterID)
+}
+
+func testAccDataApiDatasourceIDsConfig(dsName, organizationID, projectID, clusterID string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_data_api" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+}
+`, globalProviderBlock, dsName, organizationID, projectID, clusterID)
 }
 
 func testAccDataApiResourceAndDatasourceConfig(resourceName, dsName string, enableDataApi, enableNetworkPeering bool) string {


### PR DESCRIPTION
## Jira

* AV-136891

## Description

* Adds data-source-only acceptance tests for `couchbase-capella_data_api`
* The data source read path itself is exercised alongside the resource in `TestAccDataApiResource`

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

```

=== RUN   TestAccDataApiResource
--- PASS: TestAccDataApiResource (723.86s)
=== RUN   TestAccDataApiResourceNetworkPeeringWithoutDataApi
=== PAUSE TestAccDataApiResourceNetworkPeeringWithoutDataApi
=== RUN   TestAccDataApiResourceInvalidUUIDs
=== RUN   TestAccDataApiResourceInvalidUUIDs/organization_id
=== PAUSE TestAccDataApiResourceInvalidUUIDs/organization_id
=== RUN   TestAccDataApiResourceInvalidUUIDs/project_id
=== PAUSE TestAccDataApiResourceInvalidUUIDs/project_id
=== RUN   TestAccDataApiResourceInvalidUUIDs/cluster_id
=== PAUSE TestAccDataApiResourceInvalidUUIDs/cluster_id
=== CONT  TestAccDataApiResourceInvalidUUIDs/organization_id
=== CONT  TestAccDataApiResourceInvalidUUIDs/cluster_id
=== CONT  TestAccDataApiResourceInvalidUUIDs/project_id
--- PASS: TestAccDataApiResourceInvalidUUIDs (0.00s)
    --- PASS: TestAccDataApiResourceInvalidUUIDs/cluster_id (0.21s)
    --- PASS: TestAccDataApiResourceInvalidUUIDs/project_id (0.21s)
    --- PASS: TestAccDataApiResourceInvalidUUIDs/organization_id (0.22s)
=== RUN   TestAccDatasourceDataApiInvalidUUIDs
=== RUN   TestAccDatasourceDataApiInvalidUUIDs/organization_id
=== PAUSE TestAccDatasourceDataApiInvalidUUIDs/organization_id
=== RUN   TestAccDatasourceDataApiInvalidUUIDs/project_id
=== PAUSE TestAccDatasourceDataApiInvalidUUIDs/project_id
=== RUN   TestAccDatasourceDataApiInvalidUUIDs/cluster_id
=== PAUSE TestAccDatasourceDataApiInvalidUUIDs/cluster_id
=== CONT  TestAccDatasourceDataApiInvalidUUIDs/organization_id
=== CONT  TestAccDatasourceDataApiInvalidUUIDs/cluster_id
=== CONT  TestAccDatasourceDataApiInvalidUUIDs/project_id
--- PASS: TestAccDatasourceDataApiInvalidUUIDs (0.00s)
    --- PASS: TestAccDatasourceDataApiInvalidUUIDs/cluster_id (0.24s)
    --- PASS: TestAccDatasourceDataApiInvalidUUIDs/project_id (0.24s)
    --- PASS: TestAccDatasourceDataApiInvalidUUIDs/organization_id (0.24s)

```

</details>

## Further comments
