### PR TITLE
[AV-131927] Validate provider_type matches provider_config block in network_peer

### DIFF
--- a/acceptance_tests/network_peer_acceptance_test.go
+++ b/acceptance_tests/network_peer_acceptance_test.go
@@ -46,3 +46,113 @@ resource "couchbase-capella_network_peer" "%[2]s" {
 }
 `, globalProviderBlock, resourceName)
 }
+
+// TestAccNetworkPeerProviderTypeConfigMismatch_AV_131927 verifies that the provider rejects a
+// network_peer configuration at plan time when provider_type does not match the provider_config
+// block. For example, provider_type = "azure" with provider_config.aws_config should fail
+// validation before any API call.
+func TestAccNetworkPeerProviderTypeConfigMismatch_AV_131927(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerType string
+		configBlock  string
+		errorPattern string
+	}{
+		{
+			name:         "azure provider_type with aws_config",
+			providerType: "azure",
+			configBlock:  "aws_config",
+			errorPattern: `provider_type does not match the provider config block`,
+		},
+		{
+			name:         "aws provider_type with azure_config",
+			providerType: "aws",
+			configBlock:  "azure_config",
+			errorPattern: `provider_type does not match the provider config block`,
+		},
+		{
+			name:         "gcp provider_type with aws_config",
+			providerType: "gcp",
+			configBlock:  "aws_config",
+			errorPattern: `provider_type does not match the provider config block`,
+		},
+		{
+			name:         "aws provider_type with gcp_config",
+			providerType: "aws",
+			configBlock:  "gcp_config",
+			errorPattern: `provider_type does not match the provider config block`,
+		},
+		{
+			name:         "gcp provider_type with azure_config",
+			providerType: "gcp",
+			configBlock:  "azure_config",
+			errorPattern: `provider_type does not match the provider config block`,
+		},
+		{
+			name:         "azure provider_type with gcp_config",
+			providerType: "azure",
+			configBlock:  "gcp_config",
+			errorPattern: `provider_type does not match the provider config block`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resourceName := randomStringWithPrefix("tf_acc_np_mismatch_")
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config:      testAccNetworkPeerProviderTypeConfigMismatchConfig(resourceName, tt.providerType, tt.configBlock),
+						ExpectError: regexp.MustCompile(tt.errorPattern),
+					},
+				},
+			})
+		})
+	}
+}
+
+func testAccNetworkPeerProviderTypeConfigMismatchConfig(resourceName, providerType, configBlock string) string {
+	var config string
+	switch configBlock {
+	case "aws_config":
+		config = `
+    aws_config = {
+      account_id = "123456789012"
+      vpc_id     = "vpc-1234567890abcdef0"
+      cidr       = "10.10.0.0/16"
+      region     = "us-east-1"
+    }`
+	case "gcp_config":
+		config = `
+    gcp_config = {
+      cidr            = "10.10.0.0/16"
+      network_name    = "test-network"
+      project_id      = "test-project"
+      service_account = "test@test.iam.gserviceaccount.com"
+    }`
+	case "azure_config":
+		config = `
+    azure_config = {
+      cidr            = "10.10.0.0/16"
+      tenant_id       = "fee88efb-27a4-4ef6-937e-886a970af84b"
+      resource_group  = "test-resource-group"
+      subscription_id = "7df08e2f-efb1-4ed0-be9c-bb9a9d99ec84"
+      vnet_id         = "test-vnet"
+    }`
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_network_peer" "%[2]s" {
+  organization_id = "00000000-0000-0000-0000-000000000000"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  cluster_id      = "22222222-2222-2222-2222-222222222222"
+  name            = "qe-mismatch-provider-config"
+  provider_type   = "%[3]s"
+  provider_config = {%[4]s
+  }
+}
+`, globalProviderBlock, resourceName, providerType, config)
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -244,6 +244,10 @@ var (
 	// ErrProviderConfigCannotBeEmpty is returned when the provider_config was required for a request but was empty.
 	ErrProviderConfigCannotBeEmpty = errors.New("provider_config cannot be empty, it should be populated with one of- aws_config, gcp_config or azure_config. Please contact Couchbase Capella Support")
 
+	// ErrProviderTypeConfigMismatch is returned when provider_type does not match the provider_config block set.
+	// For example, provider_type = "azure" but provider_config.aws_config is populated instead of azure_config.
+	ErrProviderTypeConfigMismatch = errors.New("provider_type does not match the provider config block; provider_type \"aws\" requires aws_config, \"gcp\" requires gcp_config, \"azure\" requires azure_config")
+
 	ErrPrivateEndpointServiceTimeout = errors.New("changing private endpoint service status timed out after initiation")
 
 	// ErrPrivateEndpointServiceEnableFailed is returned when the backend reports a terminal

--- a/internal/resources/network_peer.go
+++ b/internal/resources/network_peer.go
@@ -417,6 +417,10 @@ func (n *NetworkPeer) validateCreateNetworkPeer(plan providerschema.NetworkPeer)
 		return errors.ErrClusterIdMissing
 	}
 
+	if err := n.validateProviderTypeConfigMatch(plan); err != nil {
+		return err
+	}
+
 	if plan.ProviderConfig != nil && plan.ProviderConfig.AzureConfig != nil {
 		if err := plan.ProviderConfig.AzureConfig.Validate(); err != nil {
 			return err
@@ -424,6 +428,39 @@ func (n *NetworkPeer) validateCreateNetworkPeer(plan providerschema.NetworkPeer)
 	}
 
 	return n.validateNetworkPeerAttributesTrimmed(plan)
+}
+
+// validateProviderTypeConfigMatch checks that the provider_type value matches the provider_config
+// block that the user has populated. For example, provider_type "azure" requires provider_config.azure_config,
+// and setting aws_config with provider_type "azure" is rejected at plan time before any API call.
+func (n *NetworkPeer) validateProviderTypeConfigMatch(plan providerschema.NetworkPeer) error {
+	if plan.ProviderConfig == nil {
+		return errors.ErrProviderConfigCannotBeEmpty
+	}
+
+	providerType := plan.ProviderType.ValueString()
+
+	switch {
+	case plan.ProviderConfig.AWSConfig != nil:
+		if !strings.EqualFold(providerType, "aws") {
+			return fmt.Errorf("%w: provider_type is %q but provider_config.aws_config is set; expected provider_type \"aws\"",
+				errors.ErrProviderTypeConfigMismatch, providerType)
+		}
+	case plan.ProviderConfig.GCPConfig != nil:
+		if !strings.EqualFold(providerType, "gcp") {
+			return fmt.Errorf("%w: provider_type is %q but provider_config.gcp_config is set; expected provider_type \"gcp\"",
+				errors.ErrProviderTypeConfigMismatch, providerType)
+		}
+	case plan.ProviderConfig.AzureConfig != nil:
+		if !strings.EqualFold(providerType, "azure") {
+			return fmt.Errorf("%w: provider_type is %q but provider_config.azure_config is set; expected provider_type \"azure\"",
+				errors.ErrProviderTypeConfigMismatch, providerType)
+		}
+	default:
+		return errors.ErrProviderConfigCannotBeEmpty
+	}
+
+	return nil
 }
 
 func (n *NetworkPeer) validateNetworkPeerAttributesTrimmed(plan providerschema.NetworkPeer) error {


### PR DESCRIPTION
## Jira

* [AV-131927](https://couchbasecloud.atlassian.net/browse/AV-131927)

## Description

The `couchbase-capella_network_peer` resource did not validate that `provider_type` matches the `provider_config` block. For example, `provider_type = "azure"` with `provider_config.aws_config` would pass validation and reach the API, which returned a confusing Azure-specific error instead of rejecting the mismatched configuration at plan time.

### Root Cause

`validateCreateNetworkPeer` in [internal/resources/network_peer.go](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/blob/e7ab7ddb848cbc05d286bd0b3a336e1ace5abe0e/internal/resources/network_peer.go#L63-L80) checked required IDs and Azure config validity but never verified that `provider_type` corresponds to the populated config block.

### Fix

Added `validateProviderTypeConfigMatch` that enforces:
- `provider_type = \"aws\"` requires `provider_config.aws_config`
- `provider_type = \"gcp\"` requires `provider_config.gcp_config`
- `provider_type = \"azure\"` requires `provider_config.azure_config`

Validation runs at plan time, before any API call.

Changes:
- [internal/resources/network_peer.go](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/blob/e7ab7ddb848cbc05d286bd0b3a336e1ace5abe0e/internal/resources/network_peer.go): Added `validateProviderTypeConfigMatch` and wired it into `validateCreateNetworkPeer`
- [internal/errors/errors.go](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/blob/e7ab7ddb848cbc05d286bd0b3a336e1ace5abe0e/internal/errors/errors.go): Added `ErrProviderTypeConfigMismatch` sentinel error
- [acceptance_tests/network_peer_acceptance_test.go](https://github.com/couchbasecloud/terraform-provider-couchbase-capella/blob/e7ab7ddb848cbc05d286bd0b3a336e1ace5abe0e/acceptance_tests/network_peer_acceptance_test.go): Added `TestAccNetworkPeerProviderTypeConfigMismatch_AV_131927` table-driven test covering all 6 mismatch combinations

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [x] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

```
# Compile-check acceptance tests
$ go test -c -o /dev/null ./acceptance_tests/
# PASS

# Unit tests
$ make test
# All tests pass

# Build
$ make build
# PASS

# go vet
$ make vet
# PASS
```

Acceptance test `TestAccNetworkPeerProviderTypeConfigMismatch_AV_131927` covers all 6 mismatch combinations (azure/aws, aws/azure, gcp/aws, aws/gcp, gcp/azure, azure/gcp) using dummy org/project/cluster IDs since validation fires at plan time before any API call.
</details>

## Further comments

Fix confidence: 100%. The validation is straightforward — we check the relationship between two user-provided fields at plan time using the same `strings.EqualFold` pattern already used elsewhere in the resource.

[AV-131927]: https://couchbasecloud.atlassian.net/browse/AV-131927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ