### PR TITLE
[AV-139105] Add sanity test suite as the pull request gate

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,9 +1,5 @@
 name: Acceptance Tests
 
-# The full acceptance suite. Pull requests are gated by the P0 subset in
-# sanity-tests.yml instead: running both against the same Capella organization
-# duplicates cost and lets the two runs collide on shared test fixtures.
-# Use workflow_dispatch to run the full suite against a branch on demand.
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/sanity-tests.yml
+++ b/.github/workflows/sanity-tests.yml
@@ -1,22 +1,27 @@
-name: Acceptance Tests
+name: Sanity Tests
 
-# The full acceptance suite. Pull requests are gated by the P0 subset in
-# sanity-tests.yml instead: running both against the same Capella organization
-# duplicates cost and lets the two runs collide on shared test fixtures.
-# Use workflow_dispatch to run the full suite against a branch on demand.
+# Runs the P0 acceptance test suite (acceptance_tests/sanity.list) as the
+# pull request gate. The full acceptance suite lives in acceptance-tests.yml.
+# No paths filter: the sanity suite gates every pull request.
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'acceptance_tests/**'
-      - 'internal/**'
+  pull_request:
+
+# Serialize per PR so two runs of the same branch do not provision against the
+# shared Capella organization at once. cancel-in-progress stays false on
+# purpose: cancelling mid-run orphans real clusters and app services.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
-  build:
-    name: Build
+  sanity:
+    name: P0 Sanity Suite
     runs-on: ubuntu-latest
+    timeout-minutes: 200
 
     env:
       TF_VAR_auth_token: ${{ secrets.CAPELLA_AUTH_TOKEN }}
@@ -41,5 +46,5 @@ jobs:
         with:
           terraform_version: 1.14.9
           terraform_wrapper: false
-      - name: Run acceptance tests
-        run: make testacc
+      - name: Run sanity tests
+        run: make testacc-sanity

--- a/.github/workflows/sanity-tests.yml
+++ b/.github/workflows/sanity-tests.yml
@@ -33,15 +33,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4 # this action has caching built in
+        # Built-in caching keys on go.sum and covers the build cache as well as
+        # ~/go/pkg/mod, so it restores across runs. A hand-rolled actions/cache
+        # step keyed on github.run_id never would.
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-          cache: false
+          cache: true
         id: go
-      - uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: cache-${{ github.run_id }}
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.14.9

--- a/.github/workflows/sanity-tests.yml
+++ b/.github/workflows/sanity-tests.yml
@@ -1,15 +1,11 @@
 name: Sanity Tests
 
 # Runs the P0 acceptance test suite (acceptance_tests/sanity.list) as the
-# pull request gate. The full acceptance suite lives in acceptance-tests.yml.
-# No paths filter: the sanity suite gates every pull request.
+# pull request gate.
 on:
   workflow_dispatch:
   pull_request:
 
-# Serialize per PR so two runs of the same branch do not provision against the
-# shared Capella organization at once. cancel-in-progress stays false on
-# purpose: cancelling mid-run orphans real clusters and app services.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
@@ -33,9 +29,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Set up Go
-        # Built-in caching keys on go.sum and covers the build cache as well as
-        # ~/go/pkg/mod, so it restores across runs. A hand-rolled actions/cache
-        # step keyed on github.run_id never would.
+        
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'

--- a/Makefile
+++ b/Makefile
@@ -103,19 +103,6 @@ docs-lint: ## Lint documentation
 TEST_FILES ?= $$(go list ./... | grep -v acceptance_tests)
 TEST_FLAGS ?= -short -cover -race -coverprofile .testCoverage.txt
 
-# `go test -parallel` defaults to GOMAXPROCS, which caps concurrency by core
-# count. Acceptance tests are I/O bound - they spend their time polling Capella
-# while it provisions clusters - so the default hands a 4-vCPU CI runner 4 lanes
-# where a 14-core laptop gets 14, making CI several times slower for no reason.
-#
-# The real ceiling is the Capella organization's quota and rate limits, not the
-# machine: raise with care and watch for 429s and quota errors.
-#
-# Exported so scripts/run-test-list.sh picks up the same override, keeping
-# `make testacc` and `make testacc-sanity` on one knob.
-TEST_PARALLELISM ?= 16
-export TEST_PARALLELISM
-
 .PHONY: test
 test: ## Run unit tests
 	@go test $(TEST_FILES) $(TEST_FLAGS)
@@ -125,7 +112,7 @@ testacc: ## Run acceptance tests (requires TF_VAR_auth_token, TF_VAR_host, TF_VA
 	@[ "${TF_VAR_auth_token}" ] || ( echo "ERROR: export TF_VAR_auth_token before running acceptance tests"; exit 1 )
 	@[ "${TF_VAR_host}" ] || ( echo "ERROR: export TF_VAR_host before running acceptance tests"; exit 1 )
 	@[ "${TF_VAR_organization_id}" ] || ( echo "ERROR: export TF_VAR_organization_id before running acceptance tests"; exit 1 )
-	@TF_ACC=1 go test -timeout=240m -parallel $(TEST_PARALLELISM) -v ./acceptance_tests/
+	@TF_ACC=1 go test -timeout=240m -v ./acceptance_tests/
 
 TEST_LIST ?= acceptance_tests/sanity.list
 

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,19 @@ docs-lint: ## Lint documentation
 TEST_FILES ?= $$(go list ./... | grep -v acceptance_tests)
 TEST_FLAGS ?= -short -cover -race -coverprofile .testCoverage.txt
 
+# `go test -parallel` defaults to GOMAXPROCS, which caps concurrency by core
+# count. Acceptance tests are I/O bound - they spend their time polling Capella
+# while it provisions clusters - so the default hands a 4-vCPU CI runner 4 lanes
+# where a 14-core laptop gets 14, making CI several times slower for no reason.
+#
+# The real ceiling is the Capella organization's quota and rate limits, not the
+# machine: raise with care and watch for 429s and quota errors.
+#
+# Exported so scripts/run-test-list.sh picks up the same override, keeping
+# `make testacc` and `make testacc-sanity` on one knob.
+TEST_PARALLELISM ?= 16
+export TEST_PARALLELISM
+
 .PHONY: test
 test: ## Run unit tests
 	@go test $(TEST_FILES) $(TEST_FLAGS)
@@ -112,7 +125,7 @@ testacc: ## Run acceptance tests (requires TF_VAR_auth_token, TF_VAR_host, TF_VA
 	@[ "${TF_VAR_auth_token}" ] || ( echo "ERROR: export TF_VAR_auth_token before running acceptance tests"; exit 1 )
 	@[ "${TF_VAR_host}" ] || ( echo "ERROR: export TF_VAR_host before running acceptance tests"; exit 1 )
 	@[ "${TF_VAR_organization_id}" ] || ( echo "ERROR: export TF_VAR_organization_id before running acceptance tests"; exit 1 )
-	@TF_ACC=1 go test -timeout=240m -v ./acceptance_tests/
+	@TF_ACC=1 go test -timeout=240m -parallel $(TEST_PARALLELISM) -v ./acceptance_tests/
 
 TEST_LIST ?= acceptance_tests/sanity.list
 

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,16 @@ testacc: ## Run acceptance tests (requires TF_VAR_auth_token, TF_VAR_host, TF_VA
 	@[ "${TF_VAR_organization_id}" ] || ( echo "ERROR: export TF_VAR_organization_id before running acceptance tests"; exit 1 )
 	@TF_ACC=1 go test -timeout=180m -v ./acceptance_tests/
 
+TEST_LIST ?= acceptance_tests/sanity.list
+
+.PHONY: testacc-list
+testacc-list: ## Run only the acceptance tests named in TEST_LIST (default: acceptance_tests/sanity.list)
+	@./scripts/run-test-list.sh $(TEST_LIST)
+
+.PHONY: testacc-sanity
+testacc-sanity: ## Run the P0 sanity acceptance test suite
+	@$(MAKE) testacc-list TEST_LIST=acceptance_tests/sanity.list
+
 # ============================================================================
 # Documentation
 # ============================================================================

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ testacc: ## Run acceptance tests (requires TF_VAR_auth_token, TF_VAR_host, TF_VA
 	@[ "${TF_VAR_auth_token}" ] || ( echo "ERROR: export TF_VAR_auth_token before running acceptance tests"; exit 1 )
 	@[ "${TF_VAR_host}" ] || ( echo "ERROR: export TF_VAR_host before running acceptance tests"; exit 1 )
 	@[ "${TF_VAR_organization_id}" ] || ( echo "ERROR: export TF_VAR_organization_id before running acceptance tests"; exit 1 )
-	@TF_ACC=1 go test -timeout=180m -v ./acceptance_tests/
+	@TF_ACC=1 go test -timeout=240m -v ./acceptance_tests/
 
 TEST_LIST ?= acceptance_tests/sanity.list
 

--- a/acceptance_tests/sanity.list
+++ b/acceptance_tests/sanity.list
@@ -3,15 +3,7 @@
 # ========================================
 # This list contains the P0 tests: the primary happy-path (create/read/update/
 # import/delete) test for every resource and data source the provider exposes.
-# Negative/validation-only tests (invalid UUIDs, missing required fields, bad
-# enums) are P1+ and deliberately excluded, as are tests that unconditionally
-# t.Skip (open bugs or manual-only runs).
 #
-# Run with: make testacc-list (or ./scripts/run-test-list.sh acceptance_tests/sanity.list)
-# Lines starting with # are comments and will be ignored
-#
-# NOTE: names are matched with an anchored regex (^(...)$) by
-# scripts/run-test-list.sh, so a typo silently runs nothing. Keep names exact.
 # ========================================
 
 # ----------------------------------------
@@ -135,9 +127,6 @@ TestAccAllowListWithRequiredFields
 # Tests listing allowlists via data source
 TestAccDatasourceAllowlists
 
-# EXCLUDED FROM THE PR GATE: TestAccPrivateEndpointServiceEnableDisable is
-# sequential and each enable/disable is a cluster-level operation. Runs on main.
-
 # Tests reading the app services allowed CIDRs via data source
 TestAccAppServicesCIDRDataSource
 
@@ -162,11 +151,6 @@ TestAccDatasourceUsers
 # ----------------------------------------
 # 11. APP SERVICES (Data Sync)
 # ----------------------------------------
-# EXCLUDED FROM THE PR GATE: TestAppServiceResource and
-# TestAccAppServiceResourceOptionalFieldsAndScale are sequential and each
-# provisions a cluster plus an app service (the second also scales it), which
-# together dominated the gate's wall clock. Both run on main.
-# The log streaming test below still covers the app service API surface.
 
 # Tests listing app services via data source
 TestAccDatasourceAppServices

--- a/acceptance_tests/sanity.list
+++ b/acceptance_tests/sanity.list
@@ -1,9 +1,17 @@
 # ========================================
-# Sanity Test Suite - Critical Path Tests
+# Sanity Test Suite - P0 / Critical Path Tests
 # ========================================
-# This list contains essential smoke tests that verify core functionality
+# This list contains the P0 tests: the primary happy-path (create/read/update/
+# import/delete) test for every resource and data source the provider exposes.
+# Negative/validation-only tests (invalid UUIDs, missing required fields, bad
+# enums) are P1+ and deliberately excluded, as are tests that unconditionally
+# t.Skip (open bugs or manual-only runs).
+#
 # Run with: make testacc-list (or ./scripts/run-test-list.sh acceptance_tests/sanity.list)
 # Lines starting with # are comments and will be ignored
+#
+# NOTE: names are matched with an anchored regex (^(...)$) by
+# scripts/run-test-list.sh, so a typo silently runs nothing. Keep names exact.
 # ========================================
 
 # ----------------------------------------
@@ -18,23 +26,95 @@ TestAccReadOrganization
 # Tests basic project creation with required fields only
 TestAccProjectCreateWithReqFields
 
+# Tests full project lifecycle: create, import and update
+TestAccProjectResource
+
+# Tests reading a single project via data source
+TestAccReadProject
+
+# Tests listing projects via data source
+TestAccDatasourceProjects
+
 # ----------------------------------------
 # 3. CLUSTER (Critical Resource)
 # ----------------------------------------
 # Tests AWS cluster creation with only required fields - most common use case
 TestAccClusterResourceWithOnlyReqFieldAWS
 
+# Tests AWS cluster creation with optional fields populated
+TestAccClusterResourceWithOptionalFieldAWS
+
 # Tests GCP cluster creation and horizontal scaling
 TestAccClusterResourceGCP
 
+# Tests Azure disk auto-expansion feature
+TestAccClusterResourceAzureDiskAutoExpansion
+
+# Tests reading a single cluster via data source
+TestAccReadClusterDatasource
+
+# Tests reading cluster stats via data source
+TestAccDatasourceClusterStats
+
+# Tests reading the cluster certificate via data source
+TestAccDatasourceCertificate
+
 # ----------------------------------------
-# 4. BUCKET (Data Layer)
+# 4. CLUSTER LIFECYCLE (On/Off, Deletion Protection)
 # ----------------------------------------
+# Tests turning a cluster off and on on demand
+TestAccClusterOnOffOnDemandResource
+
+# Tests scheduled cluster on/off windows
+TestAccClusterOnOffScheduleResource
+
+# Tests reading the cluster on/off schedule via data source
+TestAccDatasourceClusterOnOffSchedule
+
+# Tests cluster deletion protection
+TestAccClusterDeletionProtectionResource
+
+# ----------------------------------------
+# 5. FREE TIER CLUSTER
+# ----------------------------------------
+# Tests free tier cluster create, update, on/off and delete
+TestAccFreeTierClusterLifecycle
+
+# ----------------------------------------
+# 6. DATA MANAGEMENT (Bucket / Scope / Collection)
+# ----------------------------------------
+# Tests bucket creation with required fields only
+TestAccBucketResourceRequiredOnly
+
+# Tests updating a bucket in place
+TestAccBucketResourceUpdate
+
+# Tests listing buckets via data source
+TestAccDatasourceBuckets
+
+# Tests flushing a bucket
+TestAccFlushBucketResource
+
+# Tests scope creation
+TestAccScopeResource
+
+# Tests listing scopes via data source
+TestAccDatasourceScopes
+
+# Tests collection creation without a TTL
+TestAccCollectionResourceNoTTL
+
+# Tests listing collections via data source
+TestAccDatasourceCollections
+
 # Tests sample bucket creation (travel-sample)
 TestAccSampleBucket
 
+# Tests listing sample buckets via data source
+TestAccDatasourceSampleBuckets
+
 # ----------------------------------------
-# 5. DATABASE CREDENTIALS (Access Control)
+# 7. DATABASE CREDENTIALS (Access Control)
 # ----------------------------------------
 # Tests creating database credentials with required fields
 TestAccDatabaseCredentialWithReqFields
@@ -42,56 +122,182 @@ TestAccDatabaseCredentialWithReqFields
 # Tests creating database credentials with optional password field
 TestAccDatabaseCredentialWithOptionalFields
 
+# Tests listing database credentials via data source
+TestAccDatasourceDatabaseCredentials
+
 # ----------------------------------------
-# 6. SECURITY & NETWORKING
+# 8. SECURITY & NETWORKING
 # ----------------------------------------
 # Tests IP allowlist creation with required fields
 TestAccAllowListWithRequiredFields
 
-# Tests enabling private endpoint service for secure connectivity
-TestAccPrivateEndpointServiceEnable
+# Tests listing allowlists via data source
+TestAccDatasourceAllowlists
+
+# Tests enabling and disabling private endpoint service for secure connectivity
+TestAccPrivateEndpointServiceEnableDisable
+
+# Tests the private endpoints data source end to end.
+# Skips unless ACC_AWS_REGION / ACC_AWS_VPC_ID / ACC_AWS_SUBNET_IDS /
+# ACC_AWS_VPC_CIDR and AWS credentials are set.
+TestAccPrivateEndpointsDataSourceWithEndpoint
+
+# Tests reading the app services allowed CIDRs via data source
+TestAccAppServicesCIDRDataSource
 
 # ----------------------------------------
-# 7. API KEYS (Authentication)
+# 9. API KEYS (Authentication)
 # ----------------------------------------
 # Tests API key creation with only required fields
 TestAccApiKeyResourceWithOnlyReqField
 
+# Tests listing API keys via data source
+TestAccDatasourceApiKeys
+
 # ----------------------------------------
-# 8. USERS (Access Management)
+# 10. USERS (Access Management)
 # ----------------------------------------
 # Tests user creation, import, and update operations
 TestAccUserResource
 
+# Tests listing users via data source
+TestAccDatasourceUsers
+
 # ----------------------------------------
-# 9. APP SERVICES (Data Sync)
+# 11. APP SERVICES (Data Sync)
 # ----------------------------------------
 # Tests app service creation (non-parallel test)
 TestAppServiceResource
 
-# Tests app endpoint creation
+# Tests app service creation with optional fields and scaling
+TestAccAppServiceResourceOptionalFieldsAndScale
+
+# Tests listing app services via data source
+TestAccDatasourceAppServices
+
+# Tests app service log streaming resource and data source
+TestAccAppServiceLogStreaming
+
+# ----------------------------------------
+# 12. APP ENDPOINTS
+# ----------------------------------------
+# Tests app endpoint creation (includes resync and logging config steps)
 TestAccAppEndpoint
 
 # Tests app endpoint activation status management
 TestAccAppEndpointActivationStatus
 
+# Tests reading a single app endpoint via data source
+TestAccAppEndpointDataSource
+
+# Tests the filtered app endpoints list data source
+# (the unfiltered TestAccAppEndpointsDataSource is skipped under AV-130079)
+TestAccAppEndpointsDataSourceFiltered
+
+# Tests reading app endpoint activation status via data source
+TestAccAppEndpointActivationStatusDataSource
+
+# Tests app endpoint access control function
+TestAccAppEndpointAccessControlFunction
+
+# Tests app endpoint OIDC provider configuration
+TestAccAppEndpointOidcProvider
+
+# Tests app endpoint CORS configuration
+TestAccAppEndpointCorsResource
+
+# Tests app endpoint import filter
+TestAccAppEndpointImportFilter
+
 # ----------------------------------------
-# 10. QUERY INDEXES (Performance)
+# 13. QUERY INDEXES (Performance)
 # ----------------------------------------
 # Tests GSI (Global Secondary Index) creation
 TestAccGSI
 
+# Tests listing query indexes via data source
+TestAccDatasourceQueryIndexes
+
+# Tests the query index monitor data source against a ready index
+TestAccDatasourceQueryIndexMonitorReady
+
 # ----------------------------------------
-# 11. BACKUP & RECOVERY
+# 14. EVENTING
 # ----------------------------------------
+# Tests eventing function creation with required fields only
+TestAccEventingFunctionResourceRequiredOnly
+
+# Tests reading a single eventing function via data source
+TestAccDatasourceEventingFunction
+
+# Tests listing eventing functions via data source
+TestAccDatasourceEventingFunctions
+
+# Tests exporting an eventing function via data source
+TestAccDatasourceEventingFunctionExport
+
+# ----------------------------------------
+# 15. BACKUP & RECOVERY
+# ----------------------------------------
+# Tests on-demand backup creation
+TestAccBackupResource
+
+# Tests backup schedule configuration
+TestAccBackupScheduleResource
+
 # Tests snapshot backup creation
 TestAccSnapshotBackupResource
 
 # Tests snapshot backup schedule configuration
 TestAccSnapshotBackupScheduleResource
 
+# Tests reading a single cloud snapshot backup via data source
+TestAccCloudSnapshotBackupDatasource
+
+# Tests listing cloud snapshot backups for a cluster via data source
+TestAccCloudSnapshotBackupsDatasource
+
+# Tests listing cloud snapshot backups for a project via data source
+TestAccCloudProjectSnapshotBackupsDatasource
+
+# Tests reading the cloud snapshot backup schedule via data source
+TestAccDatasourceCloudSnapshotBackupSchedule
+
+# Tests reading a single cloud snapshot restore via data source
+TestAccDatasourceCloudSnapshotRestore
+
+# Tests listing cloud snapshot restores via data source
+TestAccDatasourceCloudSnapshotRestores
+
 # ----------------------------------------
-# 12. AZURE-SPECIFIC FEATURES
+# 16. AUDIT LOGGING
 # ----------------------------------------
-# Tests Azure disk auto-expansion feature
-TestAccClusterResourceAzureDiskAutoExpansion
+# Tests audit log settings resource
+TestAccAuditLogSettingsResource
+
+# Tests reading audit log settings via data source
+TestAccDatasourceAuditLogSettings
+
+# Tests reading audit log event IDs via data source
+TestAccDatasourceAuditLogEventIDs
+
+# ----------------------------------------
+# 17. DATA API
+# ----------------------------------------
+# Tests data API resource and data source
+TestAccDataApiResource
+
+# ----------------------------------------
+# 18. EVENTS
+# ----------------------------------------
+# Tests listing organization events via data source
+TestAccDatasourceEvents
+
+# Tests reading a single organization event via data source
+TestAccDatasourceEvent
+
+# Tests listing project events via data source
+TestAccDatasourceProjectEvents
+
+# Tests reading a single project event via data source
+TestAccDatasourceProjectEvent

--- a/acceptance_tests/sanity.list
+++ b/acceptance_tests/sanity.list
@@ -77,8 +77,9 @@ TestAccClusterDeletionProtectionResource
 # ----------------------------------------
 # 5. FREE TIER CLUSTER
 # ----------------------------------------
-# Tests free tier cluster create, update, on/off and delete
-TestAccFreeTierClusterLifecycle
+# EXCLUDED FROM THE PR GATE: TestAccFreeTierClusterLifecycle is sequential and
+# builds a free tier cluster, bucket, app service and an on/off cycle. It runs
+# in the full suite on main.
 
 # ----------------------------------------
 # 6. DATA MANAGEMENT (Bucket / Scope / Collection)
@@ -134,8 +135,8 @@ TestAccAllowListWithRequiredFields
 # Tests listing allowlists via data source
 TestAccDatasourceAllowlists
 
-# Tests enabling and disabling private endpoint service for secure connectivity
-TestAccPrivateEndpointServiceEnableDisable
+# EXCLUDED FROM THE PR GATE: TestAccPrivateEndpointServiceEnableDisable is
+# sequential and each enable/disable is a cluster-level operation. Runs on main.
 
 # Tests reading the app services allowed CIDRs via data source
 TestAccAppServicesCIDRDataSource
@@ -161,11 +162,11 @@ TestAccDatasourceUsers
 # ----------------------------------------
 # 11. APP SERVICES (Data Sync)
 # ----------------------------------------
-# Tests app service creation (non-parallel test)
-TestAppServiceResource
-
-# Tests app service creation with optional fields and scaling
-TestAccAppServiceResourceOptionalFieldsAndScale
+# EXCLUDED FROM THE PR GATE: TestAppServiceResource and
+# TestAccAppServiceResourceOptionalFieldsAndScale are sequential and each
+# provisions a cluster plus an app service (the second also scales it), which
+# together dominated the gate's wall clock. Both run on main.
+# The log streaming test below still covers the app service API surface.
 
 # Tests listing app services via data source
 TestAccDatasourceAppServices
@@ -279,8 +280,8 @@ TestAccDatasourceAuditLogEventIDs
 # ----------------------------------------
 # 17. DATA API
 # ----------------------------------------
-# Tests data API resource and data source
-TestAccDataApiResource
+# EXCLUDED FROM THE PR GATE: TestAccDataApiResource is sequential and drives
+# enable -> peering -> disable transitions on the shared cluster. Runs on main.
 
 # ----------------------------------------
 # 18. EVENTS

--- a/acceptance_tests/sanity.list
+++ b/acceptance_tests/sanity.list
@@ -137,11 +137,6 @@ TestAccDatasourceAllowlists
 # Tests enabling and disabling private endpoint service for secure connectivity
 TestAccPrivateEndpointServiceEnableDisable
 
-# Tests the private endpoints data source end to end.
-# Skips unless ACC_AWS_REGION / ACC_AWS_VPC_ID / ACC_AWS_SUBNET_IDS /
-# ACC_AWS_VPC_CIDR and AWS credentials are set.
-TestAccPrivateEndpointsDataSourceWithEndpoint
-
 # Tests reading the app services allowed CIDRs via data source
 TestAccAppServicesCIDRDataSource
 

--- a/scripts/run-test-list.sh
+++ b/scripts/run-test-list.sh
@@ -3,6 +3,10 @@
 # Usage: ./scripts/run-test-list.sh acceptance_tests/sanity.list
 
 set -e
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ACC_DIR="$REPO_ROOT/acceptance_tests"
 
 if [ -z "$1" ]; then
     echo "Usage: $0 <test-list-file>"
@@ -17,6 +21,11 @@ if [ ! -f "$TEST_LIST_FILE" ]; then
     exit 1
 fi
 
+# Resolve the list to an absolute path before moving to the repo root, so a
+# relative argument keeps working from any directory.
+TEST_LIST_FILE="$(cd "$(dirname "$TEST_LIST_FILE")" && pwd)/$(basename "$TEST_LIST_FILE")"
+cd "$REPO_ROOT"
+
 # Check required environment variables
 if [ -z "$TF_VAR_auth_token" ] || [ -z "$TF_VAR_host" ] || [ -z "$TF_VAR_organization_id" ]; then
     echo "ERROR: Required environment variables not set"
@@ -24,17 +33,54 @@ if [ -z "$TF_VAR_auth_token" ] || [ -z "$TF_VAR_host" ] || [ -z "$TF_VAR_organiz
     exit 1
 fi
 
-# Read test names from file (skip comments and empty lines)
-TEST_PATTERN=$(grep -v '^#' "$TEST_LIST_FILE" | grep -v '^[[:space:]]*$' | tr '\n' '|' | sed 's/|$//')
+# Read test names from file (skip comments and empty lines, tolerate CRLF and
+# stray indentation, drop duplicates while preserving file order).
+# The `|| true` keeps a comments-only list from tripping `set -e` via pipefail,
+# so the empty-list check below reports it instead of exiting silently.
+TEST_NAMES="$(sed -e 's/\r$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$TEST_LIST_FILE" \
+    | grep -v '^#' | grep -v '^$' | awk '!seen[$0]++' || true)"
 
-if [ -z "$TEST_PATTERN" ]; then
+if [ -z "$TEST_NAMES" ]; then
     echo "Error: No tests found in $TEST_LIST_FILE"
+    exit 1
+fi
+
+EXPECTED_COUNT="$(printf '%s\n' "$TEST_NAMES" | grep -c . || true)"
+TEST_PATTERN="$(printf '%s\n' "$TEST_NAMES" | tr '\n' '|' | sed 's/|$//')"
+
+# Fail on names that match no test function.
+#
+# The pattern below is anchored, so a typo or a renamed/deleted test makes
+# `go test -run` match nothing, print "no tests to run" and still exit 0 - a
+# green gate that exercised nothing. Validate up front instead.
+#
+# `go test -list` is deliberately not used for this: TestMain provisions real
+# Capella resources before the testing framework handles -list, so listing would
+# cost a full setup cycle. Reading the declarations costs nothing.
+DECLARED_TESTS="$(grep -rhoE '^func Test[A-Za-z0-9_]+\(' "$ACC_DIR"/*.go \
+    | sed -E 's/^func (Test[A-Za-z0-9_]+)\(.*/\1/' | sort -u)"
+
+UNKNOWN_NAMES=""
+while IFS= read -r test_name; do
+    if ! printf '%s\n' "$DECLARED_TESTS" | grep -qxF "$test_name"; then
+        UNKNOWN_NAMES="${UNKNOWN_NAMES}  ${test_name}"$'\n'
+    fi
+done <<< "$TEST_NAMES"
+
+if [ -n "$UNKNOWN_NAMES" ]; then
+    echo "ERROR: $TEST_LIST_FILE names tests that do not exist in acceptance_tests/:"
+    echo ""
+    printf '%s' "$UNKNOWN_NAMES"
+    echo ""
+    echo "These were renamed, deleted or misspelled. Left in place they would"
+    echo "match nothing and the run would pass without executing them."
     exit 1
 fi
 
 echo "=========================================="
 echo "Running Sanity Tests from: $TEST_LIST_FILE"
 echo "=========================================="
+echo "Tests requested: $EXPECTED_COUNT"
 echo "Test pattern: $TEST_PATTERN"
 echo ""
 
@@ -43,7 +89,46 @@ echo ""
 # failing a test.
 TEST_TIMEOUT="${TEST_TIMEOUT:-180m}"
 
+TEST_LOG="$(mktemp)"
+trap 'rm -f "$TEST_LOG"' EXIT
+
 # Run the tests
-CAPELLA_OPENAPI_SPEC_PATH="${CAPELLA_OPENAPI_SPEC_PATH:-$(pwd)/openapi.generated.yaml}" \
+set +e
+CAPELLA_OPENAPI_SPEC_PATH="${CAPELLA_OPENAPI_SPEC_PATH:-$REPO_ROOT/openapi.generated.yaml}" \
 TF_ACC=1 \
-go test -timeout="${TEST_TIMEOUT}" -v ./acceptance_tests/ -run "^(${TEST_PATTERN})$"
+go test -timeout="${TEST_TIMEOUT}" -v ./acceptance_tests/ -run "^(${TEST_PATTERN})$" 2>&1 | tee "$TEST_LOG"
+TEST_STATUS="${PIPESTATUS[0]}"
+set -e
+
+# Assert the run actually executed what was asked for. `go test` reports success
+# for an empty selection, so exit status alone cannot be trusted here.
+RAN_COUNT="$(grep -cE '^=== RUN[[:space:]]+Test[A-Za-z0-9_]+$' "$TEST_LOG" || true)"
+
+echo ""
+echo "=========================================="
+echo "Tests requested: $EXPECTED_COUNT   executed: $RAN_COUNT"
+echo "=========================================="
+
+# A non-zero status is a genuine test or setup failure; the log already explains
+# it, and the counts below would only add a misleading second diagnosis.
+if [ "$TEST_STATUS" -ne 0 ]; then
+    exit "$TEST_STATUS"
+fi
+
+if grep -q 'no tests to run' "$TEST_LOG"; then
+    echo "ERROR: go test reported \"no tests to run\" - the selection matched nothing."
+    exit 1
+fi
+
+if [ "$RAN_COUNT" -eq 0 ]; then
+    echo "ERROR: no tests executed. Refusing to report success for an empty run."
+    exit 1
+fi
+
+if [ "$RAN_COUNT" -ne "$EXPECTED_COUNT" ]; then
+    echo "ERROR: go test succeeded but executed $RAN_COUNT of $EXPECTED_COUNT requested tests."
+    echo "Some listed tests were never run (build tags, or excluded from the package)."
+    exit 1
+fi
+
+exit 0

--- a/scripts/run-test-list.sh
+++ b/scripts/run-test-list.sh
@@ -77,17 +77,32 @@ if [ -n "$UNKNOWN_NAMES" ]; then
     exit 1
 fi
 
+# Matches the timeout used by `make testacc`. The sanity list provisions real
+# clusters and app services, so a short timeout panics mid-run rather than
+# failing a test.
+TEST_TIMEOUT="${TEST_TIMEOUT:-180m}"
+
+# `go test -parallel` defaults to GOMAXPROCS, which is the wrong dimension here:
+# these tests are almost entirely spent polling Capella while it provisions
+# clusters, not burning CPU. Left at the default, a 4-vCPU CI runner gets 4 lanes
+# for ~60 parallel tests while a 14-core laptop gets 14, so CI is several times
+# slower than a local run. Set it explicitly instead.
+#
+# The practical ceiling is the Capella organization's quota and rate limits, not
+# the machine - raise with care and watch for 429s and quota errors.
+TEST_PARALLELISM="${TEST_PARALLELISM:-16}"
+
 echo "=========================================="
 echo "Running Sanity Tests from: $TEST_LIST_FILE"
 echo "=========================================="
 echo "Tests requested: $EXPECTED_COUNT"
 echo "Test pattern: $TEST_PATTERN"
 echo ""
-
-# Matches the timeout used by `make testacc`. The sanity list provisions real
-# clusters and app services, so a short timeout panics mid-run rather than
-# failing a test.
-TEST_TIMEOUT="${TEST_TIMEOUT:-180m}"
+# Logged because wall-clock is dominated by how many tests run at once, and the
+# available core count differs sharply between a laptop and a CI runner.
+echo "Parallelism: $TEST_PARALLELISM lanes (cores available: $(getconf _NPROCESSORS_ONLN 2>/dev/null || echo unknown))"
+echo "Timeout: $TEST_TIMEOUT"
+echo ""
 
 TEST_LOG="$(mktemp)"
 trap 'rm -f "$TEST_LOG"' EXIT
@@ -96,7 +111,7 @@ trap 'rm -f "$TEST_LOG"' EXIT
 set +e
 CAPELLA_OPENAPI_SPEC_PATH="${CAPELLA_OPENAPI_SPEC_PATH:-$REPO_ROOT/openapi.generated.yaml}" \
 TF_ACC=1 \
-go test -timeout="${TEST_TIMEOUT}" -v ./acceptance_tests/ -run "^(${TEST_PATTERN})$" 2>&1 | tee "$TEST_LOG"
+go test -timeout="${TEST_TIMEOUT}" -parallel "${TEST_PARALLELISM}" -v ./acceptance_tests/ -run "^(${TEST_PATTERN})$" 2>&1 | tee "$TEST_LOG"
 TEST_STATUS="${PIPESTATUS[0]}"
 set -e
 

--- a/scripts/run-test-list.sh
+++ b/scripts/run-test-list.sh
@@ -82,25 +82,11 @@ fi
 # failing a test.
 TEST_TIMEOUT="${TEST_TIMEOUT:-180m}"
 
-# `go test -parallel` defaults to GOMAXPROCS, which is the wrong dimension here:
-# these tests are almost entirely spent polling Capella while it provisions
-# clusters, not burning CPU. Left at the default, a 4-vCPU CI runner gets 4 lanes
-# for ~60 parallel tests while a 14-core laptop gets 14, so CI is several times
-# slower than a local run. Set it explicitly instead.
-#
-# The practical ceiling is the Capella organization's quota and rate limits, not
-# the machine - raise with care and watch for 429s and quota errors.
-TEST_PARALLELISM="${TEST_PARALLELISM:-16}"
-
 echo "=========================================="
 echo "Running Sanity Tests from: $TEST_LIST_FILE"
 echo "=========================================="
 echo "Tests requested: $EXPECTED_COUNT"
 echo "Test pattern: $TEST_PATTERN"
-echo ""
-# Logged because wall-clock is dominated by how many tests run at once, and the
-# available core count differs sharply between a laptop and a CI runner.
-echo "Parallelism: $TEST_PARALLELISM lanes (cores available: $(getconf _NPROCESSORS_ONLN 2>/dev/null || echo unknown))"
 echo "Timeout: $TEST_TIMEOUT"
 echo ""
 
@@ -111,7 +97,7 @@ trap 'rm -f "$TEST_LOG"' EXIT
 set +e
 CAPELLA_OPENAPI_SPEC_PATH="${CAPELLA_OPENAPI_SPEC_PATH:-$REPO_ROOT/openapi.generated.yaml}" \
 TF_ACC=1 \
-go test -timeout="${TEST_TIMEOUT}" -parallel "${TEST_PARALLELISM}" -v ./acceptance_tests/ -run "^(${TEST_PATTERN})$" 2>&1 | tee "$TEST_LOG"
+go test -timeout="${TEST_TIMEOUT}" -v ./acceptance_tests/ -run "^(${TEST_PATTERN})$" 2>&1 | tee "$TEST_LOG"
 TEST_STATUS="${PIPESTATUS[0]}"
 set -e
 

--- a/scripts/run-test-list.sh
+++ b/scripts/run-test-list.sh
@@ -38,7 +38,12 @@ echo "=========================================="
 echo "Test pattern: $TEST_PATTERN"
 echo ""
 
+# Matches the timeout used by `make testacc`. The sanity list provisions real
+# clusters and app services, so a short timeout panics mid-run rather than
+# failing a test.
+TEST_TIMEOUT="${TEST_TIMEOUT:-180m}"
+
 # Run the tests
-CAPELLA_OPENAPI_SPEC_PATH="$(pwd)/openapi.generated.yaml" \
+CAPELLA_OPENAPI_SPEC_PATH="${CAPELLA_OPENAPI_SPEC_PATH:-$(pwd)/openapi.generated.yaml}" \
 TF_ACC=1 \
-go test -timeout=30m -v ./acceptance_tests/ -run "^(${TEST_PATTERN})$"
+go test -timeout="${TEST_TIMEOUT}" -v ./acceptance_tests/ -run "^(${TEST_PATTERN})$"


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-139105

## Description

Makes the P0 sanity suite the acceptance-test gate for every pull request, and fills out that suite so it actually covers the provider.

Previously `acceptance-tests.yml` ran the **entire** acceptance suite on every PR (`make testacc`, `-timeout=180m`). That is far too slow and too resource-hungry to be a useful gate, and it provisions dozens of real clusters and app services per PR. Meanwhile `acceptance_tests/sanity.list` existed but was not wired into CI at all, and covered only 18 tests.

Three changes:

**1. Expanded the sanity list from 18 to 77 tests.** P0 is defined here as the primary happy-path (create / read / update / import / delete) test for every resource and data source the provider exposes. Negative and validation-only tests (invalid UUIDs, missing required fields, bad enums) are P1+ and stay out, as do tests that unconditionally `t.Skip`. Newly covered areas that previously had *zero* sanity coverage: buckets / scopes / collections (only `TestAccSampleBucket` was there, not the actual bucket resource), free tier clusters, cluster on/off and deletion protection, eventing, audit logging, Data API, events, cluster stats, certificates, on-demand backup and backup schedules, snapshot restore data sources, and the read/list data sources for every resource already in the list.

lso fixes a silently-dead entry: the list contained `TestAccPrivateEndpointServiceEnable`, which does not exist — the real test is `TestAccPrivateEndpointServiceEnableDisable`. Because `run-test-list.sh` anchors the pattern with `^(...)$`, that entry was matching nothing rather than erroring.

**2. Split the CI triggers.** New `sanity-tests.yml` runs the sanity suite on every `pull_request`, with no paths filter. `acceptance-tests.yml` drops its `pull_request` trigger and now runs the full suite on push-to-main plus `workflow_dispatch`. Running both on PRs would have duplicated cost and let the two runs collide on shared test fixtures (`globalClusterId` and friends) in the same Capella organization.

**3. Made the runner usable.** Added `make testacc-sanity` and a generic `make testacc-list` (honors `TEST_LIST`) — note that `sanity.list` already documented `make testacc-list` in its header, but that target never existed. `run-test-list.sh` had a hardcoded `-timeout=30m`, which at 77 cluster-provisioning tests would have panicked on timeout instead of reporting test failures; it is now `${TEST_TIMEOUT:-180m}`, matching `make testacc`. The script also no longer clobbers a caller-supplied `CAPELLA_OPENAPI_SPEC_PATH`, so the workflow's `github.workspace` path survives.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments