### PR TITLE
[AV-129803] Use paginated API for getAllowedCIDR to prevent silent state removal

### DIFF
--- a/internal/resources/app_service_cidr.go
+++ b/internal/resources/app_service_cidr.go
@@ -168,24 +168,13 @@ func (a *AppServiceCidr) getAllowedCIDR(ctx context.Context, organizationId, pro
 		appServiceId,
 	)
 	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
-	response, err := a.ClientV1.ExecuteWithRetry(
-		ctx,
-		cfg,
-		nil,
-		a.Token,
-		nil,
-	)
+
+	allowLists, err := api.GetPaginated[[]api.AppServiceAllowedCIDRResponse](ctx, a.ClientV1, a.Token, cfg, api.SortById)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", errors.ErrExecutingRequest, err)
 	}
 
-	allowListResp := api.ListAppServiceAllowedCIDRResponse{}
-	err = json.Unmarshal(response.Body, &allowListResp)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errors.ErrUnmarshallingResponse, err)
-	}
-
-	for _, allowlist := range allowListResp.Data {
+	for _, allowlist := range allowLists {
 		if allowlist.Id == allowListId {
 			// Found the allow list with the matching ID
 			return &allowlist, nil


### PR DESCRIPTION
## Summary

Fixes [AV-129803](https://couchbasecloud.atlassian.net/browse/AV-129803): `getAllowedCIDR` fetches the allowed CIDRs list endpoint without pagination, silently dropping resources from Terraform state when CIDR count exceeds the default page size.

## Root Cause

`getAllowedCIDR` at `internal/resources/app_service_cidr.go:161` calls `GET /allowedcidrs` with no `?page=N&perPage=M` parameters. The API applies a default page size (~10). Any CIDR whose UUID sorts past page 1 is not present in the response, `getAllowedCIDR` returns `errors.ErrNotFound`, and `Read()` calls `resp.State.RemoveResource` — silently removing a live, valid resource from Terraform state.

The datasource (`internal/datasources/app_services_cidr.go`) already uses `api.GetPaginated` for the same endpoint and handles pagination correctly. The single-item `GET /allowedcidrs/{id}` endpoint does **not** exist in the OpenAPI spec (only DELETE at that path), so pagination is the only option.

## Fix

Replace the manual single-page API call in `getAllowedCIDR` with `api.GetPaginated`, the same generic pagination helper used by the datasource. This iterates through all pages when searching for the specific CIDR by ID.

## Changes
- `internal/resources/app_service_cidr.go`: Replace `ClientV1.ExecuteWithRetry` + manual `json.Unmarshal` with `api.GetPaginated` in `getAllowedCIDR`

## Testing
- `go vet ./internal/resources/` — clean
- `go build` — passes (v1.9.1)
- `go test -c ./acceptance_tests/` — compiles cleanly
- Acceptance tests cannot be run in this environment (no Capella credentials), but the existing `app_services_cidr_datasource_test.go` exercises the datasource's paginated path indirectly

## Reviewer Callouts
- **Confidence: 95%** — the fix mirrors the datasource's proven pagination pattern for the exact same API endpoint. The only uncertainty is whether any edge case exists with `GetPaginated` interacting differently with the `SortById` parameter than the API's default sort.
- No unit test was added because `getAllowedCIDR` requires a real `*api.Client` instance. The existing test infrastructure doesn't support mocking the API client layer. A follow-up could extract the CIDR lookup into a testable helper.
- `Delete()` uses the single-item `DELETE /allowedcidrs/{id}` endpoint (with the ID in the URL), so it is **not** affected by this bug — despite the ticket's description. The ticket may have described an older version of the code, or the reporter included Delete as a precaution.


[AV-129803]: https://couchbasecloud.atlassian.net/browse/AV-129803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ