### PR TITLE
[AV-138193] Lower app endpoint CRUD test concurrency from 3 to 2

### DIFF
--- a/acceptance_tests/app_endpoint_environment.go
+++ b/acceptance_tests/app_endpoint_environment.go
@@ -31,7 +31,12 @@ var appEndpointEnvironmentOnce struct {
 // ("internal server error", code 10000) on update/list. Bounding concurrency
 // keeps the suite mostly parallel while avoiding that contention. Tune if the
 // 500s persist (lower) or the suite is too slow (raise).
-const appEndpointCRUDConcurrency = 3
+//
+// Lowered from 3 to 2: at 3, a teardown DELETE (which is held under the same
+// slot as the test body, so it counts toward this bound) still occasionally hit
+// the transient 500 during post-test destroy, failing the run with dangling
+// resources.
+const appEndpointCRUDConcurrency = 2
 
 var appEndpointCRUDSem = make(chan struct{}, appEndpointCRUDConcurrency)
 


### PR DESCRIPTION

<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-138193

## Description

Every app_endpoint resource test shares a single app service, and each endpoint mutation forces a Sync Gateway reconfiguration. At a concurrency of 3, a teardown DELETE (held under the same CRUD slot as the test body) still occasionally hit a transient HTTP 500 during post-test destroy, failing the run and leaving dangling resources. Lowering the bound to 2 reduces the contention that triggers those transient 500s.

**Summary**
Reduces flaky failures in the app_endpoint acceptance suite by lowering appEndpointCRUDConcurrency from 3 to 2, cutting the contention that triggers transient server-side HTTP 500s on the shared App Service.
**Background**
Every app_endpoint resource test shares a single App Service, and each endpoint create/update/delete forces a Sync Gateway reconfiguration. Running too many of these concurrently makes the control plane return transient code 10000 / HTTP 500 ("internal server error"). A semaphore already bounds concurrent endpoint CRUD to mitigate this — but the bound was set one notch too high to be reliable.
**What was happening**
The CRUD slot is held across the entire resource.Test call, including the framework's post-test destroy. At a concurrency of 3, up to three Sync Gateway reconfigs run at once, and a teardown DELETE still occasionally hit a transient 500, failing the run and leaving dangling resources. Example:
```
Error running post-test destroy, there may be dangling resources: exit status 1
Error: Error deleting App Endpoint
Could not delete App Endpoint tf_acc_ep_nocors_...: {"...","code":10000,"httpStatusCode":500}
```
The same contention also surfaced as a create-time 412 "already exists" when a transient 5xx caused a create POST to be retried after it had already committed.
**Change**
```
-const appEndpointCRUDConcurrency = 3
+const appEndpointCRUDConcurrency = 2
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments