### PR TITLE
[AV-138146] Return known computed states on App Service Log Streaming create error path

### DIFF
--- a/internal/resources/app_service_log_streaming.go
+++ b/internal/resources/app_service_log_streaming.go
@@ -134,6 +134,14 @@ func (r *AppServiceLogStreaming) Create(ctx context.Context, req resource.Create
 		return
 	}
 
+	// config_state and streaming_state are computed, so they are unknown in the
+	// plan. Give them known (null) values before persisting this interim state:
+	// if the wait or refresh below fails and we return early, Terraform must not
+	// find unknown values in the result, otherwise it raises a spurious "invalid
+	// result object" / "bug in the provider" error that masks the real cause.
+	plan.ConfigState = types.StringNull()
+	plan.StreamingState = types.StringNull()
+
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION

<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-138146

## Description

Fixes a provider bug where creating a couchbase-capella_app_service_log_streaming resource could fail with two misleading "Provider returned invalid result object after apply" errors — the kind Terraform attributes to "a bug in the provider" — whenever the post-create enable/refresh step failed.

**Problem**
When the create POST succeeds (HTTP 202) but the subsequent waitForLogStreamingState (or refreshLogStreaming) fails, the apply aborts with three errors instead of one:

```
Error: Provider returned invalid result object after apply
... unknown value for ...config_state. All values must be known after apply,
so this is always a bug in the provider ...

Error: Provider returned invalid result object after apply
... unknown value for ...streaming_state ...

Error: Error waiting for Log Streaming to be enabled
... <the real, actionable error>
```
Only the third is real; the first two are noise that points the finger at the provider and prompts false bug reports.

**Root cause**
config_state and streaming_state are computed, so they're unknown in the plan. Create persisted the plan as interim state while both were still unknown, then returned early on the wait/refresh error without ever assigning them known values — leaving unknowns in the applied result, which Terraform rejects.

**Fix**
Set both computed attributes to known null values before persisting the interim state, so an early return on the error path never leaves unknowns:

```
plan.ConfigState = types.StringNull()
plan.StreamingState = types.StringNull()
diags = resp.State.Set(ctx, &plan)
```
On the success path, refreshLogStreaming still overwrites both with the real remote values, so a successful apply is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments