### PR TITLE
[AV-138944] Add acceptance tests for network peer and private endpoint service data sources

### DIFF
--- a/acceptance_tests/network_peers_datasource_test.go
+++ b/acceptance_tests/network_peers_datasource_test.go
@@ -1,0 +1,175 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDatasourceNetworkPeers(t *testing.T) {
+	dataSourceName := randomStringWithPrefix("tf_acc_network_peers_ds_")
+	dataSourceReference := "data.couchbase-capella_network_peers." + dataSourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkPeersDataSourceConfig(dataSourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dataSourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dataSourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(dataSourceReference, "data.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkPeersDataSourceConfig(dataSourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_network_peers" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+}
+`, globalProviderBlock, dataSourceName, globalOrgId, globalProjectId, globalClusterId)
+}
+
+
+func TestAccDatasourceNetworkPeersMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "organization_id",
+			body: fmt.Sprintf(`
+  project_id = "%s"
+  cluster_id = "%s"
+`, globalProjectId, globalClusterId),
+		},
+		{
+			name: "project_id",
+			body: fmt.Sprintf(`
+  organization_id = "%s"
+  cluster_id      = "%s"
+`, globalOrgId, globalClusterId),
+		},
+		{
+			name: "cluster_id",
+			body: fmt.Sprintf(`
+  organization_id = "%s"
+  project_id      = "%s"
+`, globalOrgId, globalProjectId),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			dataSourceName := randomStringWithPrefix("tf_acc_network_peers_ds_missing_")
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_network_peers" "%[2]s" {%[3]s}
+`, globalProviderBlock, dataSourceName, test.body),
+						ExpectError: regexp.MustCompile(fmt.Sprintf(`The argument "%s" is required`, test.name)),
+					},
+				},
+			})
+		})
+	}
+}
+
+
+func TestAccDatasourceAzureNetworkPeerCommandInvalidCluster(t *testing.T) {
+	dataSourceName := randomStringWithPrefix("tf_acc_azure_np_command_invalid_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAzureNetworkPeerCommandConfig(dataSourceName, "22222222-2222-2222-2222-222222222222"),
+				ExpectError: regexp.MustCompile(`(?s)Error Reading Azure network peer command|Could not read Azure network peer command`),
+			},
+		},
+	})
+}
+
+
+func TestAccDatasourceAzureNetworkPeerCommandMissingRequiredFields(t *testing.T) {
+	for _, attr := range []string{"tenant_id", "subscription_id", "resource_group", "vnet_id", "vnet_peering_service_principal"} {
+		attr := attr
+		t.Run(attr, func(t *testing.T) {
+			dataSourceName := randomStringWithPrefix("tf_acc_azure_np_command_missing_")
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config:      testAccAzureNetworkPeerCommandConfigOmitting(dataSourceName, attr),
+						ExpectError: regexp.MustCompile(fmt.Sprintf(`The argument "%s" is required`, attr)),
+					},
+				},
+			})
+		})
+	}
+}
+
+func testAccAzureNetworkPeerCommandConfig(dataSourceName, clusterID string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_azure_network_peer_command" "%[2]s" {
+  organization_id                = "%[3]s"
+  project_id                     = "%[4]s"
+  cluster_id                     = "%[5]s"
+  tenant_id                      = "33333333-3333-3333-3333-333333333333"
+  subscription_id                = "44444444-4444-4444-4444-444444444444"
+  resource_group                 = "tf-acc-resource-group"
+  vnet_id                        = "tf-acc-vnet"
+  vnet_peering_service_principal = "55555555-5555-5555-5555-555555555555"
+}
+`, globalProviderBlock, dataSourceName, globalOrgId, globalProjectId, clusterID)
+}
+
+
+func testAccAzureNetworkPeerCommandConfigOmitting(dataSourceName, omit string) string {
+	attrs := map[string]string{
+		"organization_id":                globalOrgId,
+		"project_id":                     globalProjectId,
+		"cluster_id":                     globalClusterId,
+		"tenant_id":                      "33333333-3333-3333-3333-333333333333",
+		"subscription_id":                "44444444-4444-4444-4444-444444444444",
+		"resource_group":                 "tf-acc-resource-group",
+		"vnet_id":                        "tf-acc-vnet",
+		"vnet_peering_service_principal": "55555555-5555-5555-5555-555555555555",
+	}
+	delete(attrs, omit)
+
+	var body string
+	// Iterate a fixed key order so the generated config is stable across runs.
+	for _, k := range []string{
+		"organization_id", "project_id", "cluster_id", "tenant_id",
+		"subscription_id", "resource_group", "vnet_id", "vnet_peering_service_principal",
+	} {
+		if v, ok := attrs[k]; ok {
+			body += fmt.Sprintf("  %s = %q\n", k, v)
+		}
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_azure_network_peer_command" "%[2]s" {
+%[3]s}
+`, globalProviderBlock, dataSourceName, body)
+}

--- a/acceptance_tests/private_endpoint_acceptance_test.go
+++ b/acceptance_tests/private_endpoint_acceptance_test.go
@@ -16,14 +16,16 @@ import (
 func TestAccPrivateEndpointServiceEnableDisable(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_private_endpoint_service_")
 	dataSourceName := randomStringWithPrefix("tf_acc_private_endpoints_ds_")
+	serviceDataSourceName := randomStringWithPrefix("tf_acc_private_endpoint_service_ds_")
 	resourceReference := "couchbase-capella_private_endpoint_service." + resourceName
 	dataSourceReference := "data.couchbase-capella_private_endpoints." + dataSourceName
+	serviceDataSourceReference := "data.couchbase-capella_private_endpoint_service." + serviceDataSourceName
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrivateEndpointsDataSourceNoEndpointConfig(resourceName, dataSourceName),
+				Config: testAccPrivateEndpointsDataSourceNoEndpointConfig(resourceName, dataSourceName, serviceDataSourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
@@ -34,19 +36,79 @@ func TestAccPrivateEndpointServiceEnableDisable(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceReference, "cluster_id", globalClusterId),
 					resource.TestCheckResourceAttrSet(dataSourceReference, "private_endpoint_dns"),
 					resource.TestCheckResourceAttr(dataSourceReference, "data.#", "0"),
+					// The service data source sees the enabled service and its service_name.
+					resource.TestCheckResourceAttr(serviceDataSourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(serviceDataSourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(serviceDataSourceReference, "cluster_id", globalClusterId),
+					resource.TestCheckResourceAttr(serviceDataSourceReference, "enabled", "true"),
+					resource.TestCheckResourceAttrSet(serviceDataSourceReference, "status"),
+					resource.TestCheckResourceAttrSet(serviceDataSourceReference, "service_name"),
 				),
 			},
 			{
-				Config: testAccPrivateEndpointServiceEnableConfig(resourceName, false),
+				Config: testAccPrivateEndpointServiceDisableWithDataSourceConfig(resourceName, serviceDataSourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
 					resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
 					resource.TestCheckResourceAttr(resourceReference, "enabled", "false"),
+					// The data source follows the service to disabled.
+					resource.TestCheckResourceAttr(serviceDataSourceReference, "enabled", "false"),
 				),
 			},
 		},
 	})
+}
+
+// TestAccDatasourcePrivateEndpointServiceMissingRequiredFields verifies each required
+// identifier is enforced by Terraform before any API call is made.
+func TestAccDatasourcePrivateEndpointServiceMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "organization_id",
+			body: fmt.Sprintf(`
+  project_id = "%s"
+  cluster_id = "%s"
+`, globalProjectId, globalClusterId),
+		},
+		{
+			name: "project_id",
+			body: fmt.Sprintf(`
+  organization_id = "%s"
+  cluster_id      = "%s"
+`, globalOrgId, globalClusterId),
+		},
+		{
+			name: "cluster_id",
+			body: fmt.Sprintf(`
+  organization_id = "%s"
+  project_id      = "%s"
+`, globalOrgId, globalProjectId),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			dataSourceName := randomStringWithPrefix("tf_acc_pe_service_ds_missing_")
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_private_endpoint_service" "%[2]s" {%[3]s}
+`, globalProviderBlock, dataSourceName, test.body),
+						ExpectError: regexp.MustCompile(fmt.Sprintf(`The argument "%s" is required`, test.name)),
+					},
+				},
+			})
+		})
+	}
 }
 
 // TestAccAWSPrivateEndpointCommandInvalidVPCID verifies that the AWS private endpoint
@@ -158,7 +220,7 @@ func testAccPrivateEndpointServiceEnableConfig(resourceName string, enabled bool
 		`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, enabled)
 }
 
-func testAccPrivateEndpointsDataSourceNoEndpointConfig(serviceResourceName, dataSourceName string) string {
+func testAccPrivateEndpointsDataSourceNoEndpointConfig(serviceResourceName, dataSourceName, serviceDataSourceName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -176,7 +238,39 @@ data "couchbase-capella_private_endpoints" "%[3]s" {
 
   depends_on = [couchbase-capella_private_endpoint_service.%[2]s]
 }
-`, globalProviderBlock, serviceResourceName, dataSourceName, globalOrgId, globalProjectId, globalClusterId)
+
+data "couchbase-capella_private_endpoint_service" "%[7]s" {
+  organization_id = "%[4]s"
+  project_id      = "%[5]s"
+  cluster_id      = "%[6]s"
+
+  depends_on = [couchbase-capella_private_endpoint_service.%[2]s]
+}
+`, globalProviderBlock, serviceResourceName, dataSourceName, globalOrgId, globalProjectId, globalClusterId, serviceDataSourceName)
+}
+
+// testAccPrivateEndpointServiceDisableWithDataSourceConfig disables the service and reads
+// it back through the data source in the same apply, so the data source is exercised
+// against a disabled service as well as an enabled one.
+func testAccPrivateEndpointServiceDisableWithDataSourceConfig(serviceResourceName, serviceDataSourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_private_endpoint_service" "%[2]s" {
+  organization_id = "%[4]s"
+  project_id      = "%[5]s"
+  cluster_id      = "%[6]s"
+  enabled         = false
+}
+
+data "couchbase-capella_private_endpoint_service" "%[3]s" {
+  organization_id = "%[4]s"
+  project_id      = "%[5]s"
+  cluster_id      = "%[6]s"
+
+  depends_on = [couchbase-capella_private_endpoint_service.%[2]s]
+}
+`, globalProviderBlock, serviceResourceName, serviceDataSourceName, globalOrgId, globalProjectId, globalClusterId)
 }
 
 // TestAccPrivateEndpointsInvalidEndpointID verifies that the private endpoints resource rejects


### PR DESCRIPTION

<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-138944

## Description

**Summary**
Adds acceptance test coverage for three data sources that previously had none, and extends the existing private endpoint service test to also read the service back through its data source. Test-only change — no provider code is touched.

**Changes**
**New: [acceptance_tests/network_peers_datasource_test.go]**

- TestAccDatasourceNetworkPeers — reads couchbase-capella_network_peers against the global test cluster and asserts the identifiers round-trip and that data.# is 0 when no peers exist.
- TestAccDatasourceNetworkPeersMissingRequiredFields — table-driven, one subtest per required identifier (organization_id, project_id, cluster_id), asserting Terraform rejects the config at plan time.
- TestAccDatasourceAzureNetworkPeerCommandInvalidCluster — asserts couchbase-capella_azure_network_peer_command surfaces a read error for a non-existent cluster ID.
- TestAccDatasourceAzureNetworkPeerCommandMissingRequiredFields — one subtest per Azure-specific required attribute (tenant_id, subscription_id, resource_group, vnet_id, vnet_peering_service_principal). The config builder walks a fixed key order so the generated HCL is stable across runs.

**Extended: [acceptance_tests/private_endpoint_acceptance_test.go]**

- TestAccPrivateEndpointServiceEnableDisable now also declares a couchbase-capella_private_endpoint_service data source alongside the resource. Step 1 asserts the data source reports enabled = true with status and service_name set; step 2 disables the service and asserts the data source follows to enabled = false. This exercises the data source against both an enabled and a disabled service within the existing test's lifecycle, at no extra cluster cost.
- New TestAccDatasourcePrivateEndpointServiceMissingRequiredFields — same table-driven required-field pattern for the service data source.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments