### PR TITLE
[AV-132638] Fix invalid HCL syntax in query index example files

### DIFF
--- a/examples/data-sources/couchbase-capella_query_indexes/data-source.tf
+++ b/examples/data-sources/couchbase-capella_query_indexes/data-source.tf
@@ -1,7 +1,7 @@
 data "couchbase-capella_query_indexes" "list" {
-  organization_id = <organization_id>
-  project_id      = <project_id>
-  cluster_id      = <cluster_id>
+  organization_id = "<organization_id>"
+  project_id      = "<project_id>"
+  cluster_id      = "<cluster_id>"
   bucket_name     = "api"
   scope_name      = "metrics"
   collection_name = "memory"

--- a/examples/resources/couchbase-capella_query_indexes/resource.tf
+++ b/examples/resources/couchbase-capella_query_indexes/resource.tf
@@ -1,5 +1,7 @@
-# Example json file -
-  {
+/*
+Example indexes.json template file for deferred index builds:
+
+{
   "resource": {
     "couchbase-capella_indexes": {
       "idx1": {
@@ -8,7 +10,7 @@
         "cluster_id": "ffffffff-aaaa-1414-eeee-000000000000",
         "bucket_name": "api",
         "scope_name": "metrics",
-        "scope_name": "memory",
+        "collection_name": "memory",
         "index_name": "idx1",
         "index_keys": [
           "field1"
@@ -17,24 +19,25 @@
           "defer_build": true
         }
       },
-    "idx2": {
-          "organization_id": "ffffffff-aaaa-1414-eeee-000000000000",
-          "project_id": "ffffffff-aaaa-1414-eeee-000000000000",
-          "cluster_id": "ffffffff-aaaa-1414-eeee-000000000000",
-          "bucket_name": "api",
-          "scope_name": "metrics",
-          "scope_name": "memory",
-          "index_name": "idx2",
-          "index_keys": [
-            "field2"
-          ],
-          "with": {
-            "defer_build": true
-             }
-          }
+      "idx2": {
+        "organization_id": "ffffffff-aaaa-1414-eeee-000000000000",
+        "project_id": "ffffffff-aaaa-1414-eeee-000000000000",
+        "cluster_id": "ffffffff-aaaa-1414-eeee-000000000000",
+        "bucket_name": "api",
+        "scope_name": "metrics",
+        "collection_name": "memory",
+        "index_name": "idx2",
+        "index_keys": [
+          "field2"
+        ],
+        "with": {
+          "defer_build": true
         }
       }
     }
+  }
+}
+*/
 
 # Example for deferred index build -
 locals {


### PR DESCRIPTION
## Jira

* [AV-132638](https://couchbasecloud.atlassian.net/browse/AV-132638)

## Description

Two query index example files under `examples/` contain invalid HCL syntax that prevents users from running `terraform fmt`, `terraform validate`, or using the snippets directly.

**Root cause:** The `data-source.tf` file used raw angle-bracket placeholders (`<organization_id>`) instead of valid HCL string values. The `resource.tf` file opened with a raw JSON example block which is not valid HCL in a `.tf` file.

**Fix:**
- `data-source.tf`: Quote placeholder values as HCL strings (`"<organization_id>"`)
- `resource.tf`: Wrap the raw JSON example in a `/* ... */` comment block so it remains as documentation without breaking Terraform parsing. Also fixed a bug in the example JSON where `scope_name` was duplicated instead of having a `collection_name` field.

> **Fix confidence:** 100%
>
> Both issues are straightforward HCL syntax fixes. Files pass `terraform fmt -check`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).

## Manual Testing Approach

### How was this change tested and do you have evidence?

- [x] Manually tested

### Testing

<details open>
  <summary>Testing</summary>

Both files pass `terraform fmt -check` (exit code 0):

```
$ terraform fmt -check examples/data-sources/couchbase-capella_query_indexes/data-source.tf examples/resources/couchbase-capella_query_indexes/resource.tf
# exit: 0
```

Full provider validation passes:
- `make fmt` — clean
- `make vet` — clean
- `make test` — all unit tests pass
- `go test -c -o /dev/null ./acceptance_tests/` — compiles successfully
- `go build` — binary builds successfully

No Go code changes; the fix is confined to `.tf` example files only.

</details>

## Further comments

Generated by the tf-ticket-autofix droid. Draft — a human reviewer makes the merge decision.

The non-deferred index example in `resource.tf` (lines after the comment block) was already valid HCL and is unchanged.


[AV-132638]: https://couchbasecloud.atlassian.net/browse/AV-132638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ