### PR TITLE
[AV-136389] Skip ALTER INDEX when num_replica is unchanged

### DIFF
--- a/acceptance_tests/gsi_accpetance_test.go
+++ b/acceptance_tests/gsi_accpetance_test.go
@@ -160,6 +160,155 @@ resource "couchbase-capella_query_indexes" "%[8]s" {
 		resourceName)
 }
 
+// TestAccGSIImportWithoutIsPrimary verifies that importing an existing index
+// without specifying is_primary in the config does not trigger a spurious
+// in-place update. The is_primary attribute is computed, so Terraform uses the
+// imported value and produces no diff.
+func TestAccGSIImportWithoutIsPrimary(t *testing.T) {
+	const resourceType = "couchbase-capella_query_indexes"
+	indexResourceName := "idx"
+	indexResourceReference := fmt.Sprintf("%s.%s", resourceType, indexResourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_query_indexes" "%[8]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  bucket_name     = "%[5]s"
+  scope_name      = "%[6]s"
+  collection_name = "%[7]s"
+  index_name      = "import_test_idx"
+  index_keys      = ["import_test_key"]
+}
+`, globalProviderBlock,
+					globalOrgId,
+					globalProjectId,
+					globalClusterId,
+					globalBucketName,
+					globalScopeName,
+					globalCollectionName,
+					indexResourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(indexResourceReference, "index_name", "import_test_idx"),
+					resource.TestCheckResourceAttr(indexResourceReference, "index_keys.0", "import_test_key"),
+				),
+			},
+			{
+				ResourceName:            indexResourceReference,
+				ImportStateIdFunc:       generateGsiImportIdForResource(indexResourceReference),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"with"},
+			},
+		},
+	})
+}
+
+// TestAccGSINumReplicaUnchangedNoop verifies that re-applying the same config
+// after an index is created does not trigger a failing ALTER INDEX call when
+// num_replica has not changed. Previously the provider issued an unconditional
+// ALTER INDEX on every in-place update, which Couchbase Server rejects when
+// num_replica is unchanged ("Index already has X number of replica").
+func TestAccGSINumReplicaUnchangedNoop(t *testing.T) {
+	const resourceType = "couchbase-capella_query_indexes"
+	indexResourceName := "idx"
+	indexResourceReference := fmt.Sprintf("%s.%s", resourceType, indexResourceName)
+
+	configWithNumReplica0 := fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_query_indexes" "%[8]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  bucket_name     = "%[5]s"
+  scope_name      = "%[6]s"
+  collection_name = "%[7]s"
+  index_name      = "noop_test_idx"
+  index_keys      = ["noop_test_key"]
+  with = {
+    num_replica = 0
+  }
+}
+`, globalProviderBlock,
+		globalOrgId,
+		globalProjectId,
+		globalClusterId,
+		globalBucketName,
+		globalScopeName,
+		globalCollectionName,
+		indexResourceName)
+
+	configWithNumReplica1 := fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_query_indexes" "%[8]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = "%[4]s"
+  bucket_name     = "%[5]s"
+  scope_name      = "%[6]s"
+  collection_name = "%[7]s"
+  index_name      = "noop_test_idx"
+  index_keys      = ["noop_test_key"]
+  with = {
+    num_replica = 1
+  }
+}
+`, globalProviderBlock,
+		globalOrgId,
+		globalProjectId,
+		globalClusterId,
+		globalBucketName,
+		globalScopeName,
+		globalCollectionName,
+		indexResourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			// Step 1: Create index with num_replica = 0
+			{
+				Config: configWithNumReplica0,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(indexResourceReference, "index_name", "noop_test_idx"),
+					resource.TestCheckResourceAttr(indexResourceReference, "with.num_replica", "0"),
+				),
+			},
+			// Step 2: Re-apply the same config — should be a no-op, not fail
+			{
+				Config: configWithNumReplica0,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(indexResourceReference, "index_name", "noop_test_idx"),
+					resource.TestCheckResourceAttr(indexResourceReference, "with.num_replica", "0"),
+				),
+			},
+			// Step 3: Update num_replica from 0 to 1
+			{
+				Config: configWithNumReplica1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(indexResourceReference, "index_name", "noop_test_idx"),
+					resource.TestCheckResourceAttr(indexResourceReference, "with.num_replica", "1"),
+				),
+			},
+			// Step 4: Re-apply with num_replica = 1 — should be a no-op, not fail
+			{
+				Config: configWithNumReplica1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(indexResourceReference, "index_name", "noop_test_idx"),
+					resource.TestCheckResourceAttr(indexResourceReference, "with.num_replica", "1"),
+				),
+			},
+		},
+	})
+}
+
 func generateGsiImportIdForResource(resourceReference string) resource.ImportStateIdFunc {
 	return func(state *terraform.State) (string, error) {
 		var rawState map[string]string

--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -437,8 +437,9 @@ func (g *GSI) Read(ctx context.Context, req resource.ReadRequest, resp *resource
 
 // Update will send a request to alter an index.
 func (g *GSI) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan providerschema.GsiDefinition
+	var plan, state providerschema.GsiDefinition
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -449,6 +450,18 @@ func (g *GSI) Update(ctx context.Context, req resource.UpdateRequest, resp *reso
 			"Missing Required Attribute",
 			"num_replica must be specified for index updates. The update operation only supports changing the number of replicas.",
 		)
+		return
+	}
+
+	// Skip the ALTER INDEX call if num_replica hasn't changed.
+	// This prevents unnecessary and failing ALTER INDEX calls when an in-place
+	// update is triggered by a non-num_replica attribute change (e.g. is_primary
+	// becoming null on import).
+	if state.With != nil &&
+		!state.With.NumReplica.IsNull() && !state.With.NumReplica.IsUnknown() &&
+		state.With.NumReplica.ValueInt64() == plan.With.NumReplica.ValueInt64() {
+
+		resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 		return
 	}
 

--- a/internal/resources/gsi_schema.go
+++ b/internal/resources/gsi_schema.go
@@ -39,7 +39,7 @@ func GsiSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "scope_name", gsiBuilder, stringDefaultAttribute("_default", optional, computed, useStateForUnknown, requiresReplace))
 	capellaschema.AddAttr(attrs, "collection_name", gsiBuilder, stringDefaultAttribute("_default", optional, computed, useStateForUnknown, requiresReplace))
 	capellaschema.AddAttr(attrs, "index_name", gsiBuilder, stringAttribute([]string{optional, requiresReplace}))
-	capellaschema.AddAttr(attrs, "is_primary", gsiBuilder, boolAttribute(optional))
+	capellaschema.AddAttr(attrs, "is_primary", gsiBuilder, boolAttribute(optional, computed))
 	capellaschema.AddAttr(attrs, "index_keys", gsiBuilder, stringListAttribute(optional, requiresReplace))
 	capellaschema.AddAttr(attrs, "where", gsiBuilder, stringAttribute([]string{optional, requiresReplace}))
 	capellaschema.AddAttr(attrs, "status", gsiBuilder, stringAttribute([]string{computed, useStateForUnknown}))


### PR DESCRIPTION
## Problem

The terraform provider makes an unconditional `ALTER INDEX` call on in-place updates to GSI indexes even when `num_replica` hasn't changed. Couchbase Server rejects this with "Index already has X number of replica", causing `terraform apply` to fail.

This commonly happens when importing an existing index without specifying `is_primary` in the config. The `is_primary` attribute (Optional but not Computed) shows `false -> null` in the plan, triggering an in-place update that unconditionally sends ALTER INDEX with the same `num_replica` value.

## Fix

### 1. Make `is_primary` Computed (schema change)
`is_primary` was `Optional` only. Adding `Computed` means Terraform uses the imported/api value when the user doesn't specify it, preventing the false `false -> null` diff.

### 2. Guard Update() against unchanged `num_replica`
The `Update` function now reads the old state and compares `num_replica` values. If `num_replica` hasn't changed, it skips the ALTER INDEX call entirely. This is a defensive measure that also handles cases where in-place updates are triggered for other reasons.

## Changes

| File | Change |
|------|--------|
| `internal/resources/gsi_schema.go` | Added `Computed` to `is_primary` attribute |
| `internal/resources/gsi.go` | Added guard in `Update()` to skip ALTER INDEX when num_replica unchanged |
| `acceptance_tests/gsi_accpetance_test.go` | Added `TestAccGSIImportWithoutIsPrimary` and `TestAccGSINumReplicaUnchangedNoop` |

## Validation

- `go vet ./internal/resources/` — clean
- `go build` — succeeds (24.9 MB binary)
- `go test -c ./acceptance_tests/` — compiles cleanly
- `go test ./internal/resources/` — all existing tests pass
- `goimports` — clean

## Acceptance tests (not run in this environment)

`TestAccGSIImportWithoutIsPrimary`: Creates an index without `is_primary`, then imports it — verifies no spurious in-place update.

`TestAccGSINumReplicaUnchangedNoop`:
1. Creates index with `num_replica = 0`
2. Re-applies same config (should be no-op, not fail)
3. Updates to `num_replica = 1` (ALTER INDEX should succeed)
4. Re-applies with `num_replica = 1` (should be no-op, not fail)

## Reviewer callouts

- The `is_primary` `Computed` change is safe: users creating indexes still set it explicitly; on import/read it prevents false diffs.
- The `Update` guard compares old `state.With.NumReplica` with `plan.With.NumReplica`. If `state.With` is nil, we fall through to the existing ALTER INDEX path (should not happen in practice since Create/Read always populate `With`).