### PR TITLE
[AV-138606] Wait for desired state

### DIFF
--- a/internal/api/data_api/state.go
+++ b/internal/api/data_api/state.go
@@ -10,12 +10,10 @@ const (
 	Configuring State = "configuring"
 )
 
-// IsFinalState checks whether the Data API or its network peering has finished transitioning and reached a final state
-func IsFinalState(state State) bool {
-	switch state {
-	case Enabled, Disabled:
-		return true
-	default:
-		return false
+// DesiredState maps the requested enable/disable flag to the final state the resource should reach.
+func DesiredState(enabled bool) State {
+	if enabled {
+		return Enabled
 	}
+	return Disabled
 }

--- a/internal/resources/data_api.go
+++ b/internal/resources/data_api.go
@@ -119,7 +119,14 @@ func (d *DataApi) Create(ctx context.Context, req resource.CreateRequest, resp *
 		return
 	}
 
-	refreshedState, err := d.checkDataApiStatus(ctx, organizationId, projectId, clusterId)
+	refreshedState, err := d.checkDataApiStatus(
+		ctx,
+		organizationId,
+		projectId,
+		clusterId,
+		data_api.DesiredState(plan.EnableDataApi.ValueBool()),
+		data_api.DesiredState(plan.EnableNetworkPeering.ValueBool()),
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Data API configuration",
@@ -215,7 +222,14 @@ func (d *DataApi) Update(ctx context.Context, req resource.UpdateRequest, resp *
 		return
 	}
 
-	refreshedState, err := d.checkDataApiStatus(ctx, organizationId, projectId, clusterId)
+	refreshedState, err := d.checkDataApiStatus(
+		ctx,
+		organizationId,
+		projectId,
+		clusterId,
+		data_api.DesiredState(plan.EnableDataApi.ValueBool()),
+		data_api.DesiredState(plan.EnableNetworkPeering.ValueBool()),
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating Data API configuration",
@@ -267,10 +281,14 @@ func (d *DataApi) updateDataApi(ctx context.Context, plan providerschema.DataApi
 	return err
 }
 
-// checkDataApiStatus polls the Data API status until both the Data API and its network peering reach a final state,
-// then returns the refreshed resource state.
+// checkDataApiStatus polls the Data API status until both the Data API and its network peering reach the desired
+// states from the plan, then returns the refreshed resource state.
 // Polls up to 30 minutes, with a 15-second interval between polls to allow for the asynchronous operation to complete.
-func (d *DataApi) checkDataApiStatus(ctx context.Context, organizationId, projectId, clusterId string) (*providerschema.DataApi, error) {
+func (d *DataApi) checkDataApiStatus(
+	ctx context.Context,
+	organizationId, projectId, clusterId string,
+	desiredStateForDataAPI, desiredStateForNetworkPeering data_api.State,
+) (*providerschema.DataApi, error) {
 	const timeout = time.Minute * 30
 
 	var cancel context.CancelFunc
@@ -288,14 +306,14 @@ func (d *DataApi) checkDataApiStatus(ctx context.Context, organizationId, projec
 				return nil, err
 			}
 			tflog.Info(ctx, "retrying after error polling Data API status", map[string]interface{}{"error": err.Error()})
-		case data_api.IsFinalState(statusResp.State) && data_api.IsFinalState(statusResp.StateForNetworkPeering):
-			tflog.Debug(ctx, "data api has reached a final state", map[string]interface{}{
+		case statusResp.State == desiredStateForDataAPI && statusResp.StateForNetworkPeering == desiredStateForNetworkPeering:
+			tflog.Debug(ctx, "data api has reached the desired state", map[string]interface{}{
 				"state_for_data_api":        statusResp.State,
 				"state_for_network_peering": statusResp.StateForNetworkPeering,
 			})
 			return providerschema.NewDataApi(organizationId, projectId, clusterId, statusResp), nil
 		default:
-			tflog.Info(ctx, "waiting for Data API to finish transitioning to a final state", map[string]interface{}{
+			tflog.Info(ctx, "waiting for Data API to reach the desired state", map[string]interface{}{
 				"state_for_data_api":        statusResp.State,
 				"state_for_network_peering": statusResp.StateForNetworkPeering,
 			})
@@ -303,7 +321,7 @@ func (d *DataApi) checkDataApiStatus(ctx context.Context, organizationId, projec
 
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("timed out while waiting for data API state to finish transitioning to a final state: %w", ctx.Err())
+			return nil, fmt.Errorf("timed out while waiting for data API to reach the desired state: %w", ctx.Err())
 		case <-ticker.C:
 		}
 	}

--- a/internal/resources/data_api.go
+++ b/internal/resources/data_api.go
@@ -324,7 +324,12 @@ func (d *DataApi) checkDataApiStatus(
 
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("timed out while waiting for data API to reach the desired state: %w", ctx.Err())
+			return nil, fmt.Errorf(
+				"timed out while waiting for data API to reach the desired state (desired data API state: %s, desired network peering state: %s): %w",
+				desiredStateForDataAPI,
+				desiredStateForNetworkPeering,
+				ctx.Err(),
+			)
 		case <-ticker.C:
 		}
 	}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-138606

## Description

fixes an issue where after changing data API, provider only waits for any terminal state (ie disabled/enabled) instead of the desired state.  this is problematic because data API reaches a terminal state that's different from what's in the HCL it will cause `Provider produced inconsistent result after apply` 

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

validation in ticket

</details>

## Further comments