### PR TITLE
[AV-138941] Stop app service on/off reporting spurious drift on every plan

### DIFF
--- a/acceptance_tests/appservice_onoff_ondemand_acceptance_test.go
+++ b/acceptance_tests/appservice_onoff_ondemand_acceptance_test.go
@@ -1,0 +1,220 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+
+func TestAccAppServiceOnOffOnDemandResource(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_app_service_onoff_ondemand_")
+	resourceReference := "couchbase-capella_app_service_onoff_ondemand." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServiceOnOffOnDemandResourceConfig(resourceName, globalAppServiceId, "on"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(resourceReference, "app_service_id", globalAppServiceId),
+					resource.TestCheckResourceAttr(resourceReference, "state", "on"),
+				),
+			},
+			{
+				ResourceName:                         resourceReference,
+				ImportStateIdFunc:                    generateAppServiceOnOffOnDemandImportId(resourceReference),
+				ImportState:                          true,
+				ImportStateVerifyIdentifierAttribute: "app_service_id",
+			},
+		},
+	})
+}
+
+func TestAccAppServiceOnOffOnDemandResourceInvalidState(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_app_service_onoff_invalid_state_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAppServiceOnOffOnDemandResourceConfig(resourceName, globalAppServiceId, "frozen"),
+				ExpectError: regexp.MustCompile(`(?s)state must be either 'on' or 'off'|App Service activation failed`),
+			},
+		},
+	})
+}
+
+func TestAccAppServiceOnOffOnDemandResourceInvalidAppService(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_app_service_onoff_invalid_appsvc_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAppServiceOnOffOnDemandResourceConfig(resourceName, "33333333-3333-3333-3333-333333333333", "on"),
+				ExpectError: regexp.MustCompile(`(?s)App Service activation failed|switching on/off|not found|access to the requested resource is denied`),
+			},
+		},
+	})
+}
+
+func TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs(t *testing.T) {
+	tests := []struct {
+		name           string
+		organizationID string
+		projectID      string
+		clusterID      string
+		appServiceID   string
+	}{
+		{
+			name:           "organization_id",
+			organizationID: "not-a-uuid",
+			projectID:      "11111111-1111-1111-1111-111111111111",
+			clusterID:      "22222222-2222-2222-2222-222222222222",
+			appServiceID:   "33333333-3333-3333-3333-333333333333",
+		},
+		{
+			name:           "project_id",
+			organizationID: "00000000-0000-0000-0000-000000000000",
+			projectID:      "not-a-uuid",
+			clusterID:      "22222222-2222-2222-2222-222222222222",
+			appServiceID:   "33333333-3333-3333-3333-333333333333",
+		},
+		{
+			name:           "cluster_id",
+			organizationID: "00000000-0000-0000-0000-000000000000",
+			projectID:      "11111111-1111-1111-1111-111111111111",
+			clusterID:      "not-a-uuid",
+			appServiceID:   "33333333-3333-3333-3333-333333333333",
+		},
+		{
+			name:           "app_service_id",
+			organizationID: "00000000-0000-0000-0000-000000000000",
+			projectID:      "11111111-1111-1111-1111-111111111111",
+			clusterID:      "22222222-2222-2222-2222-222222222222",
+			appServiceID:   "not-a-uuid",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			resourceName := randomStringWithPrefix("tf_acc_app_service_onoff_invalid_uuid_")
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccAppServiceOnOffOnDemandResourceConfigWithIDs(
+							resourceName,
+							test.organizationID,
+							test.projectID,
+							test.clusterID,
+							test.appServiceID,
+							"on",
+						),
+						ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Match.*` + test.name + `.*must be a valid UUID`),
+					},
+				},
+			})
+		})
+	}
+}
+
+func TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "app_service_id",
+			body: fmt.Sprintf(`
+  organization_id = "%s"
+  project_id      = "%s"
+  cluster_id      = "%s"
+  state           = "on"
+`, globalOrgId, globalProjectId, globalClusterId),
+		},
+		{
+			name: "state",
+			body: fmt.Sprintf(`
+  organization_id = "%s"
+  project_id      = "%s"
+  cluster_id      = "%s"
+  app_service_id  = "%s"
+`, globalOrgId, globalProjectId, globalClusterId, globalAppServiceId),
+		},
+		{
+			name: "cluster_id",
+			body: fmt.Sprintf(`
+  organization_id = "%s"
+  project_id      = "%s"
+  app_service_id  = "%s"
+  state           = "on"
+`, globalOrgId, globalProjectId, globalAppServiceId),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			resourceName := randomStringWithPrefix("tf_acc_app_service_onoff_missing_")
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_app_service_onoff_ondemand" "%[2]s" {%[3]s}
+`, globalProviderBlock, resourceName, test.body),
+						ExpectError: regexp.MustCompile(fmt.Sprintf(`The argument "%s" is required`, test.name)),
+					},
+				},
+			})
+		})
+	}
+}
+
+func testAccAppServiceOnOffOnDemandResourceConfig(resourceName, appServiceID, state string) string {
+	return testAccAppServiceOnOffOnDemandResourceConfigWithIDs(
+		resourceName, globalOrgId, globalProjectId, globalClusterId, appServiceID, state,
+	)
+}
+
+func testAccAppServiceOnOffOnDemandResourceConfigWithIDs(resourceName, organizationID, projectID, clusterID, appServiceID, state string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_app_service_onoff_ondemand" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  app_service_id  = "%[6]s"
+  state           = "%[7]s"
+}
+`, globalProviderBlock, resourceName, organizationID, projectID, clusterID, appServiceID, state)
+}
+
+func generateAppServiceOnOffOnDemandImportId(resourceReference string) resource.ImportStateIdFunc {
+	return func(state *terraform.State) (string, error) {
+		res, ok := state.RootModule().Resources[resourceReference]
+		if !ok {
+			return "", fmt.Errorf("resource %s not found in state", resourceReference)
+		}
+		attrs := res.Primary.Attributes
+		return fmt.Sprintf(
+			"app_service_id=%s,cluster_id=%s,project_id=%s,organization_id=%s",
+			attrs["app_service_id"],
+			attrs["cluster_id"],
+			attrs["project_id"],
+			attrs["organization_id"],
+		), nil
+	}
+}

--- a/internal/resources/appservice_onoff.go
+++ b/internal/resources/appservice_onoff.go
@@ -252,7 +252,7 @@ func (a *AppServiceOnOffOnDemand) Read(ctx context.Context, req resource.ReadReq
 		appServiceId   = IDs[providerschema.AppServiceId]
 	)
 
-	refreshedState, err := a.retrieveAppServiceOnOff(ctx, organizationId, projectId, clusterId, appServiceId, state.State.String())
+	refreshedState, err := a.retrieveAppServiceOnOff(ctx, organizationId, projectId, clusterId, appServiceId, state.State.ValueString())
 	if err != nil {
 		resourceNotFound, _ := app_service_onoff_api.CheckResourceNotFoundError(err)
 		if resourceNotFound {


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-138941](https://jira.issues.couchbase.com/browse/AV-138941)

## Description

Stop app service on/off reporting spurious drift on every plan

Read passed state.State.String() into the refresh instead of ValueString().
StringValue.String() returns fmt.Sprintf("%q", value), so "on" was persisted
as "\"on\"" and every plan showed a change the apply could not settle.

Create and Update were already correct; only the refresh path was wrong. The
equivalent cluster resource does this correctly, which is why cluster on/off
never showed the behaviour.

Add acceptance tests for app_service_onoff_ondemand, previously the only
released resource with none - the empty-plan check after apply is exactly the
assertion this bug broke.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

```
TF_ACC=1 go test -timeout=60m -v ./acceptance_tests/ \
  -run 'TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs|TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields'

2026/08/03 12:29:31 project quota hit; reusing existing project 44c1cdb1-2b82-4fac-be27-7b00cd92a2ab
2026/08/03 12:32:33 cluster created - 8be620c2-ecb0-4bd1-84fb-f04c3555f8b6
2026/08/03 12:33:35 bucket created
2026/08/03 12:33:35 Created bucket: default (ZGVmYXVsdA==)
2026/08/03 12:34:37 metadata bucket created
2026/08/03 12:34:37 Created metadata bucket: metadata (bWV0YWRhdGE=)
2026/08/03 12:34:37 cluster created - 8be620c2-ecb0-4bd1-84fb-f04c3555f8b6
2026/08/03 12:39:41 app service created - f69b3165-b773-496f-a25c-d099423583fd
2026/08/03 12:40:44 app endpoint state Offline
=== RUN   TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs
=== RUN   TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/organization_id
=== PAUSE TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/organization_id
=== RUN   TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/project_id
=== PAUSE TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/project_id
=== RUN   TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/cluster_id
=== PAUSE TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/cluster_id
=== RUN   TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/app_service_id
=== PAUSE TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/app_service_id
=== CONT  TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/organization_id
=== CONT  TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/cluster_id
=== CONT  TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/app_service_id
=== CONT  TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/project_id
--- PASS: TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs (0.00s)
    --- PASS: TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/cluster_id (1.52s)
    --- PASS: TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/project_id (1.52s)
    --- PASS: TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/organization_id (1.59s)
    --- PASS: TestAccAppServiceOnOffOnDemandResourceInvalidUUIDs/app_service_id (1.59s)
=== RUN   TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields
=== RUN   TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/app_service_id
=== PAUSE TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/app_service_id
=== RUN   TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/state
=== PAUSE TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/state
=== RUN   TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/cluster_id
=== PAUSE TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/cluster_id
=== CONT  TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/app_service_id
=== CONT  TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/cluster_id
=== CONT  TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/state
--- PASS: TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields (0.00s)
    --- PASS: TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/state (0.13s)
    --- PASS: TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/app_service_id (0.13s)
    --- PASS: TestAccAppServiceOnOffOnDemandResourceMissingRequiredFields/cluster_id (0.13s)
PASS
ok      github.com/couchbasecloud/terraform-provider-couchbase-capella/acceptance_tests 1286.481s
```


## Further comments

[AV-138941]: https://couchbasecloud.atlassian.net/browse/AV-138941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ