### PR TITLE
[AV-138151] Bound API client retries with exponential backoff and jitter

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -7,6 +7,7 @@ import (
 	goer "errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"time"
@@ -56,6 +57,15 @@ type EndpointCfg struct {
 
 // defaultWaitAttempt re-attempt http request after 2 seconds.
 const defaultWaitAttempt = time.Second * 2
+
+// maxRetryAttempts caps the number of retries for retryable errors
+// (rate limit, service unavailable, gateway timeout) so that a
+// persistently unavailable endpoint fails fast instead of hanging
+// for the full context timeout (10 minutes).
+const maxRetryAttempts = 5
+
+// maxBackoff caps exponential backoff to prevent unbounded growth.
+const maxBackoff = 30 * time.Second
 
 // ExecuteWithRetry is used to construct and execute a HTTP request with retry.
 // It then returns the response.
@@ -182,6 +192,7 @@ func exec(
 		err      error
 		backOff  time.Duration
 		response *Response
+		attempts int
 	)
 
 	const timeout = time.Minute * 10
@@ -190,26 +201,56 @@ func exec(
 	ctx, cancel = context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	start := time.Now()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("timed out executing request against api: %w", ctx.Err())
 		case <-timer.C:
 			response, backOff, err = fn()
-			switch {
-			case err == nil:
+			if err == nil {
 				return response, nil
-			case goer.Is(err, errors.ErrRatelimit):
-			case goer.Is(err, errors.ErrServiceUnavailable):
-			case !goer.Is(err, errors.ErrGatewayTimeout):
+			}
+
+			if !isRetryable(err) {
 				return response, err
+			}
+
+			if attempts >= maxRetryAttempts {
+				return nil, &RetriesExhaustedError{
+					Original: err,
+					Attempts: attempts + 1,
+					Elapsed:  time.Since(start),
+				}
 			}
 
 			if backOff > 0 {
 				timer.Reset(backOff)
 			} else {
-				timer.Reset(waitOnReattempt)
+				timer.Reset(backoffWithJitter(attempts))
 			}
+			attempts++
 		}
 	}
+}
+
+// isRetryable reports whether err is a sentinel error that the exec loop should retry.
+func isRetryable(err error) bool {
+	return goer.Is(err, errors.ErrRatelimit) ||
+		goer.Is(err, errors.ErrServiceUnavailable) ||
+		goer.Is(err, errors.ErrGatewayTimeout)
+}
+
+// backoffWithJitter computes an exponential backoff duration with equal jitter.
+// The base is defaultWaitAttempt (2s), doubling each attempt and capped at
+// maxBackoff (30s). Jitter is applied as raw/2 + rand(0, raw/2) so the
+// result is guaranteed to be between raw/2 and raw.
+func backoffWithJitter(attempt int) time.Duration {
+	raw := defaultWaitAttempt * (1 << attempt)
+	if raw > maxBackoff {
+		raw = maxBackoff
+	}
+	// Equal jitter: raw/2 + rand(0, raw/2)
+	return raw/2 + time.Duration(rand.Int63n(int64(raw/2+1)))
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,229 @@
+package api
+
+import (
+	"context"
+	goer "errors"
+	"fmt"
+	"testing"
+	"time"
+
+	internalerrors "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExec_Success(t *testing.T) {
+	fn := func() (*Response, time.Duration, error) {
+		return &Response{}, 0, nil
+	}
+	resp, err := exec(context.Background(), fn, defaultWaitAttempt)
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestExec_NonRetryableError(t *testing.T) {
+	fn := func() (*Response, time.Duration, error) {
+		return nil, 0, assert.AnError
+	}
+	_, err := exec(context.Background(), fn, defaultWaitAttempt)
+	require.Error(t, err)
+	assert.True(t, goer.Is(err, assert.AnError))
+}
+
+func TestExec_AttemptCapEnforced(t *testing.T) {
+	// Use short Retry-After values so the test runs quickly.
+	// The exponential-backoff path is exercised by TestBackoffWithJitter_*.
+	shortBackoff := 1 * time.Millisecond
+
+	tests := []struct {
+		name           string
+		retryableErr   error
+		backOff        time.Duration
+		expectAttempts int
+	}{
+		{
+			name:           "503 service unavailable",
+			retryableErr:   internalerrors.ErrServiceUnavailable,
+			backOff:        shortBackoff,
+			expectAttempts: maxRetryAttempts + 1,
+		},
+		{
+			name:           "504 gateway timeout",
+			retryableErr:   internalerrors.ErrGatewayTimeout,
+			backOff:        shortBackoff,
+			expectAttempts: maxRetryAttempts + 1,
+		},
+		{
+			name:           "429 rate limit with Retry-After",
+			retryableErr:   internalerrors.ErrRatelimit,
+			backOff:        shortBackoff,
+			expectAttempts: maxRetryAttempts + 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var callCount int
+			fn := func() (*Response, time.Duration, error) {
+				callCount++
+				return nil, tt.backOff, tt.retryableErr
+			}
+			_, err := exec(context.Background(), fn, defaultWaitAttempt)
+			require.Error(t, err)
+
+			assert.Equal(t, tt.expectAttempts, callCount, "should make initial call + maxRetryAttempts retries")
+
+			var retryErr *RetriesExhaustedError
+			require.True(t, goer.As(err, &retryErr), "error should be *RetriesExhaustedError")
+			assert.Equal(t, tt.expectAttempts, retryErr.Attempts)
+			assert.True(t, goer.Is(retryErr, tt.retryableErr), "RetriesExhaustedError should wrap the original sentinel")
+			assert.Greater(t, retryErr.Elapsed, time.Duration(0), "elapsed time should be recorded")
+		})
+	}
+}
+
+func TestExec_ExhaustionErrorIsTyped(t *testing.T) {
+	fn := func() (*Response, time.Duration, error) {
+		return nil, 1 * time.Millisecond, internalerrors.ErrServiceUnavailable
+	}
+	_, err := exec(context.Background(), fn, defaultWaitAttempt)
+
+	var retryErr *RetriesExhaustedError
+	require.True(t, goer.As(err, &retryErr))
+	assert.Contains(t, err.Error(), "request failed after")
+	assert.Contains(t, err.Error(), "attempts over")
+	assert.True(t, goer.Is(err, internalerrors.ErrServiceUnavailable),
+		"errors.Is should find the wrapped sentinel through Unwrap()")
+}
+
+func TestExec_RetryAfterHonored(t *testing.T) {
+	retryAfter := 10 * time.Millisecond
+	var callCount int
+	fn := func() (*Response, time.Duration, error) {
+		callCount++
+		return nil, retryAfter, internalerrors.ErrRatelimit
+	}
+
+	start := time.Now()
+	_, err := exec(context.Background(), fn, defaultWaitAttempt)
+	elapsed := time.Since(start)
+
+	// maxRetryAttempts retries × retryAfter = total wait time, plus overhead.
+	minExpected := time.Duration(maxRetryAttempts) * retryAfter
+	assert.GreaterOrEqual(t, elapsed, minExpected,
+		"total elapsed should be at least retryAfter × maxRetryAttempts")
+
+	var retryErr *RetriesExhaustedError
+	require.True(t, goer.As(err, &retryErr))
+	assert.Equal(t, maxRetryAttempts+1, callCount)
+}
+
+func TestExec_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	var callCount int
+	fn := func() (*Response, time.Duration, error) {
+		callCount++
+		// Return a retryable error so we stay in the loop, but with a long
+		// backoff that gives the context time to expire.
+		return nil, 200 * time.Millisecond, internalerrors.ErrServiceUnavailable
+	}
+
+	_, err := exec(ctx, fn, defaultWaitAttempt)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out executing request against api")
+	assert.Equal(t, 1, callCount, "only the initial call should fire before context expires")
+}
+
+func TestExec_MixedRetryableAndNonRetryable(t *testing.T) {
+	// A non-retryable error on the second call should stop retries immediately.
+	var callCount int
+	fn := func() (*Response, time.Duration, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return nil, 1 * time.Millisecond, internalerrors.ErrServiceUnavailable
+		default:
+			return nil, 0, fmt.Errorf("non-retryable failure")
+		}
+	}
+
+	_, err := exec(context.Background(), fn, defaultWaitAttempt)
+	require.Error(t, err)
+	assert.Equal(t, 2, callCount, "should stop after encountering a non-retryable error")
+	assert.False(t, goer.Is(err, internalerrors.ErrServiceUnavailable))
+	var retryErr *RetriesExhaustedError
+	assert.False(t, goer.As(err, &retryErr))
+}
+
+func TestBackoffWithJitter_Grows(t *testing.T) {
+	// Verify that backoff values are strictly increasing between attempts
+	// due to non-overlapping jitter ranges.
+	var previous time.Duration
+	for attempt := range maxRetryAttempts {
+		b := backoffWithJitter(attempt)
+		if attempt > 0 {
+			assert.Greater(t, b, previous,
+				"backoff attempt %d (%v) should be > attempt %d (%v)", attempt, b, attempt-1, previous)
+		}
+		previous = b
+	}
+}
+
+func TestBackoffWithJitter_Capped(t *testing.T) {
+	// At high attempt numbers the raw value is capped at maxBackoff.
+	b := backoffWithJitter(10) // 2 * 2^10 = 2048s, capped at 30s
+	assert.LessOrEqual(t, b, maxBackoff)
+	assert.GreaterOrEqual(t, b, maxBackoff/2)
+}
+
+func TestBackoffWithJitter_Jittered(t *testing.T) {
+	// Run multiple times for the same attempt and verify the values differ
+	// (proof of jitter), but stay within the expected range [raw/2, raw].
+	const attempt = 2 // raw = 2 * 2^2 = 8s, range [4s, 8s]
+	const iterations = 10
+
+	var values []time.Duration
+	for range iterations {
+		values = append(values, backoffWithJitter(attempt))
+	}
+
+	allSame := true
+	for i := 1; i < len(values); i++ {
+		if values[i] != values[0] {
+			allSame = false
+			break
+		}
+	}
+	assert.False(t, allSame, "jitter should produce varying values across calls")
+
+	raw := defaultWaitAttempt * (1 << attempt)
+	for _, v := range values {
+		assert.GreaterOrEqual(t, v, raw/2, "jittered value should be >= raw/2")
+		assert.LessOrEqual(t, v, raw, "jittered value should be <= raw")
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{"ErrRatelimit is retryable", internalerrors.ErrRatelimit, true},
+		{"ErrServiceUnavailable is retryable", internalerrors.ErrServiceUnavailable, true},
+		{"ErrGatewayTimeout is retryable", internalerrors.ErrGatewayTimeout, true},
+		{"ErrGatewayTimeoutForIndexDDL is NOT retryable", internalerrors.ErrGatewayTimeoutForIndexDDL, false},
+		{"wrapped ErrRatelimit is retryable", fmt.Errorf("wrap: %w", internalerrors.ErrRatelimit), true},
+		{"nil is not retryable", nil, false},
+		{"arbitrary error is not retryable", assert.AnError, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.retryable, isRetryable(tt.err))
+		})
+	}
+}

--- a/internal/api/error.go
+++ b/internal/api/error.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 // Error tracks the error structure received from Capella V4 APIs.
@@ -70,4 +71,23 @@ func CheckResourceNotFoundError(err error) (bool, string) {
 func IsForbiddenError(err error) bool {
 	var apiError *Error
 	return errors.As(err, &apiError) && apiError.HttpStatusCode == http.StatusForbidden
+}
+
+// RetriesExhaustedError is returned when all retry attempts have been exhausted
+// for a retryable error (rate limit, service unavailable, or gateway timeout).
+// It wraps the original sentinel error so callers can still inspect the cause
+// with errors.Is.
+type RetriesExhaustedError struct {
+	Original error
+	Attempts int
+	Elapsed  time.Duration
+}
+
+func (e *RetriesExhaustedError) Error() string {
+	return fmt.Sprintf("request failed after %d attempts over %s: %s",
+		e.Attempts, e.Elapsed.Truncate(time.Millisecond), e.Original.Error())
+}
+
+func (e *RetriesExhaustedError) Unwrap() error {
+	return e.Original
 }


### PR DESCRIPTION
## Jira

* [AV-138151](https://couchbasecloud.atlassian.net/browse/AV-138151)

## Description

The shared API client's `exec` retry loop (`internal/api/client.go`) had two problems for 503 and 504 responses:

1. **No attempt cap** — retries were only bounded by the 10-minute context timeout, so a persistently-down endpoint was retried ~300 times over the full 10 minutes before returning a generic deadline error.
2. **Fixed 2-second wait with no backoff or jitter** — every retry waited exactly 2 seconds, hammering a struggling backend at a flat cadence. Only 429 (rate-limit) had proper backoff via its mandatory `Retry-After` header.

**Fix:**

- Added `maxRetryAttempts = 5` to cap retries for 503, 504, and 429.
- Introduced exponential backoff with equal jitter (`2s → 4s → 8s → 16s → 30s`), so a call fails in ~1 minute instead of ~10 minutes.
- `Retry-After` headers (from 429 or 503/504) are still honored and take precedence over computed backoff.
- On exhaustion, returns a typed `*RetriesExhaustedError` wrapping the original sentinel, making it inspectable via `errors.Is` and `errors.As`.

> **Fix confidence:** 95%
> **Reviewer action required:** The ticket flags whether non-idempotent POST should be retried on 5xx at all. The current logic retries 503/504 for all HTTP methods (including POST). This PR does not change that; please review and decide whether a separate follow-up should make retries conditional on method/idempotency.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).

## Manual Testing Approach

### How was this change tested and do you have evidence?

- [x] Unit tested

### Testing

<details open>
  <summary>Testing</summary>

Added 11 table-driven unit tests in `internal/api/client_test.go` asserting:

- (a) Attempt cap is enforced for 503, 504, and 429.
- (b) Exponential backoff grows monotonically between attempts; is capped at 30s.
- (c) Jitter produces varying values across runs within the expected bounds.
- (d) `Retry-After` is honored when the function returns a non-zero duration.
- (e) Exhaustion returns a typed `*RetriesExhaustedError` wrapping the original sentinel.
- (f) Non-retryable errors stop the loop immediately.
- (g) Context cancellation works correctly.
- (h) `isRetryable` correctly classifies sentinel errors.

All tests pass; `go vet`, `goimports`, `make fmt`, and `go build` all clean.
Acceptance tests compile-checked with `go test -c -o /dev/null ./acceptance_tests/`.

</details>

## Further comments

Generated by the tf-ticket-autofix droid. Draft — a human reviewer makes the merge decision.


[AV-138151]: https://couchbasecloud.atlassian.net/browse/AV-138151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ