### PR TITLE
[AV-138040] Add review_model gpt-5.2 and bump droid-action to v5

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -25,8 +25,9 @@ jobs:
           fetch-depth: 1
 
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@v3
+        uses: Factory-AI/droid-action@e3d1f5e7861c36fe4a9c4dca3edec87b964b2bc4 # v5.0.0
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          review_model: gpt-5.2
           automatic_review: true
           allowed_bots: "factory-droid[bot]"

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -34,7 +34,8 @@ jobs:
           fetch-depth: 1
 
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@v3
+        uses: Factory-AI/droid-action@e3d1f5e7861c36fe4a9c4dca3edec87b964b2bc4 # v5.0.0
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          review_model: gpt-5.2
           allowed_bots: "factory-droid[bot]"


### PR DESCRIPTION
## Jira

* [AV-138040](https://couchbasecloud.atlassian.net/browse/AV-138040)

## Description

Configures the Factory Droid GitHub Actions workflows to use `gpt-5.2` for reviews.

- `droid-review.yml` — add `review_model: gpt-5.2`; bump `Factory-AI/droid-action` v3 → v5.0.0 (pinned SHA `e3d1f5e7861c36fe4a9c4dca3edec87b964b2bc4`)
- `droid.yml` — add `review_model: gpt-5.2`; bump `droid-action` v3 → v5.0.0

v3 predates the current `review_model` input contract, so the action bump is required for the input to be honored. No security workflow exists in this repo (net-new parity deferred, out of scope for this AV).

## Type of Change

- [x] This change updates the ci/cd workflow.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested

### Testing

<details open>
  <summary>Testing</summary>

- Both workflow YAML files parse cleanly.
- No stale `droid-action@v3` references remain.
- Pending: throwaway PR to confirm auto-review fires and the run log shows `gpt-5.2`.

</details>

## Further comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AV-138040]: https://couchbasecloud.atlassian.net/browse/AV-138040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ