### PR TITLE
[AV-136695] Merge Data API feature branch (feature/AV-136695-data-api-config-support) in to main

### DIFF
--- a/acceptance_tests/data_api_acceptance_test.go
+++ b/acceptance_tests/data_api_acceptance_test.go
@@ -1,0 +1,263 @@
+package acceptance_tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/data_api"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+// TestAccDataApiResource exercises the resource and its paired data source together through the
+// enable, enable-peering, import and disable transitions on the shared cluster.
+func TestAccDataApiResource(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_data_api_")
+	resourceReference := "couchbase-capella_data_api." + resourceName
+	dsName := randomStringWithPrefix("tf_acc_data_api_ds_")
+	dsReference := "data.couchbase-capella_data_api." + dsName
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataApiResourceAndDatasourceConfig(resourceName, dsName, true, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDataApiResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(resourceReference, "enable_data_api", "true"),
+					resource.TestCheckResourceAttr(resourceReference, "enable_network_peering", "false"),
+					resource.TestCheckResourceAttr(resourceReference, "state_for_data_api", "enabled"),
+					resource.TestCheckResourceAttr(resourceReference, "state_for_network_peering", "disabled"),
+					resource.TestCheckResourceAttrSet(resourceReference, "connection_string"),
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(dsReference, "enable_data_api", "true"),
+					resource.TestCheckResourceAttr(dsReference, "enable_network_peering", "false"),
+					resource.TestCheckResourceAttr(dsReference, "state_for_data_api", "enabled"),
+					resource.TestCheckResourceAttr(dsReference, "state_for_network_peering", "disabled"),
+					resource.TestCheckResourceAttrSet(dsReference, "connection_string"),
+				),
+			},
+			{
+				ResourceName:                         resourceReference,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    generateDataApiImportId(resourceReference),
+				ImportStateVerifyIdentifierAttribute: "cluster_id",
+			},
+			{
+				Config: testAccDataApiResourceAndDatasourceConfig(resourceName, dsName, true, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDataApiResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "enable_data_api", "true"),
+					resource.TestCheckResourceAttr(resourceReference, "enable_network_peering", "true"),
+					resource.TestCheckResourceAttr(resourceReference, "state_for_data_api", "enabled"),
+					resource.TestCheckResourceAttr(resourceReference, "state_for_network_peering", "enabled"),
+					resource.TestCheckResourceAttrSet(resourceReference, "connection_string"),
+					resource.TestCheckResourceAttr(dsReference, "enable_data_api", "true"),
+					resource.TestCheckResourceAttr(dsReference, "enable_network_peering", "true"),
+					resource.TestCheckResourceAttr(dsReference, "state_for_data_api", "enabled"),
+					resource.TestCheckResourceAttr(dsReference, "state_for_network_peering", "enabled"),
+					resource.TestCheckResourceAttrSet(dsReference, "connection_string"),
+				),
+			},
+			{
+				Config: testAccDataApiResourceAndDatasourceConfig(resourceName, dsName, false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDataApiResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "enable_data_api", "false"),
+					resource.TestCheckResourceAttr(resourceReference, "enable_network_peering", "false"),
+					resource.TestCheckResourceAttr(resourceReference, "state_for_data_api", "disabled"),
+					resource.TestCheckResourceAttr(resourceReference, "state_for_network_peering", "disabled"),
+					resource.TestCheckResourceAttr(dsReference, "enable_data_api", "false"),
+					resource.TestCheckResourceAttr(dsReference, "enable_network_peering", "false"),
+					resource.TestCheckResourceAttr(dsReference, "state_for_data_api", "disabled"),
+					resource.TestCheckResourceAttr(dsReference, "state_for_network_peering", "disabled"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDataApiResourceNetworkPeeringWithoutDataApi verifies that enabling network peering while the Data API is
+// disabled is rejected by local config validation instead of being sent to the API.
+func TestAccDataApiResourceNetworkPeeringWithoutDataApi(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_data_api_peering_only_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataApiResourceConfig(resourceName, false, true),
+				ExpectError: regexp.MustCompile(`Network peering cannot be enabled`),
+			},
+		},
+	})
+}
+
+// TestAccDataApiResourceInvalidUUIDs verifies that each ID attribute rejects
+// non-UUID values via local schema validation, one attribute per subtest.
+func TestAccDataApiResourceInvalidUUIDs(t *testing.T) {
+	tests := []struct {
+		name           string
+		organizationID string
+		projectID      string
+		clusterID      string
+	}{
+		{
+			name:           "organization_id",
+			organizationID: "not-a-uuid",
+			projectID:      "11111111-1111-1111-1111-111111111111",
+			clusterID:      "22222222-2222-2222-2222-222222222222",
+		},
+		{
+			name:           "project_id",
+			organizationID: "00000000-0000-0000-0000-000000000000",
+			projectID:      "not-a-uuid",
+			clusterID:      "22222222-2222-2222-2222-222222222222",
+		},
+		{
+			name:           "cluster_id",
+			organizationID: "00000000-0000-0000-0000-000000000000",
+			projectID:      "11111111-1111-1111-1111-111111111111",
+			clusterID:      "not-a-uuid",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resourceName := randomStringWithPrefix("tf_acc_data_api_non_uuid_")
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccDataApiResourceIDsConfig(
+							resourceName, test.organizationID, test.projectID, test.clusterID),
+						ExpectError: regexp.MustCompile(
+							`(?s)Invalid Attribute Value Match.*` + test.name + `.*must be a valid UUID`),
+					},
+				},
+			})
+		})
+	}
+}
+
+func testAccDataApiResourceConfig(resourceName string, enableDataApi, enableNetworkPeering bool) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_data_api" "%[2]s" {
+  organization_id        = "%[3]s"
+  project_id             = "%[4]s"
+  cluster_id             = "%[5]s"
+  enable_data_api        = %[6]t
+  enable_network_peering = %[7]t
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, enableDataApi, enableNetworkPeering)
+}
+
+func testAccDataApiResourceIDsConfig(resourceName, organizationID, projectID, clusterID string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_data_api" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  enable_data_api = true
+}
+`, globalProviderBlock, resourceName, organizationID, projectID, clusterID)
+}
+
+func testAccDataApiResourceAndDatasourceConfig(resourceName, dsName string, enableDataApi, enableNetworkPeering bool) string {
+	// enable_network_peering is omitted when false so those steps also exercise the attribute's default.
+	enableNetworkPeeringAttr := ""
+	if enableNetworkPeering {
+		enableNetworkPeeringAttr = "\n  enable_network_peering = true"
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_data_api" "%[2]s" {
+  organization_id = "%[4]s"
+  project_id      = "%[5]s"
+  cluster_id      = "%[6]s"
+  enable_data_api = %[7]t%[8]s
+}
+
+data "couchbase-capella_data_api" "%[3]s" {
+  organization_id = "%[4]s"
+  project_id      = "%[5]s"
+  cluster_id      = "%[6]s"
+
+  depends_on = [couchbase-capella_data_api.%[2]s]
+}
+`, globalProviderBlock, resourceName, dsName, globalOrgId, globalProjectId, globalClusterId, enableDataApi, enableNetworkPeeringAttr)
+}
+
+func generateDataApiImportId(resourceReference string) resource.ImportStateIdFunc {
+	return func(state *terraform.State) (string, error) {
+		var rawState map[string]string
+		for _, m := range state.Modules {
+			if len(m.Resources) > 0 {
+				if v, ok := m.Resources[resourceReference]; ok {
+					rawState = v.Primary.Attributes
+				}
+			}
+		}
+		return fmt.Sprintf(
+			"cluster_id=%s,project_id=%s,organization_id=%s",
+			rawState["cluster_id"],
+			rawState["project_id"],
+			rawState["organization_id"],
+		), nil
+	}
+}
+
+func retrieveDataApiStatusFromServer(data *providerschema.Data, organizationId, projectId, clusterId string) (*data_api.GetDataApiStatusResponse, error) {
+	url := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/dataAPI",
+		data.HostURL, organizationId, projectId, clusterId,
+	)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := data.ClientV1.ExecuteWithRetry(context.Background(), cfg, nil, data.Token, nil)
+	if err != nil {
+		return nil, err
+	}
+	status := &data_api.GetDataApiStatusResponse{}
+	if err := json.Unmarshal(response.Body, status); err != nil {
+		return nil, err
+	}
+	return status, nil
+}
+
+func testAccExistsDataApiResource(t *testing.T, resourceReference string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		var rawState map[string]string
+		for _, m := range s.Modules {
+			if len(m.Resources) > 0 {
+				if v, ok := m.Resources[resourceReference]; ok {
+					rawState = v.Primary.Attributes
+				}
+			}
+		}
+		data := newTestClient(t)
+		_, err := retrieveDataApiStatusFromServer(
+			data, rawState["organization_id"], rawState["project_id"], rawState["cluster_id"],
+		)
+		return err
+	}
+}

--- a/acceptance_tests/data_api_acceptance_test.go
+++ b/acceptance_tests/data_api_acceptance_test.go
@@ -154,6 +154,54 @@ func TestAccDataApiResourceInvalidUUIDs(t *testing.T) {
 	}
 }
 
+// TestAccDatasourceDataApiInvalidUUIDs verifies that each ID attribute rejects
+// non-UUID values via local schema validation, one attribute per subtest.
+func TestAccDatasourceDataApiInvalidUUIDs(t *testing.T) {
+	tests := []struct {
+		name           string
+		organizationID string
+		projectID      string
+		clusterID      string
+	}{
+		{
+			name:           "organization_id",
+			organizationID: "not-a-uuid",
+			projectID:      "11111111-1111-1111-1111-111111111111",
+			clusterID:      "22222222-2222-2222-2222-222222222222",
+		},
+		{
+			name:           "project_id",
+			organizationID: "00000000-0000-0000-0000-000000000000",
+			projectID:      "not-a-uuid",
+			clusterID:      "22222222-2222-2222-2222-222222222222",
+		},
+		{
+			name:           "cluster_id",
+			organizationID: "00000000-0000-0000-0000-000000000000",
+			projectID:      "11111111-1111-1111-1111-111111111111",
+			clusterID:      "not-a-uuid",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dsName := randomStringWithPrefix("tf_acc_data_api_ds_non_uuid_")
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccDataApiDatasourceIDsConfig(
+							dsName, test.organizationID, test.projectID, test.clusterID),
+						ExpectError: regexp.MustCompile(
+							`(?s)Invalid Attribute Value Match.*` + test.name + `.*must be a valid UUID`),
+					},
+				},
+			})
+		})
+	}
+}
+
 func testAccDataApiResourceConfig(resourceName string, enableDataApi, enableNetworkPeering bool) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -179,6 +227,18 @@ resource "couchbase-capella_data_api" "%[2]s" {
   enable_data_api = true
 }
 `, globalProviderBlock, resourceName, organizationID, projectID, clusterID)
+}
+
+func testAccDataApiDatasourceIDsConfig(dsName, organizationID, projectID, clusterID string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_data_api" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+}
+`, globalProviderBlock, dsName, organizationID, projectID, clusterID)
 }
 
 func testAccDataApiResourceAndDatasourceConfig(resourceName, dsName string, enableDataApi, enableNetworkPeering bool) string {

--- a/examples/data-sources/couchbase-capella_data_api/data-source.tf
+++ b/examples/data-sources/couchbase-capella_data_api/data-source.tf
@@ -1,0 +1,5 @@
+data "couchbase-capella_data_api" "existing_data_api" {
+  organization_id = "<organization_id>"
+  project_id      = "<project_id>"
+  cluster_id      = "<cluster_id>"
+}

--- a/examples/data_api/README.md
+++ b/examples/data_api/README.md
@@ -1,0 +1,148 @@
+# Capella Data API Example
+
+This example shows how to enable or disable the Data API and network peering on an existing Couchbase Capella operational cluster using the `couchbase-capella_data_api` resource.
+
+## Example Walkthrough
+
+1. **CREATE** - Enable the Data API on an existing cluster.
+2. **UPDATE** - Enable network peering for the Data API.
+3. **IMPORT** - Import an existing Data API configuration into Terraform state.
+4. **DESTROY** - Remove the resource from state (a no-op operation that does not alter the cluster Data API configuration).
+
+Copy `terraform.template.tfvars` to `terraform.tfvars` and update the values with your credentials.
+
+## CREATE
+
+### View the plan
+
+Command: `terraform plan`
+
+Sample Output:
+```
+$ terraform plan
+
+Terraform will perform the following actions:
+
+  # couchbase-capella_data_api.new_data_api will be created
+  + resource "couchbase-capella_data_api" "new_data_api" {
+      + cluster_id                = "ffffffff-aaaa-1414-eeee-000000000000"
+      + connection_string         = (known after apply)
+      + enable_data_api           = true
+      + enable_network_peering    = false
+      + organization_id           = "ffffffff-aaaa-1414-eeee-000000000000"
+      + project_id                = "ffffffff-aaaa-1414-eeee-000000000000"
+      + state_for_data_api        = (known after apply)
+      + state_for_network_peering = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+```
+
+### Apply the plan
+
+Enabling the Data API is an asynchronous operation, so the apply waits (up to 30 minutes) for the Data API to finish transitioning and reach a final state.
+
+Command: `terraform apply`
+
+Sample Output:
+```
+$ terraform apply
+
+...
+
+couchbase-capella_data_api.new_data_api: Creating...
+couchbase-capella_data_api.new_data_api: Still creating... [00m10s elapsed]
+...
+couchbase-capella_data_api.new_data_api: Still creating... [08m00s elapsed]
+couchbase-capella_data_api.new_data_api: Creation complete after 8m1s
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+new_data_api = {
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "connection_string" = "couchbases://cb.abcdefghijklmnop.cloud.couchbase.com"
+  "enable_data_api" = true
+  "enable_network_peering" = false
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "state_for_data_api" = "enabled"
+  "state_for_network_peering" = "disabled"
+}
+```
+
+## UPDATE - Enable network peering
+
+Set `enable_network_peering = true` in `terraform.tfvars`, then apply:
+
+Command: `terraform apply`
+
+Sample Output:
+```
+$ terraform apply
+
+...
+
+  # couchbase-capella_data_api.new_data_api will be updated in-place
+  ~ resource "couchbase-capella_data_api" "new_data_api" {
+      ~ enable_network_peering    = false -> true
+      ~ state_for_data_api        = "enabled" -> (known after apply)
+      ~ state_for_network_peering = "disabled" -> (known after apply)
+    }
+
+...
+
+couchbase-capella_data_api.new_data_api: Modifying...
+couchbase-capella_data_api.new_data_api: Still modifying... [00m10s elapsed]
+...
+couchbase-capella_data_api.new_data_api: Still modifying... [01m00s elapsed]
+couchbase-capella_data_api.new_data_api: Modifications complete after 1m0s
+
+Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
+```
+
+## IMPORT
+Command: `terraform import couchbase-capella_data_api.new_data_api cluster_id=<cluster_id>,project_id=<project_id>,organization_id=<organization_id>`
+
+In this case, the complete command is:
+`terraform import couchbase-capella_data_api.new_data_api cluster_id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000000,organization_id=ffffffff-aaaa-1414-eeee-000000000000`
+
+Sample Output:
+```
+$ terraform import couchbase-capella_data_api.new_data_api cluster_id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000000,organization_id=ffffffff-aaaa-1414-eeee-000000000000
+couchbase-capella_data_api.new_data_api: Importing from ID "cluster_id=ffffffff-aaaa-1414-eeee-000000000000,project_id=ffffffff-aaaa-1414-eeee-000000000000,organization_id=ffffffff-aaaa-1414-eeee-000000000000"...
+couchbase-capella_data_api.new_data_api: Import prepared!
+  Prepared couchbase-capella_data_api for import
+couchbase-capella_data_api.test: Refreshing state...
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+## DESTROY
+
+Removing this resource from state does **not** modify the Data API on the cluster. The Data API and network peering are left in their current state. This destroy is purely a no-op.
+
+Command: `terraform destroy`
+
+Sample Output:
+```
+$ terraform destroy
+
+couchbase-capella_data_api.new_data_api: Refreshing state...
+
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+  - destroy
+
+...
+
+couchbase-capella_data_api.new_data_api: Destroying...
+couchbase-capella_data_api.new_data_api: Destruction complete after 0s
+
+Destroy complete! Resources: 1 destroyed.
+```
+
+If you need to disable the Data API, set `enable_data_api = false` and apply before destroying.

--- a/examples/data_api/README.md
+++ b/examples/data_api/README.md
@@ -1,13 +1,14 @@
 # Capella Data API Example
 
-This example shows how to enable or disable the Data API and network peering on an existing Couchbase Capella operational cluster using the `couchbase-capella_data_api` resource.
+This example shows how to enable or disable the Data API and network peering on an existing Couchbase Capella operational cluster using the `couchbase-capella_data_api` resource, and how to read the current Data API status using the `couchbase-capella_data_api` data source.
 
 ## Example Walkthrough
 
 1. **CREATE** - Enable the Data API on an existing cluster.
 2. **UPDATE** - Enable network peering for the Data API.
-3. **IMPORT** - Import an existing Data API configuration into Terraform state.
-4. **DESTROY** - Remove the resource from state (a no-op operation that does not alter the cluster Data API configuration).
+3. **GET** - Read the current Data API status using the data source.
+4. **IMPORT** - Import an existing Data API configuration into Terraform state.
+5. **DESTROY** - Remove the resource from state (a no-op operation that does not alter the cluster Data API configuration).
 
 Copy `terraform.template.tfvars` to `terraform.tfvars` and update the values with your credentials.
 
@@ -100,6 +101,27 @@ couchbase-capella_data_api.new_data_api: Still modifying... [01m00s elapsed]
 couchbase-capella_data_api.new_data_api: Modifications complete after 1m0s
 
 Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
+```
+
+## GET - Read the Data API status
+
+The `get_data_api.tf` file reads the current Data API status of the cluster using the `couchbase-capella_data_api` data source and exposes it as the `existing_data_api` output.
+
+Command: `terraform output existing_data_api`
+
+Sample Output:
+```
+$ terraform output existing_data_api
+{
+  "cluster_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "connection_string" = "couchbases://cb.abcdefghijklmnop.cloud.couchbase.com"
+  "enable_data_api" = true
+  "enable_network_peering" = true
+  "organization_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "project_id" = "ffffffff-aaaa-1414-eeee-000000000000"
+  "state_for_data_api" = "enabled"
+  "state_for_network_peering" = "enabled"
+}
 ```
 
 ## IMPORT

--- a/examples/data_api/create_data_api.tf
+++ b/examples/data_api/create_data_api.tf
@@ -1,0 +1,11 @@
+output "new_data_api" {
+  value = couchbase-capella_data_api.new_data_api
+}
+
+resource "couchbase-capella_data_api" "new_data_api" {
+  organization_id        = var.organization_id
+  project_id             = var.project_id
+  cluster_id             = var.cluster_id
+  enable_data_api        = var.data_api.enable_data_api
+  enable_network_peering = var.data_api.enable_network_peering
+}

--- a/examples/data_api/get_data_api.tf
+++ b/examples/data_api/get_data_api.tf
@@ -1,0 +1,9 @@
+output "existing_data_api" {
+  value = data.couchbase-capella_data_api.existing_data_api
+}
+
+data "couchbase-capella_data_api" "existing_data_api" {
+  organization_id = var.organization_id
+  project_id      = var.project_id
+  cluster_id      = var.cluster_id
+}

--- a/examples/data_api/main.tf
+++ b/examples/data_api/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    couchbase-capella = {
+      source = "couchbasecloud/couchbase-capella"
+    }
+  }
+}
+
+provider "couchbase-capella" {
+  authentication_token = var.auth_token
+}

--- a/examples/data_api/terraform.template.tfvars
+++ b/examples/data_api/terraform.template.tfvars
@@ -1,0 +1,9 @@
+auth_token      = "<v4-api-key-secret>"
+organization_id = "<organization_id>"
+project_id      = "<project_id>"
+cluster_id      = "<cluster_id>"
+
+data_api = {
+  enable_data_api        = true
+  enable_network_peering = false
+}

--- a/examples/data_api/variables.tf
+++ b/examples/data_api/variables.tf
@@ -1,0 +1,25 @@
+variable "organization_id" {
+  description = "Capella Organization ID"
+}
+
+variable "project_id" {
+  description = "Capella Project ID"
+}
+
+variable "cluster_id" {
+  description = "Capella Cluster ID"
+}
+
+variable "auth_token" {
+  description = "Authentication API Key"
+  sensitive   = true
+}
+
+variable "data_api" {
+  description = "Data API configuration for the cluster"
+
+  type = object({
+    enable_data_api        = bool
+    enable_network_peering = bool
+  })
+}

--- a/examples/resources/couchbase-capella_data_api/import.sh
+++ b/examples/resources/couchbase-capella_data_api/import.sh
@@ -1,0 +1,1 @@
+terraform import couchbase-capella_data_api.new_data_api cluster_id=<cluster_id>,project_id=<project_id>,organization_id=<organization_id>

--- a/examples/resources/couchbase-capella_data_api/resource.tf
+++ b/examples/resources/couchbase-capella_data_api/resource.tf
@@ -1,0 +1,7 @@
+resource "couchbase-capella_data_api" "new_data_api" {
+  organization_id        = "<organization_id>"
+  project_id             = "<project_id>"
+  cluster_id             = "<cluster_id>"
+  enable_data_api        = true
+  enable_network_peering = false
+}

--- a/internal/api/data_api/data_api.go
+++ b/internal/api/data_api/data_api.go
@@ -1,0 +1,31 @@
+package data_api
+
+// UpdateDataApiRequest is the payload sent to the Capella V4 Public API when enabling or disabling
+// the Data API and network peering on a cluster.
+type UpdateDataApiRequest struct {
+	// EnableDataApi enables or disables the Data API for the cluster.
+	EnableDataApi bool `json:"enableDataApi"`
+
+	// EnableNetworkPeering enables or disables network peering when the Data API is enabled.
+	EnableNetworkPeering bool `json:"enableNetworkPeering"`
+}
+
+// GetDataApiStatusResponse is the response received from the Capella V4 Public API when retrieving
+// the Data API and network peering status of a cluster.
+type GetDataApiStatusResponse struct {
+	// Enabled indicates whether the Data API is enabled or disabled on the cluster.
+	Enabled bool `json:"enabled"`
+
+	// State is the current status of the Data API.
+	State State `json:"state"`
+
+	// EnabledForNetworkPeering indicates whether network peering was enabled or disabled for the Data API.
+	EnabledForNetworkPeering bool `json:"enabledForNetworkPeering"`
+
+	// StateForNetworkPeering is the current status of network peering for the Data API.
+	StateForNetworkPeering State `json:"stateForNetworkPeering"`
+
+	// ConnectionString is the connection string for the Data API service.
+	// If the Data API is not enabled, this is an empty string.
+	ConnectionString string `json:"connectionString"`
+}

--- a/internal/api/data_api/state.go
+++ b/internal/api/data_api/state.go
@@ -1,0 +1,21 @@
+package data_api
+
+type State string
+
+const (
+	Enabled     State = "enabled"
+	Disabled    State = "disabled"
+	Enabling    State = "enabling"
+	Disabling   State = "disabling"
+	Configuring State = "configuring"
+)
+
+// IsFinalState checks whether the Data API or its network peering has finished transitioning and reached a final state
+func IsFinalState(state State) bool {
+	switch state {
+	case Enabled, Disabled:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/datasources/data_api.go
+++ b/internal/datasources/data_api.go
@@ -1,0 +1,109 @@
+package datasources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/data_api"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = (*DataApi)(nil)
+	_ datasource.DataSourceWithConfigure = (*DataApi)(nil)
+)
+
+// DataApi is the Data API status data source implementation.
+type DataApi struct {
+	*providerschema.Data
+}
+
+// NewDataApi is a helper function to simplify the provider implementation.
+func NewDataApi() datasource.DataSource {
+	return &DataApi{}
+}
+
+// Metadata returns the Data API status data source type name.
+func (d *DataApi) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_data_api"
+}
+
+func (d *DataApi) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = DataApiSchema()
+}
+
+// Read refreshes the Terraform state with the latest Data API and network peering status.
+func (d *DataApi) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state providerschema.DataApi
+	diags := req.Config.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var (
+		organizationId = state.OrganizationId.ValueString()
+		projectId      = state.ProjectId.ValueString()
+		clusterId      = state.ClusterId.ValueString()
+	)
+
+	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/dataAPI", d.HostURL, organizationId, projectId, clusterId)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := d.ClientV1.ExecuteWithRetry(
+		ctx,
+		cfg,
+		nil,
+		d.Token,
+		nil,
+	)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Capella Data API Status",
+			"Could not read Data API status in cluster "+state.ClusterId.String()+": "+api.ParseError(err),
+		)
+		return
+	}
+
+	statusResp := data_api.GetDataApiStatusResponse{}
+	err = json.Unmarshal(response.Body, &statusResp)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Capella Data API Status",
+			"Could not read Data API status in cluster, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	refreshedState := providerschema.NewDataApi(organizationId, projectId, clusterId, &statusResp)
+
+	// Set state
+	diags = resp.State.Set(ctx, refreshedState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (d *DataApi) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	data, ok := req.ProviderData.(*providerschema.Data)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *providerschema.Data, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.Data = data
+}

--- a/internal/datasources/data_api_schema.go
+++ b/internal/datasources/data_api_schema.go
@@ -1,0 +1,28 @@
+package datasources
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+
+	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+var dataApiBuilder = capellaschema.NewSchemaBuilder("dataApi")
+
+// DataApiSchema returns the schema for the DataApi data source.
+func DataApiSchema() schema.Schema {
+	attrs := make(map[string]schema.Attribute)
+
+	capellaschema.AddAttr(attrs, "organization_id", dataApiBuilder, requiredUUIDString())
+	capellaschema.AddAttr(attrs, "project_id", dataApiBuilder, requiredUUIDString())
+	capellaschema.AddAttr(attrs, "cluster_id", dataApiBuilder, requiredUUIDString())
+	capellaschema.AddAttr(attrs, "enable_data_api", dataApiBuilder, computedBool())
+	capellaschema.AddAttr(attrs, "enable_network_peering", dataApiBuilder, computedBool())
+	capellaschema.AddAttr(attrs, "state_for_data_api", dataApiBuilder, computedString())
+	capellaschema.AddAttr(attrs, "state_for_network_peering", dataApiBuilder, computedString())
+	capellaschema.AddAttr(attrs, "connection_string", dataApiBuilder, computedString())
+
+	return schema.Schema{
+		MarkdownDescription: "The data source to retrieve the Data API and network peering status for an operational cluster.",
+		Attributes:          attrs,
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -335,5 +335,6 @@ func (p *capellaProvider) Resources(_ context.Context) []func() resource.Resourc
 		resources.NewAppEndpointLoggingConfig,
 		resources.NewAppEndpointResync,
 		resources.NewClusterDeletionProtection,
+		resources.NewDataApi,
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -287,6 +287,7 @@ func (p *capellaProvider) DataSources(_ context.Context) []func() datasource.Dat
 		datasources.NewSnapshotBackupSchedule,
 		datasources.NewAppEndpointLoggingConfig,
 		datasources.NewAppServiceLogStreaming,
+		datasources.NewDataApi,
 	}
 }
 

--- a/internal/resources/data_api.go
+++ b/internal/resources/data_api.go
@@ -1,0 +1,340 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/data_api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+var (
+	_ resource.Resource                   = (*DataApi)(nil)
+	_ resource.ResourceWithConfigure      = (*DataApi)(nil)
+	_ resource.ResourceWithImportState    = (*DataApi)(nil)
+	_ resource.ResourceWithValidateConfig = (*DataApi)(nil)
+)
+
+const errorMessageWhileDataApiUpdate = "There is an error during the Data API configuration update. Please check in Capella to see if any" +
+	" hanging resources have been created, unexpected error: "
+
+const errorMessageAfterDataApiUpdate = "Data API configuration update has been processed, but encountered an error while checking the current" +
+	" state of the Data API. Please run `terraform plan` after 1-2 minutes to know the" +
+	" current state. Additionally, run `terraform apply --refresh-only` to update" +
+	" the state from remote, unexpected error: "
+
+// DataApi is the Data API configuration resource implementation.
+type DataApi struct {
+	*providerschema.Data
+}
+
+func NewDataApi() resource.Resource {
+	return &DataApi{}
+}
+
+// Metadata returns the Data API configuration resource type name.
+func (d *DataApi) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_data_api"
+}
+
+// Schema defines the schema for the Data API configuration resource.
+func (d *DataApi) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = DataApiSchema()
+}
+
+// ValidateConfig rejects enabling network peering while the Data API is disabled, as the Capella API does
+// not allow this combination.
+func (d *DataApi) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config providerschema.DataApi
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Defer validation until Terraform resolves expressions that determine these attribute values.
+	if config.EnableDataApi.IsNull() || config.EnableDataApi.IsUnknown() ||
+		config.EnableNetworkPeering.IsNull() || config.EnableNetworkPeering.IsUnknown() {
+		return
+	}
+
+	if !config.EnableDataApi.ValueBool() && config.EnableNetworkPeering.ValueBool() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("enable_network_peering"),
+			"Invalid Data API Configuration",
+			"Network peering cannot be enabled while the Data API is disabled. "+
+				"Set enable_data_api to true to enable network peering.",
+		)
+	}
+}
+
+// Configure adds the provider configured client to the Data API configuration resource.
+func (d *DataApi) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	data, ok := req.ProviderData.(*providerschema.Data)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *ProviderSourceData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.Data = data
+}
+
+// Create updates a clusters data API configuration and adds it to the state.
+func (d *DataApi) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan providerschema.DataApi
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var (
+		organizationId = plan.OrganizationId.ValueString()
+		projectId      = plan.ProjectId.ValueString()
+		clusterId      = plan.ClusterId.ValueString()
+	)
+
+	err := d.updateDataApi(ctx, plan)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating Data API configuration",
+			errorMessageWhileDataApiUpdate+api.ParseError(err),
+		)
+		return
+	}
+
+	refreshedState, err := d.checkDataApiStatus(ctx, organizationId, projectId, clusterId)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating Data API configuration",
+			errorMessageAfterDataApiUpdate+api.ParseError(err),
+		)
+		return
+	}
+
+	// Set state to fully populated data
+	diags = resp.State.Set(ctx, refreshedState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read retrieves the Data API and network peering status.
+func (d *DataApi) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state providerschema.DataApi
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	IDs, err := state.Validate()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Capella Data API Configuration",
+			"Could not read Capella Data API configuration: "+err.Error(),
+		)
+		return
+	}
+
+	var (
+		organizationId = IDs[providerschema.OrganizationId]
+		projectId      = IDs[providerschema.ProjectId]
+		clusterId      = IDs[providerschema.ClusterId]
+	)
+
+	statusResp, err := d.getDataApiStatus(ctx, organizationId, projectId, clusterId)
+	if err != nil {
+		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
+		if resourceNotFound {
+			tflog.Info(ctx, "cluster not found, removing resource from state file")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading Capella Data API Configuration",
+			"Could not read Capella Data API configuration: "+errString,
+		)
+		return
+	}
+
+	refreshedState := providerschema.NewDataApi(organizationId, projectId, clusterId, statusResp)
+
+	// Set refreshed state
+	diags = resp.State.Set(ctx, refreshedState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates the Data API configuration.
+func (d *DataApi) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan providerschema.DataApi
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var (
+		organizationId = plan.OrganizationId.ValueString()
+		projectId      = plan.ProjectId.ValueString()
+		clusterId      = plan.ClusterId.ValueString()
+	)
+
+	err := d.updateDataApi(ctx, plan)
+	if err != nil {
+		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
+		if resourceNotFound {
+			tflog.Info(ctx, "cluster not found, removing resource from state file")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error updating Data API configuration",
+			errorMessageWhileDataApiUpdate+errString,
+		)
+		return
+	}
+
+	refreshedState, err := d.checkDataApiStatus(ctx, organizationId, projectId, clusterId)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating Data API configuration",
+			errorMessageAfterDataApiUpdate+api.ParseError(err),
+		)
+		return
+	}
+
+	// Set state to fully populated data
+	diags = resp.State.Set(ctx, refreshedState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete is a no-op operation because the Data API configuration cannot be deleted. The Data API and network peering are left in their current state on the cluster.
+func (d *DataApi) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {
+	// No-op operation.
+}
+
+func (d *DataApi) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("cluster_id"), req, resp)
+}
+
+// updateDataApi calls the update endpoint, which asynchronously enables or disables the Data API and network peering on the cluster.
+func (d *DataApi) updateDataApi(ctx context.Context, plan providerschema.DataApi) error {
+	updateRequest := data_api.UpdateDataApiRequest{
+		EnableDataApi:        plan.EnableDataApi.ValueBool(),
+		EnableNetworkPeering: plan.EnableNetworkPeering.ValueBool(),
+	}
+
+	url := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/dataAPI",
+		d.HostURL,
+		plan.OrganizationId.ValueString(),
+		plan.ProjectId.ValueString(),
+		plan.ClusterId.ValueString(),
+	)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodPut, SuccessStatus: http.StatusAccepted}
+	_, err := d.ClientV1.ExecuteWithRetry(
+		ctx,
+		cfg,
+		updateRequest,
+		d.Token,
+		nil,
+	)
+
+	return err
+}
+
+// checkDataApiStatus polls the Data API status until both the Data API and its network peering reach a final state,
+// then returns the refreshed resource state.
+// Polls up to 30 minutes, with a 15-second interval between polls to allow for the asynchronous operation to complete.
+func (d *DataApi) checkDataApiStatus(ctx context.Context, organizationId, projectId, clusterId string) (*providerschema.DataApi, error) {
+	const timeout = time.Minute * 30
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		statusResp, err := d.getDataApiStatus(ctx, organizationId, projectId, clusterId)
+		switch {
+		case err != nil:
+			if resourceNotFound, _ := api.CheckResourceNotFoundError(err); resourceNotFound {
+				return nil, err
+			}
+			tflog.Info(ctx, "retrying after error polling Data API status", map[string]interface{}{"error": err.Error()})
+		case data_api.IsFinalState(statusResp.State) && data_api.IsFinalState(statusResp.StateForNetworkPeering):
+			tflog.Debug(ctx, "data api has reached a final state", map[string]interface{}{
+				"state_for_data_api":        statusResp.State,
+				"state_for_network_peering": statusResp.StateForNetworkPeering,
+			})
+			return providerschema.NewDataApi(organizationId, projectId, clusterId, statusResp), nil
+		default:
+			tflog.Info(ctx, "waiting for Data API to finish transitioning to a final state", map[string]interface{}{
+				"state_for_data_api":        statusResp.State,
+				"state_for_network_peering": statusResp.StateForNetworkPeering,
+			})
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out while waiting for data API state to finish transitioning to a final state: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (d *DataApi) getDataApiStatus(ctx context.Context, organizationId, projectId, clusterId string) (*data_api.GetDataApiStatusResponse, error) {
+	url := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/dataAPI",
+		d.HostURL,
+		organizationId,
+		projectId,
+		clusterId,
+	)
+
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := d.ClientV1.ExecuteWithRetry(
+		ctx,
+		cfg,
+		nil,
+		d.Token,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errors.ErrExecutingRequest, err)
+	}
+
+	statusResp := data_api.GetDataApiStatusResponse{}
+	err = json.Unmarshal(response.Body, &statusResp)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errors.ErrUnmarshallingResponse, err)
+	}
+
+	return &statusResp, nil
+}

--- a/internal/resources/data_api_schema.go
+++ b/internal/resources/data_api_schema.go
@@ -1,0 +1,27 @@
+package resources
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+
+	capellaschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+var dataApiBuilder = capellaschema.NewSchemaBuilder("dataApi")
+
+func DataApiSchema() schema.Schema {
+	attrs := make(map[string]schema.Attribute)
+
+	capellaschema.AddAttr(attrs, "organization_id", dataApiBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "project_id", dataApiBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "cluster_id", dataApiBuilder, requiredUUIDStringAttribute())
+	capellaschema.AddAttr(attrs, "enable_data_api", dataApiBuilder, boolAttribute(required))
+	capellaschema.AddAttr(attrs, "enable_network_peering", dataApiBuilder, boolDefaultAttribute(false, optional, computed))
+	capellaschema.AddAttr(attrs, "state_for_data_api", dataApiBuilder, stringAttribute([]string{computed}))
+	capellaschema.AddAttr(attrs, "state_for_network_peering", dataApiBuilder, stringAttribute([]string{computed}))
+	capellaschema.AddAttr(attrs, "connection_string", dataApiBuilder, stringAttribute([]string{computed, useStateForUnknown}))
+
+	return schema.Schema{
+		MarkdownDescription: "This resource allows you to enable or disable the Data API and network peering for an operational cluster.",
+		Attributes:          attrs,
+	}
+}

--- a/internal/resources/data_api_schema.go
+++ b/internal/resources/data_api_schema.go
@@ -18,7 +18,7 @@ func DataApiSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "enable_network_peering", dataApiBuilder, boolDefaultAttribute(false, optional, computed))
 	capellaschema.AddAttr(attrs, "state_for_data_api", dataApiBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "state_for_network_peering", dataApiBuilder, stringAttribute([]string{computed}))
-	capellaschema.AddAttr(attrs, "connection_string", dataApiBuilder, stringAttribute([]string{computed, useStateForUnknown}))
+	capellaschema.AddAttr(attrs, "connection_string", dataApiBuilder, stringAttribute([]string{computed}))
 
 	return schema.Schema{
 		MarkdownDescription: "This resource allows you to enable or disable the Data API and network peering for an operational cluster.",

--- a/internal/schema/data_api.go
+++ b/internal/schema/data_api.go
@@ -1,0 +1,53 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/data_api"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+)
+
+// DataApi maps the couchbase-capella_data_api resource and data source schema data.
+type DataApi struct {
+	OrganizationId         types.String `tfsdk:"organization_id"`
+	ProjectId              types.String `tfsdk:"project_id"`
+	ClusterId              types.String `tfsdk:"cluster_id"`
+	EnableDataApi          types.Bool   `tfsdk:"enable_data_api"`
+	EnableNetworkPeering   types.Bool   `tfsdk:"enable_network_peering"`
+	StateForDataApi        types.String `tfsdk:"state_for_data_api"`
+	StateForNetworkPeering types.String `tfsdk:"state_for_network_peering"`
+	ConnectionString       types.String `tfsdk:"connection_string"`
+}
+
+// NewDataApi morphs the Data API status response into the schema struct.
+func NewDataApi(organizationId, projectId, clusterId string, status *data_api.GetDataApiStatusResponse) *DataApi {
+	return &DataApi{
+		OrganizationId:         types.StringValue(organizationId),
+		ProjectId:              types.StringValue(projectId),
+		ClusterId:              types.StringValue(clusterId),
+		EnableDataApi:          types.BoolValue(status.Enabled),
+		EnableNetworkPeering:   types.BoolValue(status.EnabledForNetworkPeering),
+		StateForDataApi:        types.StringValue(string(status.State)),
+		StateForNetworkPeering: types.StringValue(string(status.StateForNetworkPeering)),
+		ConnectionString:       types.StringValue(status.ConnectionString),
+	}
+}
+
+// Validate is used to verify that IDs have been properly imported.
+func (d *DataApi) Validate() (map[Attr]string, error) {
+	state := map[Attr]basetypes.StringValue{
+		OrganizationId: d.OrganizationId,
+		ProjectId:      d.ProjectId,
+		ClusterId:      d.ClusterId,
+	}
+
+	IDs, err := validateSchemaState(state, ClusterId)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errors.ErrValidatingResource, err)
+	}
+
+	return IDs, nil
+}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-136695

## Description

- Merge the feature branch for Data API in to main

All PRs that have been merged in to feature/AV-136695-data-api-config-support have been approved separately so this should be a no-op approval.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

All PRs have been tested separately before merging in to the feature branch.

```

=== RUN   TestAccDataApiResource
--- PASS: TestAccDataApiResource (1414.75s)
=== RUN   TestAccDataApiResourceNetworkPeeringWithoutDataApi
=== PAUSE TestAccDataApiResourceNetworkPeeringWithoutDataApi
=== RUN   TestAccDataApiResourceInvalidUUIDs
=== RUN   TestAccDataApiResourceInvalidUUIDs/organization_id
=== PAUSE TestAccDataApiResourceInvalidUUIDs/organization_id
=== RUN   TestAccDataApiResourceInvalidUUIDs/project_id
=== PAUSE TestAccDataApiResourceInvalidUUIDs/project_id
=== RUN   TestAccDataApiResourceInvalidUUIDs/cluster_id
=== PAUSE TestAccDataApiResourceInvalidUUIDs/cluster_id
=== CONT  TestAccDataApiResourceInvalidUUIDs/organization_id
=== CONT  TestAccDataApiResourceInvalidUUIDs/cluster_id
=== CONT  TestAccDataApiResourceInvalidUUIDs/project_id
--- PASS: TestAccDataApiResourceInvalidUUIDs (0.00s)
    --- PASS: TestAccDataApiResourceInvalidUUIDs/cluster_id (0.21s)
    --- PASS: TestAccDataApiResourceInvalidUUIDs/organization_id (0.22s)
    --- PASS: TestAccDataApiResourceInvalidUUIDs/project_id (0.22s)
=== RUN   TestAccDatasourceDataApiInvalidUUIDs
=== RUN   TestAccDatasourceDataApiInvalidUUIDs/organization_id
=== PAUSE TestAccDatasourceDataApiInvalidUUIDs/organization_id
=== RUN   TestAccDatasourceDataApiInvalidUUIDs/project_id
=== PAUSE TestAccDatasourceDataApiInvalidUUIDs/project_id
=== RUN   TestAccDatasourceDataApiInvalidUUIDs/cluster_id
=== PAUSE TestAccDatasourceDataApiInvalidUUIDs/cluster_id
=== CONT  TestAccDatasourceDataApiInvalidUUIDs/organization_id
=== CONT  TestAccDatasourceDataApiInvalidUUIDs/cluster_id
=== CONT  TestAccDatasourceDataApiInvalidUUIDs/project_id
--- PASS: TestAccDatasourceDataApiInvalidUUIDs (0.00s)
    --- PASS: TestAccDatasourceDataApiInvalidUUIDs/project_id (0.22s)
    --- PASS: TestAccDatasourceDataApiInvalidUUIDs/cluster_id (0.23s)
    --- PASS: TestAccDatasourceDataApiInvalidUUIDs/organization_id (0.24s)

```

</details>

## Further comments