### PR TITLE
[AV-133415] Add keyspace-readiness acceptance tests for bucket → index in one apply

### DIFF
--- a/acceptance_tests/gsi_keyspace_readiness_acceptance_test.go
+++ b/acceptance_tests/gsi_keyspace_readiness_acceptance_test.go
@@ -1,0 +1,187 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccGSI_AV_133415 covers CBSE-22110: creating an index in the same apply as its
+// bucket used to fail with `httpStatusCode: 424, message: "Keyspace not found in CB
+// datastore"`. POST /v4/.../buckets returns 201 as soon as ns_server accepts the
+// bucket, but the query nodes serve index DDL from an eventually-consistent metadata
+// cache, so a CREATE INDEX issued immediately afterwards lands before the keyspace is
+// visible and the apply fails.
+//
+// The config deliberately contains no time_sleep and no readiness poll: the indexes
+// reach the bucket only through a bucket_name reference, so Terraform fires the index
+// DDL the moment the bucket create returns — the exact window the customer hit. The
+// bucket is ephemeral to match their automation.
+//
+// The secondary index is chained behind the primary rather than created alongside it:
+// the indexer rejects concurrent builds on a keyspace with a warning, which would
+// leave a partially-populated resource and make the assertions flap. Serializing keeps
+// the assertion focused on the keyspace-propagation window, which only the first DDL
+// after the bucket create can exercise.
+func TestAccGSI_AV_133415(t *testing.T) {
+	bucketName := randomStringWithPrefix("tf_acc_ks_bkt_")
+	primaryIdxName := randomStringWithPrefix("tf_acc_ks_pidx_")
+	secondaryIdxName := randomStringWithPrefix("tf_acc_ks_sidx_")
+
+	bucketReference := "couchbase-capella_bucket." + bucketName
+	primaryReference := "couchbase-capella_query_indexes." + primaryIdxName
+	secondaryReference := "couchbase-capella_query_indexes." + secondaryIdxName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGSIBucketAndIndexInOneApplyConfig(bucketName, primaryIdxName, secondaryIdxName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(bucketReference, "name", bucketName),
+					resource.TestCheckResourceAttr(bucketReference, "type", "ephemeral"),
+					resource.TestCheckResourceAttr(bucketReference, "cluster_id", globalClusterId),
+
+					resource.TestCheckResourceAttr(primaryReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(primaryReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(primaryReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(primaryReference, "bucket_name", bucketName),
+					resource.TestCheckResourceAttr(primaryReference, "scope_name", "_default"),
+					resource.TestCheckResourceAttr(primaryReference, "collection_name", "_default"),
+					resource.TestCheckResourceAttr(primaryReference, "index_name", primaryIdxName),
+					resource.TestCheckResourceAttr(primaryReference, "is_primary", "true"),
+					resource.TestCheckResourceAttrSet(primaryReference, "status"),
+
+					resource.TestCheckResourceAttr(secondaryReference, "bucket_name", bucketName),
+					resource.TestCheckResourceAttr(secondaryReference, "index_name", secondaryIdxName),
+					resource.TestCheckResourceAttr(secondaryReference, "index_keys.0", "c1"),
+					resource.TestCheckResourceAttrSet(secondaryReference, "status"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccGSI_AV_133415_NewCollection is the same race one level down: a bucket, scope,
+// collection and index all created in a single apply. Scope and collection creation is
+// also accepted asynchronously, so the query service can be behind on any part of the
+// keyspace, not just the bucket. This is the shape most real configurations take.
+func TestAccGSI_AV_133415_NewCollection(t *testing.T) {
+	bucketName := randomStringWithPrefix("tf_acc_kc_bkt_")
+	scopeName := randomStringWithPrefix("tf_acc_kc_scp_")
+	collectionName := randomStringWithPrefix("tf_acc_kc_col_")
+	idxName := randomStringWithPrefix("tf_acc_kc_idx_")
+
+	idxReference := "couchbase-capella_query_indexes." + idxName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGSINewCollectionAndIndexInOneApplyConfig(bucketName, scopeName, collectionName, idxName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(idxReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(idxReference, "bucket_name", bucketName),
+					resource.TestCheckResourceAttr(idxReference, "scope_name", scopeName),
+					resource.TestCheckResourceAttr(idxReference, "collection_name", collectionName),
+					resource.TestCheckResourceAttr(idxReference, "index_name", idxName),
+					resource.TestCheckResourceAttr(idxReference, "index_keys.0", "c1"),
+					resource.TestCheckResourceAttrSet(idxReference, "status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGSIBucketAndIndexInOneApplyConfig(bucketName, primaryIdxName, secondaryIdxName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_bucket" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  name            = "%[2]s"
+  type            = "ephemeral"
+  eviction_policy = "nruEviction"
+}
+
+resource "couchbase-capella_query_indexes" "%[6]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = couchbase-capella_bucket.%[2]s.name
+  scope_name      = "_default"
+  collection_name = "_default"
+  index_name      = "%[6]s"
+  is_primary      = true
+}
+
+resource "couchbase-capella_query_indexes" "%[7]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = couchbase-capella_bucket.%[2]s.name
+  scope_name      = "_default"
+  collection_name = "_default"
+  index_name      = "%[7]s"
+  index_keys      = ["c1"]
+  with = {
+    defer_build = false
+  }
+
+  depends_on = [couchbase-capella_query_indexes.%[6]s]
+}
+`, globalProviderBlock, bucketName, globalOrgId, globalProjectId, globalClusterId,
+		primaryIdxName, secondaryIdxName)
+}
+
+func testAccGSINewCollectionAndIndexInOneApplyConfig(bucketName, scopeName, collectionName, idxName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_bucket" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  name            = "%[2]s"
+}
+
+resource "couchbase-capella_scope" "%[6]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_id       = couchbase-capella_bucket.%[2]s.id
+  scope_name      = "%[6]s"
+}
+
+resource "couchbase-capella_collection" "%[7]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_id       = couchbase-capella_bucket.%[2]s.id
+  scope_name      = "%[6]s"
+  collection_name = "%[7]s"
+
+  depends_on = [couchbase-capella_scope.%[6]s]
+}
+
+resource "couchbase-capella_query_indexes" "%[8]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = couchbase-capella_bucket.%[2]s.name
+  scope_name      = "%[6]s"
+  collection_name = "%[7]s"
+  index_name      = "%[8]s"
+  index_keys      = ["c1"]
+  with = {
+    defer_build = false
+  }
+
+  depends_on = [couchbase-capella_collection.%[7]s]
+}
+`, globalProviderBlock, bucketName, globalOrgId, globalProjectId, globalClusterId,
+		scopeName, collectionName, idxName)
+}

--- a/acceptance_tests/gsi_keyspace_readiness_cluster_onoff_acceptance_test.go
+++ b/acceptance_tests/gsi_keyspace_readiness_cluster_onoff_acceptance_test.go
@@ -1,0 +1,479 @@
+package acceptance_tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	clusterapi "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/cluster"
+)
+
+const (
+	cycleBucketCount       = 5
+	cycleIndexesPerBucket  = 5
+	cycleClusterWait       = 40 * time.Minute
+	cycleClusterWaitPoll   = 20 * time.Second
+	cycleBucketMemoryInMiB = 100
+)
+
+// TestAccGSIKeyspaceReadinessAcrossClusterOnOff_AV_133415 asserts that indexes can be
+// created on freshly created buckets immediately after a cluster resume, without a
+// sleep — the case a hibernate/resume cycle makes hardest, because the query nodes come
+// back with empty metadata caches and so take longest to see a new keyspace.
+//
+// It is the escalated customer's automation sequence (CBSE-22110) end to end: turn the
+// cluster off, on, create 5 ephemeral buckets with 5 indexes each, delete them, turn
+// off, and do the buckets and indexes again. Scale matters here — 25 indexes per round
+// across 5 keyspaces is what the customer runs, and a single index would not stress the
+// same code path.
+//
+// The narrower single-apply case, without any cluster transition, is
+// TestAccGSI_AV_133415 in gsi_keyspace_readiness_acceptance_test.go, which runs on the
+// shared cluster in minutes. This one creates a cluster and hibernates it twice, so it
+// costs hours — select it deliberately with -run rather than sweeping the package.
+//
+// The cluster is declared in the config and created by the first step, following
+// TestAccFreeTierClusterLifecycle. Its block is byte-identical in every step so it is
+// never replaced, and Terraform destroys it at the end.
+//
+// The steps do not map one-to-one onto the reported sequence, for three reasons that
+// are properties of the bug rather than of the test:
+//
+//   - The cluster has to exist before it can be turned off, so step 1 creates it and
+//     the reported sequence starts at step 2.
+//
+//   - Bucket creation and index creation have to happen in the SAME apply. That is
+//     what puts the index DDL inside the window where the query service has not yet
+//     cached the new keyspace. Split across two applies the second runs long after
+//     propagation and the race is gone, so "create buckets" and "create indexes" are
+//     one step here.
+//
+//   - A cluster transition has to be its own step. couchbase-capella_cluster_onoff_ondemand
+//     treats the API's 202 as done and never polls (AV-138686), so a bucket declared in
+//     the same apply as a turn-on races it even with depends_on, and fails with 422
+//     "Temporarily unavailable while the Cluster is in the Turning Off state." Each
+//     transition step therefore ends with waitForClusterState, which runs after apply
+//     and so gates the following step.
+//
+// Step 8 is the interesting one: the query nodes come back with cold metadata caches
+// after the step 6 turn-off, giving the widest propagation window — and the best chance
+// of exceeding the ~15s the control plane retries for since AV-133415 shipped in 2.2.283.
+func TestAccGSIKeyspaceReadinessAcrossClusterOnOff_AV_133415(t *testing.T) {
+	clusterName := randomStringWithPrefix("tf_acc_onoff_cluster_")
+	onOffName := randomStringWithPrefix("tf_acc_onoff_state_")
+	prefix := randomStringWithPrefix("tf_acc_onoff_")
+	cidr := generateRandomCIDR()
+
+	clusterReference := "couchbase-capella_cluster." + clusterName
+	onOffReference := "couchbase-capella_cluster_onoff_ondemand." + onOffName
+
+	buckets := cycleBucketNames(prefix)
+
+	// Byte-identical across every step so the cluster is never replaced mid-flow.
+	clusterBlock := cycleClusterBlock(clusterName, cidr)
+
+	onOff := func(state string) string { return cycleOnOffBlock(clusterName, onOffName, state) }
+	bucketsAndIndexes := cycleBucketAndIndexBlocks(clusterName, prefix)
+
+	// resource.Test rather than ParallelTest: a multi-hour run that hibernates a
+	// cluster should not interleave with anything else.
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				// Create the cluster the flow runs on. couchbase-capella_cluster polls
+				// to a final state on create, so it is Healthy when this returns.
+				Config: cycleConfig(clusterBlock),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(clusterReference, "id"),
+					resource.TestCheckResourceAttr(clusterReference, "name", clusterName),
+					waitForClusterState(clusterReference, clusterapi.Healthy),
+				),
+			},
+			{
+				// 1. turn the cluster off
+				Config: cycleConfig(clusterBlock, onOff("off")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(onOffReference, "state", "off"),
+					waitForClusterState(clusterReference, clusterapi.TurnedOff),
+				),
+			},
+			{
+				// 2. turn it on
+				Config: cycleConfig(clusterBlock, onOff("on")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(onOffReference, "state", "on"),
+					waitForClusterState(clusterReference, clusterapi.Healthy),
+				),
+			},
+			{
+				// 3 + 4. create the buckets and, in the same apply, their indexes.
+				Config: cycleConfig(clusterBlock, onOff("on"), bucketsAndIndexes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					append(
+						cycleBucketAndIndexChecks(clusterReference, buckets),
+						waitForClusterState(clusterReference, clusterapi.Healthy),
+					)...,
+				),
+			},
+			{
+				// 5. delete the ephemeral buckets. The indexes go with them, and
+				// Terraform drops them first because they depend on the buckets.
+				Config: cycleConfig(clusterBlock, onOff("on")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					cycleCheckBucketsAbsent(clusterReference, buckets),
+					waitForClusterState(clusterReference, clusterapi.Healthy),
+				),
+			},
+			{
+				// 6. turn the cluster off
+				Config: cycleConfig(clusterBlock, onOff("off")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(onOffReference, "state", "off"),
+					waitForClusterState(clusterReference, clusterapi.TurnedOff),
+				),
+			},
+			{
+				// Bring the cluster back up before recreating the buckets. Creating a
+				// bucket on a hibernated cluster fails for an unrelated reason, which
+				// would mask the keyspace race this test exists for.
+				Config: cycleConfig(clusterBlock, onOff("on")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(onOffReference, "state", "on"),
+					waitForClusterState(clusterReference, clusterapi.Healthy),
+				),
+			},
+			{
+				// 7 + 8. buckets and indexes again, this time against query nodes
+				// whose caches are cold from the turn-off.
+				Config: cycleConfig(clusterBlock, onOff("on"), bucketsAndIndexes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					append(
+						cycleBucketAndIndexChecks(clusterReference, buckets),
+						waitForClusterState(clusterReference, clusterapi.Healthy),
+					)...,
+				),
+			},
+		},
+	})
+}
+
+func cycleConfig(blocks ...string) string {
+	return globalProviderBlock + "\n" + strings.Join(blocks, "\n")
+}
+
+// cycleClusterBlock is the cluster the flow runs on: its own, not the shared one, because
+// the flow hibernates it twice and every other test assumes its cluster stays up. It
+// carries data, index and query — index DDL needs the latter two. The caller passes a
+// randomised CIDR to avoid colliding with existing clusters in the organization.
+func cycleClusterBlock(clusterName, cidr string) string {
+	return fmt.Sprintf(`
+resource "couchbase-capella_cluster" "%[1]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  name            = "%[1]s"
+  description     = "Customer flow acceptance test (CBSE-22110)."
+  cloud_provider = {
+    type   = "aws"
+    region = "us-east-1"
+    cidr   = "%[4]s"
+  }
+  service_groups = [
+    {
+      node = {
+        compute = {
+          cpu = 4
+          ram = 16
+        }
+        disk = {
+          storage = 50
+          type    = "gp3"
+          iops    = 3000
+        }
+      }
+      num_of_nodes = 3
+      services     = ["data", "index", "query"]
+    }
+  ]
+  availability = {
+    "type" : "multi"
+  }
+  support = {
+    plan     = "enterprise"
+    timezone = "PT"
+  }
+}
+`, clusterName, globalOrgId, globalProjectId, cidr)
+}
+
+func cycleOnOffBlock(clusterName, onOffName, state string) string {
+	return fmt.Sprintf(`
+resource "couchbase-capella_cluster_onoff_ondemand" "%[1]s" {
+  organization_id            = "%[2]s"
+  project_id                 = "%[3]s"
+  cluster_id                 = couchbase-capella_cluster.%[4]s.id
+  state                      = "%[5]s"
+  turn_on_linked_app_service = false
+}
+`, onOffName, globalOrgId, globalProjectId, clusterName, state)
+}
+
+func cycleBucketNames(prefix string) []string {
+	names := make([]string, 0, cycleBucketCount)
+	for i := 1; i <= cycleBucketCount; i++ {
+		names = append(names, fmt.Sprintf("%s_%d", prefix, i))
+	}
+	return names
+}
+
+func cycleIndexNames(bucket string) []string {
+	names := make([]string, 0, cycleIndexesPerBucket)
+	for i := 1; i <= cycleIndexesPerBucket; i++ {
+		names = append(names, fmt.Sprintf("%s_idx_%d", bucket, i))
+	}
+	return names
+}
+
+// cycleBucketAndIndexBlocks declares the buckets and their indexes together. bucket_name
+// reads through the bucket resource rather than repeating the literal name: that
+// reference is what orders the DDL after the bucket create, and puts it immediately
+// after, with nothing waiting in between.
+//
+// The blocks are emitted one per resource rather than with for_each, which would be the
+// natural way to write this. GSI.ValidateConfig guards only on organization_id being
+// unknown and then tests index_name with ValueString() == ""; under for_each, index_name
+// is still unknown when validation runs and ValueString() yields "", so it rejects the
+// config at plan time with "Expected index_name to be configured but is null" even
+// though it is set (AV-138687). Once that is fixed this can collapse to a for_each over
+// a map of index specs.
+//
+// The indexes are created deferred and built per bucket with one BUILD INDEX. Five
+// immediate builds on one keyspace get rejected by the indexer as concurrent builds,
+// which the provider surfaces as a warning and leaves the resource unpopulated — that
+// would fail the attribute checks for reasons unrelated to the keyspace race. The
+// CREATE still has to resolve the keyspace, so the race stands.
+func cycleBucketAndIndexBlocks(clusterName, prefix string) string {
+	var b strings.Builder
+
+	for i, bucket := range cycleBucketNames(prefix) {
+		fmt.Fprintf(&b, `
+resource "couchbase-capella_bucket" "%[1]s" {
+  organization_id         = "%[2]s"
+  project_id              = "%[3]s"
+  cluster_id              = couchbase-capella_cluster.%[4]s.id
+  name                    = "%[5]s"
+  type                    = "ephemeral"
+  eviction_policy         = "nruEviction"
+  memory_allocation_in_mb = %[6]d
+}
+`, cycleBucketResourceName(i), globalOrgId, globalProjectId, clusterName, bucket, cycleBucketMemoryInMiB)
+
+		for j, index := range cycleIndexNames(bucket) {
+			fmt.Fprintf(&b, `
+resource "couchbase-capella_query_indexes" "%[1]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = couchbase-capella_cluster.%[4]s.id
+  bucket_name     = couchbase-capella_bucket.%[5]s.name
+  scope_name      = "_default"
+  collection_name = "_default"
+  index_name      = "%[6]s"
+  index_keys      = ["c%[7]d"]
+
+  with = {
+    defer_build = true
+  }
+}
+`, cycleIndexResourceName(i, j), globalOrgId, globalProjectId, clusterName,
+				cycleBucketResourceName(i), index, j+1)
+		}
+
+		fmt.Fprintf(&b, `
+resource "couchbase-capella_query_indexes" "%[1]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+  cluster_id      = couchbase-capella_cluster.%[4]s.id
+  bucket_name     = couchbase-capella_bucket.%[5]s.name
+  scope_name      = "_default"
+  collection_name = "_default"
+  build_indexes   = %[6]s
+
+  depends_on = [%[7]s]
+}
+`, cycleBuildResourceName(i), globalOrgId, globalProjectId, clusterName,
+			cycleBucketResourceName(i), cycleHCLStringList(cycleIndexNames(bucket)), cycleIndexResourceRefs(i))
+	}
+
+	return b.String()
+}
+
+func cycleBucketResourceName(bucketIdx int) string {
+	return fmt.Sprintf("bkt_%d", bucketIdx+1)
+}
+
+func cycleIndexResourceName(bucketIdx, indexIdx int) string {
+	return fmt.Sprintf("idx_%d_%d", bucketIdx+1, indexIdx+1)
+}
+
+func cycleBuildResourceName(bucketIdx int) string {
+	return fmt.Sprintf("build_%d", bucketIdx+1)
+}
+
+func cycleHCLStringList(values []string) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, fmt.Sprintf("%q", value))
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}
+
+func cycleIndexResourceRefs(bucketIdx int) string {
+	refs := make([]string, 0, cycleIndexesPerBucket)
+	for j := 0; j < cycleIndexesPerBucket; j++ {
+		refs = append(refs, "couchbase-capella_query_indexes."+cycleIndexResourceName(bucketIdx, j))
+	}
+	return strings.Join(refs, ", ")
+}
+
+// resourceAttrFromState reads one attribute of a resource out of Terraform state, for
+// checks that need a value only known after apply — here the generated cluster ID.
+func resourceAttrFromState(state *terraform.State, resourceRef, attr string) (string, error) {
+	for _, module := range state.Modules {
+		rs, ok := module.Resources[resourceRef]
+		if !ok {
+			continue
+		}
+		value := rs.Primary.Attributes[attr]
+		if value == "" {
+			return "", fmt.Errorf("%s has no %q in state", resourceRef, attr)
+		}
+		return value, nil
+	}
+	return "", fmt.Errorf("%s not found in state", resourceRef)
+}
+
+// waitForClusterState polls until the cluster reaches want. It is used as the last
+// check of a step so that the following step starts against a settled cluster: the
+// on/off resource returns on the API's 202 without waiting (AV-138686), and a bucket
+// create against a turningOn/turningOff cluster fails with 422. It also absorbs the
+// rebalance each bucket create kicks off.
+func waitForClusterState(clusterResourceRef string, want clusterapi.State) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		clusterID, err := resourceAttrFromState(state, clusterResourceRef, "id")
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cycleClusterWait)
+		defer cancel()
+
+		url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s",
+			globalHost, globalOrgId, globalProjectId, clusterID)
+		cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+
+		var last clusterapi.State
+		for {
+			response, err := globalClient.ExecuteWithRetry(ctx, cfg, nil, globalToken, nil)
+			if err != nil {
+				return fmt.Errorf("reading cluster %s while waiting for %s: %w", clusterID, want, err)
+			}
+
+			var cluster clusterapi.GetClusterResponse
+			if err := json.Unmarshal(response.Body, &cluster); err != nil {
+				return fmt.Errorf("unmarshalling cluster %s: %w", clusterID, err)
+			}
+			last = cluster.CurrentState
+
+			if last == want {
+				return nil
+			}
+			// Failed transitions never resolve, so give up rather than spend the
+			// whole timeout on a cluster that will not move.
+			if strings.HasSuffix(string(last), "Failed") {
+				return fmt.Errorf("cluster %s entered terminal state %q while waiting for %q",
+					clusterID, last, want)
+			}
+
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("timed out after %s waiting for cluster %s to reach %q, last state %q",
+					cycleClusterWait, clusterID, want, last)
+			case <-time.After(cycleClusterWaitPoll):
+			}
+		}
+	}
+}
+
+func cycleBucketAndIndexChecks(clusterReference string, buckets []string) []resource.TestCheckFunc {
+	checks := make([]resource.TestCheckFunc, 0, len(buckets)*(cycleIndexesPerBucket+1))
+
+	for i, bucket := range buckets {
+		bucketReference := "couchbase-capella_bucket." + cycleBucketResourceName(i)
+		checks = append(checks,
+			resource.TestCheckResourceAttr(bucketReference, "name", bucket),
+			resource.TestCheckResourceAttrPair(bucketReference, "cluster_id", clusterReference, "id"),
+			resource.TestCheckResourceAttr(bucketReference, "type", "ephemeral"),
+		)
+
+		for j, index := range cycleIndexNames(bucket) {
+			indexReference := "couchbase-capella_query_indexes." + cycleIndexResourceName(i, j)
+			checks = append(checks,
+				resource.TestCheckResourceAttr(indexReference, "bucket_name", bucket),
+				resource.TestCheckResourceAttr(indexReference, "index_name", index),
+				resource.TestCheckResourceAttr(indexReference, "scope_name", "_default"),
+				resource.TestCheckResourceAttr(indexReference, "collection_name", "_default"),
+			)
+		}
+	}
+
+	return checks
+}
+
+// cycleCheckBucketsAbsent confirms the buckets are gone from Capella, not merely dropped
+// from state, so the delete step actually proves something.
+func cycleCheckBucketsAbsent(clusterReference string, buckets []string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		clusterID, err := resourceAttrFromState(state, clusterReference, "id")
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/buckets",
+			globalHost, globalOrgId, globalProjectId, clusterID)
+		cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+
+		remaining, err := api.GetPaginated[[]struct {
+			Name string `json:"name"`
+		}](ctx, globalClient, globalToken, cfg, api.SortById)
+		if err != nil {
+			return fmt.Errorf("listing buckets on %s: %w", clusterID, err)
+		}
+
+		present := make(map[string]struct{}, len(remaining))
+		for _, bucket := range remaining {
+			present[bucket.Name] = struct{}{}
+		}
+
+		var leftover []string
+		for _, bucket := range buckets {
+			if _, ok := present[bucket]; ok {
+				leftover = append(leftover, bucket)
+			}
+		}
+		if len(leftover) > 0 {
+			return fmt.Errorf("buckets still present after delete: %s", strings.Join(leftover, ", "))
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-133415

## Description

gsi_keyspace_readiness_acceptance_test.go — the narrow case, on the shared cluster, minutes to run:

TestAccGSI_AV_133415 — ephemeral bucket + primary index + secondary index in one apply on _default._default
TestAccGSI_AV_133415_NewCollection — bucket + scope + collection + index in one apply; scope and collection creation are async too, so the query service can lag on any part of the keyspace
gsi_keyspace_readiness_cluster_onoff_acceptance_test.go — the customer's full flow, hours to run:

TestAccGSIKeyspaceReadinessAcrossClusterOnOff_AV_133415 — 8 steps: create cluster → off → on → 5 ephemeral buckets + 25 indexes → delete buckets → off → on → buckets + indexes again. Declares its own cluster (it hibernates it twice, which no shared cluster tolerates), block kept byte-identical across steps so it's never replaced, following TestAccFreeTierClusterLifecycle.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments