### PR TITLE
[AV-138335] Move version change check to a ModifyPlan validator

### DIFF
--- a/acceptance_tests/appservice_acceptance_test.go
+++ b/acceptance_tests/appservice_acceptance_test.go
@@ -107,8 +107,16 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 				),
 			},
 			{
-				// Changing the major.minor version is not supported and must be rejected at apply time.
+				// Changing the major.minor version is not supported and must be rejected at plan time.
 				Config:      testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, "1.0", 3, 4, 8),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?s)version as this is not supported`),
+			},
+			{
+				// The rejection must also apply when the app service is being replaced for another reason, as the replacement would otherwise be created with the new version.
+				// This test will need modifying when AV-65838 is fixed, as name will no longer be tagged with requires replace.
+				Config:      testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName+"_renamed", description, "1.0", 3, 4, 8),
+				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`(?s)version as this is not supported`),
 			},
 		},

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -23,6 +23,7 @@ var (
 	_ resource.Resource                = &AppService{}
 	_ resource.ResourceWithConfigure   = &AppService{}
 	_ resource.ResourceWithImportState = &AppService{}
+	_ resource.ResourceWithModifyPlan  = &AppService{}
 )
 
 const errorMessageAfterAppServiceCreationInitiation = "App Service creation is initiated, but encountered an error while checking the current" +
@@ -52,6 +53,35 @@ func (a *AppService) Metadata(_ context.Context, req resource.MetadataRequest, r
 // Schema defines the schema for the AppService resource.
 func (a *AppService) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = AppServiceSchema()
+}
+
+// ModifyPlan rejects a version change on a deployed app service including when the plan calls for a force replacement.
+func (a *AppService) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Either a create or destroy, so no version check needed.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var config, state providerschema.AppService
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Plan version is null, unknown, or the same as the App Service, so no error.
+	if config.Version.IsNull() || config.Version.IsUnknown() || config.Version.Equal(state.Version) {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		path.Root("version"),
+		"Error updating app service",
+		"Could not update app service ID "+state.Id.String()+" version as this is not supported. "+
+			"To fix, destroy the App Service and create a new one with the desired version, "+
+			"update the version in the plan to the current version ("+state.Version.ValueString()+") to keep it pinned, "+
+			"or omit version from the plan completely.",
+	)
 }
 
 // Create creates a new AppService.
@@ -257,17 +287,6 @@ func (a *AppService) Update(ctx context.Context, req resource.UpdateRequest, res
 		resp.Diagnostics.AddError(
 			"Error updating app service",
 			"Could not update app service id "+state.Id.String()+" unexpected error: "+errors.ErrUnableToUpdateAppServiceName.Error(),
-		)
-		return
-	}
-
-	if !plan.Version.IsNull() && !plan.Version.IsUnknown() && !plan.Version.Equal(state.Version) {
-		resp.Diagnostics.AddError(
-			"Error updating app service",
-			"Could not update app service ID "+state.Id.String()+" version as this is not supported. "+
-				"To fix, destroy the App Service and create a new one with the desired version, "+
-				"update the version in the plan to the current version ("+state.Version.ValueString()+"), "+
-				"or omit version from the plan completely.",
 		)
 		return
 	}

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -69,7 +69,7 @@ func (a *AppService) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequ
 		return
 	}
 
-	// Plan version is null, unknown, or the same as the App Service, so no error.
+	// Configured version is null, unknown, or the same as the App Service, so no error.
 	if config.Version.IsNull() || config.Version.IsUnknown() || config.Version.Equal(state.Version) {
 		return
 	}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-138335

## Description

- Move the version change check to ModifyPlan validation function so that it gets flagged during plan time, even when a full app service replacement is done due to changing a `requiresReplace` attribute.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

```

=== RUN   TestAppServiceResource
--- PASS: TestAppServiceResource (914.32s)
=== RUN   TestAccAppServiceResourceOptionalFieldsAndScale
--- PASS: TestAccAppServiceResourceOptionalFieldsAndScale (1581.00s)


```
</details>

## Further comments