### PR TITLE
[AV-138744] Stop bucket update sending zero values for unconfigured fields

### DIFF
--- a/internal/resources/attributes.go
+++ b/internal/resources/attributes.go
@@ -146,13 +146,13 @@ func boolAttribute(fields ...string) *schema.BoolAttribute {
 			var planModifiers = []planmodifier.Bool{
 				boolplanmodifier.RequiresReplace(),
 			}
-			attribute.PlanModifiers = planModifiers
+			attribute.PlanModifiers = append(attribute.PlanModifiers, planModifiers...)
 
 		case useStateForUnknown:
 			var planModifiers = []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			}
-			attribute.PlanModifiers = planModifiers
+			attribute.PlanModifiers = append(attribute.PlanModifiers, planModifiers...)
 		}
 	}
 

--- a/internal/resources/audit_log_settings.go
+++ b/internal/resources/audit_log_settings.go
@@ -199,26 +199,26 @@ func (a *AuditLogSettings) Read(ctx context.Context, req resource.ReadRequest, r
 
 // Update updates the audit log settings.
 func (a *AuditLogSettings) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var state providerschema.ClusterAuditSettings
-	diags := req.Plan.Get(ctx, &state)
+	var plan providerschema.ClusterAuditSettings
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	var (
-		organizationId = state.OrganizationId.ValueString()
-		projectId      = state.ProjectId.ValueString()
-		clusterId      = state.ClusterId.ValueString()
+		organizationId = plan.OrganizationId.ValueString()
+		projectId      = plan.ProjectId.ValueString()
+		clusterId      = plan.ClusterId.ValueString()
 	)
 
-	eventIds := make([]int32, len(state.EnabledEventIDs))
-	for i, event := range state.EnabledEventIDs {
+	eventIds := make([]int32, len(plan.EnabledEventIDs))
+	for i, event := range plan.EnabledEventIDs {
 		eventIds[i] = int32(event.ValueInt64()) //nolint:gosec // Event IDs are small integers, no overflow risk
 	}
 
-	disabledUsers := make([]api.AuditSettingsDisabledUser, len(state.DisabledUsers))
-	for i, user := range state.DisabledUsers {
+	disabledUsers := make([]api.AuditSettingsDisabledUser, len(plan.DisabledUsers))
+	for i, user := range plan.DisabledUsers {
 		u := api.AuditSettingsDisabledUser{
 			Domain: user.Domain.ValueStringPointer(),
 			Name:   user.Name.ValueStringPointer(),
@@ -227,7 +227,7 @@ func (a *AuditLogSettings) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	auditLogUpdateRequest := api.UpdateClusterAuditSettingsRequest{
-		AuditEnabled:    state.AuditEnabled.ValueBool(),
+		AuditEnabled:    plan.AuditEnabled.ValueBool(),
 		EnabledEventIDs: eventIds,
 		DisabledUsers:   disabledUsers,
 	}

--- a/internal/resources/audit_log_settings_schema.go
+++ b/internal/resources/audit_log_settings_schema.go
@@ -19,7 +19,9 @@ func AuditLogSettingsSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "organization_id", auditLogSettingsBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "project_id", auditLogSettingsBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "cluster_id", auditLogSettingsBuilder, requiredUUIDStringAttribute())
-	capellaschema.AddAttr(attrs, "audit_enabled", auditLogSettingsBuilder, boolAttribute(computed, optional))
+	// useStateForUnknown: audit_enabled goes into UpdateClusterAuditSettingsRequest, and
+	// without it an unconfigured one is sent as false, disabling auditing.
+	capellaschema.AddAttr(attrs, "audit_enabled", auditLogSettingsBuilder, boolAttribute(computed, optional, useStateForUnknown))
 	capellaschema.AddAttr(attrs, "enabled_event_ids", auditLogSettingsBuilder, &schema.SetAttribute{
 		Computed:    true,
 		Optional:    true,

--- a/internal/resources/audit_log_settings_schema.go
+++ b/internal/resources/audit_log_settings_schema.go
@@ -5,6 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -22,6 +24,8 @@ func AuditLogSettingsSchema() schema.Schema {
 	// useStateForUnknown: audit_enabled goes into UpdateClusterAuditSettingsRequest, and
 	// without it an unconfigured one is sent as false, disabling auditing.
 	capellaschema.AddAttr(attrs, "audit_enabled", auditLogSettingsBuilder, boolAttribute(computed, optional, useStateForUnknown))
+	// useStateForUnknown: enabled_event_ids goes into UpdateClusterAuditSettingsRequest as a
+	// native slice, which cannot hold an unknown, so an unconfigured one breaks the update.
 	capellaschema.AddAttr(attrs, "enabled_event_ids", auditLogSettingsBuilder, &schema.SetAttribute{
 		Computed:    true,
 		Optional:    true,
@@ -29,17 +33,24 @@ func AuditLogSettingsSchema() schema.Schema {
 		Validators: []validator.Set{
 			setvalidator.ValueInt64sAre(int64validator.AtLeast(1)),
 		},
+		PlanModifiers: []planmodifier.Set{
+			setplanmodifier.UseStateForUnknown(),
+		},
 	})
 
 	disabledUserAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(disabledUserAttrs, "domain", auditLogSettingsBuilder, stringAttribute([]string{required}, stringvalidator.LengthAtLeast(1)))
 	capellaschema.AddAttr(disabledUserAttrs, "name", auditLogSettingsBuilder, stringAttribute([]string{required}, stringvalidator.LengthAtLeast(1)))
 
+	// useStateForUnknown: same as enabled_event_ids.
 	capellaschema.AddAttr(attrs, "disabled_users", auditLogSettingsBuilder, &schema.SetNestedAttribute{
 		Computed: true,
 		Optional: true,
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: disabledUserAttrs,
+		},
+		PlanModifiers: []planmodifier.Set{
+			setplanmodifier.UseStateForUnknown(),
 		},
 	})
 

--- a/internal/resources/bucket.go
+++ b/internal/resources/bucket.go
@@ -363,18 +363,18 @@ func (c *Bucket) retrieveBucket(
 
 // Update updates the bucket.
 func (c *Bucket) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var state providerschema.Bucket
-	diags := req.Plan.Get(ctx, &state)
+	var plan providerschema.Bucket
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	IDs, err := state.Validate()
+	IDs, err := plan.Validate()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Bucket in Capella",
-			"Could not read Capella Bucket with ID "+state.Id.String()+": "+err.Error(),
+			"Could not read Capella Bucket with ID "+plan.Id.String()+": "+err.Error(),
 		)
 		return
 	}
@@ -386,12 +386,14 @@ func (c *Bucket) Update(ctx context.Context, req resource.UpdateRequest, resp *r
 		bucketId       = IDs[providerschema.Id]
 	)
 
+	// Plan values. Each field relies on useStateForUnknown in the schema to have already
+	// resolved an unconfigured value back to prior state; without it this sends "" or 0.
 	bucketUpdateRequest := bucketapi.PutBucketRequest{
-		MemoryAllocationInMb: state.MemoryAllocationInMB.ValueInt64(),
-		DurabilityLevel:      state.DurabilityLevel.ValueString(),
-		Replicas:             state.Replicas.ValueInt64(),
-		Flush:                state.Flush.ValueBool(),
-		TimeToLiveInSeconds:  state.TimeToLiveInSeconds.ValueInt64(),
+		MemoryAllocationInMb: plan.MemoryAllocationInMB.ValueInt64(),
+		DurabilityLevel:      plan.DurabilityLevel.ValueString(),
+		Replicas:             plan.Replicas.ValueInt64(),
+		Flush:                plan.Flush.ValueBool(),
+		TimeToLiveInSeconds:  plan.TimeToLiveInSeconds.ValueInt64(),
 	}
 
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/buckets/%s", c.HostURL, organizationId, projectId, clusterId, bucketId)

--- a/internal/resources/bucket_schema.go
+++ b/internal/resources/bucket_schema.go
@@ -22,7 +22,9 @@ func BucketSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "cluster_id", bucketBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "type", bucketBuilder, stringAttribute([]string{computed, optional, requiresReplace, useStateForUnknown}))
 	capellaschema.AddAttr(attrs, "storage_backend", bucketBuilder, stringAttribute([]string{computed, optional, requiresReplace, useStateForUnknown}))
-	capellaschema.AddAttr(attrs, "memory_allocation_in_mb", bucketBuilder, int64Attribute(optional, computed))
+	// useStateForUnknown on the four attributes below: they go into PutBucketRequest, and
+	// without it an unconfigured one reaches Update as unknown and is sent as "" or 0.
+	capellaschema.AddAttr(attrs, "memory_allocation_in_mb", bucketBuilder, int64Attribute(optional, computed, useStateForUnknown))
 	capellaschema.AddAttr(attrs, "vbuckets", bucketBuilder, &schema.Int64Attribute{
 		Optional: true,
 		Computed: true,
@@ -35,10 +37,10 @@ func BucketSchema() schema.Schema {
 		},
 	})
 	capellaschema.AddAttr(attrs, "bucket_conflict_resolution", bucketBuilder, stringDefaultAttribute("seqno", computed, optional, requiresReplace, useStateForUnknown))
-	capellaschema.AddAttr(attrs, "durability_level", bucketBuilder, stringAttribute([]string{computed, optional}))
-	capellaschema.AddAttr(attrs, "replicas", bucketBuilder, int64Attribute(optional, computed))
+	capellaschema.AddAttr(attrs, "durability_level", bucketBuilder, stringAttribute([]string{computed, optional, useStateForUnknown}))
+	capellaschema.AddAttr(attrs, "replicas", bucketBuilder, int64Attribute(optional, computed, useStateForUnknown))
 	capellaschema.AddAttr(attrs, "flush", bucketBuilder, boolDefaultAttribute(false, optional, computed))
-	capellaschema.AddAttr(attrs, "time_to_live_in_seconds", bucketBuilder, int64Attribute(optional, computed))
+	capellaschema.AddAttr(attrs, "time_to_live_in_seconds", bucketBuilder, int64Attribute(optional, computed, useStateForUnknown))
 	capellaschema.AddAttr(attrs, "eviction_policy", bucketBuilder, stringAttribute([]string{computed, optional, requiresReplace, useStateForUnknown}))
 
 	statsAttrs := make(map[string]schema.Attribute)

--- a/internal/resources/project.go
+++ b/internal/resources/project.go
@@ -198,27 +198,27 @@ func (r *Project) Read(ctx context.Context, req resource.ReadRequest, resp *reso
 
 // Update updates the project.
 func (r *Project) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var state providerschema.Project
-	diags := req.Plan.Get(ctx, &state)
+	var plan providerschema.Project
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	IDs, err := state.Validate()
+	IDs, err := plan.Validate()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Capella Project",
-			"Could not update Capella project ID "+state.Id.String()+": "+err.Error(),
+			"Could not update Capella project ID "+plan.Id.String()+": "+err.Error(),
 		)
 		return
 	}
 
-	if err := r.validateProjectAttributesTrimmed(state); err != nil {
+	if err := r.validateProjectAttributesTrimmed(plan); err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Capella Project",
-			"Could not update Capella project ID "+state.Id.String()+": "+err.Error(),
+			"Could not update Capella project ID "+plan.Id.String()+": "+err.Error(),
 		)
 		return
 	}
@@ -229,13 +229,13 @@ func (r *Project) Update(ctx context.Context, req resource.UpdateRequest, resp *
 	)
 
 	projectRequest := api.PutProjectRequest{
-		Description: state.Description.ValueString(),
-		Name:        state.Name.ValueString(),
+		Description: plan.Description.ValueString(),
+		Name:        plan.Name.ValueString(),
 	}
 
 	var headers = make(map[string]string)
-	if !state.IfMatch.IsUnknown() && !state.IfMatch.IsNull() {
-		headers["If-Match"] = state.IfMatch.ValueString()
+	if !plan.IfMatch.IsUnknown() && !plan.IfMatch.IsNull() {
+		headers["If-Match"] = plan.IfMatch.ValueString()
 	}
 
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s", r.HostURL, organizationId, projectId)
@@ -256,7 +256,7 @@ func (r *Project) Update(ctx context.Context, req resource.UpdateRequest, resp *
 		}
 		resp.Diagnostics.AddError(
 			"Error Updating Capella Projects",
-			"Could not update Capella project ID "+state.Id.String()+": "+errString,
+			"Could not update Capella project ID "+plan.Id.String()+": "+errString,
 		)
 		return
 	}
@@ -276,8 +276,8 @@ func (r *Project) Update(ctx context.Context, req resource.UpdateRequest, resp *
 		return
 	}
 
-	if !state.IfMatch.IsUnknown() && !state.IfMatch.IsNull() {
-		currentState.IfMatch = state.IfMatch
+	if !plan.IfMatch.IsUnknown() && !plan.IfMatch.IsNull() {
+		currentState.IfMatch = plan.IfMatch
 	}
 
 	// Set state to fully populated data

--- a/internal/resources/project_schema.go
+++ b/internal/resources/project_schema.go
@@ -17,7 +17,9 @@ func ProjectSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "id", projectBuilder, stringAttribute([]string{computed, useStateForUnknown}))
 	capellaschema.AddAttr(attrs, "organization_id", projectBuilder, requiredUUIDStringAttribute())
 	capellaschema.AddAttr(attrs, "name", projectBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(attrs, "description", projectBuilder, stringAttribute([]string{optional, computed}))
+	// useStateForUnknown: description goes into PutProjectRequest, and without it an
+	// unconfigured one is sent as "", wiping the existing description.
+	capellaschema.AddAttr(attrs, "description", projectBuilder, stringAttribute([]string{optional, computed, useStateForUnknown}))
 	capellaschema.AddAttr(attrs, "if_match", projectBuilder, stringAttribute([]string{optional}))
 	capellaschema.AddAttr(attrs, "etag", projectBuilder, stringAttribute([]string{computed}))
 	capellaschema.AddAttr(attrs, "audit", projectBuilder, computedAuditAttribute())

--- a/internal/resources/update_unknown_safety_test.go
+++ b/internal/resources/update_unknown_safety_test.go
@@ -77,7 +77,15 @@ func TestUpdateBodyAttributesResolveUnknownsToState(t *testing.T) {
 }
 
 // resolvesUnknownToState reports whether an unconfigured value (null config, unknown
-// plan) is restored to prior state, either by a Default or by the plan modifiers.
+// plan) is restored to prior state by the plan modifiers.
+//
+// An attribute with a Default is exempt: a Default is a value the practitioner declared
+// in the schema, so transmitting it is what the configuration asks for. That is not the
+// same as transmitting a zero value because an unknown got unwrapped.
+//
+// Each modifier sees the plan value the previous one produced, matching the framework
+// (fwserver.AttributeModifyPlan) - a modifier that runs after one which resolved the
+// unknown must observe a known plan value, or the result here does not reflect reality.
 func resolvesUnknownToState(t *testing.T, attr schema.Attribute) bool {
 	t.Helper()
 
@@ -88,46 +96,49 @@ func resolvesUnknownToState(t *testing.T, attr schema.Attribute) bool {
 		if a.Default != nil {
 			return true
 		}
-		resp := planmodifier.StringResponse{PlanValue: types.StringUnknown()}
 		req := planmodifier.StringRequest{
 			StateValue:  types.StringValue("prior"),
 			PlanValue:   types.StringUnknown(),
 			ConfigValue: types.StringNull(),
 		}
 		for _, m := range a.PlanModifiers {
+			resp := planmodifier.StringResponse{PlanValue: req.PlanValue}
 			m.PlanModifyString(ctx, req, &resp)
+			req.PlanValue = resp.PlanValue
 		}
-		return resp.PlanValue.Equal(types.StringValue("prior"))
+		return req.PlanValue.Equal(types.StringValue("prior"))
 
 	case *schema.Int64Attribute:
 		if a.Default != nil {
 			return true
 		}
-		resp := planmodifier.Int64Response{PlanValue: types.Int64Unknown()}
 		req := planmodifier.Int64Request{
 			StateValue:  types.Int64Value(42),
 			PlanValue:   types.Int64Unknown(),
 			ConfigValue: types.Int64Null(),
 		}
 		for _, m := range a.PlanModifiers {
+			resp := planmodifier.Int64Response{PlanValue: req.PlanValue}
 			m.PlanModifyInt64(ctx, req, &resp)
+			req.PlanValue = resp.PlanValue
 		}
-		return resp.PlanValue.Equal(types.Int64Value(42))
+		return req.PlanValue.Equal(types.Int64Value(42))
 
 	case *schema.BoolAttribute:
 		if a.Default != nil {
 			return true
 		}
-		resp := planmodifier.BoolResponse{PlanValue: types.BoolUnknown()}
 		req := planmodifier.BoolRequest{
 			StateValue:  types.BoolValue(true),
 			PlanValue:   types.BoolUnknown(),
 			ConfigValue: types.BoolNull(),
 		}
 		for _, m := range a.PlanModifiers {
+			resp := planmodifier.BoolResponse{PlanValue: req.PlanValue}
 			m.PlanModifyBool(ctx, req, &resp)
+			req.PlanValue = resp.PlanValue
 		}
-		return resp.PlanValue.Equal(types.BoolValue(true))
+		return req.PlanValue.Equal(types.BoolValue(true))
 
 	default:
 		t.Fatalf("unhandled attribute type %T - extend resolvesUnknownToState", attr)

--- a/internal/resources/update_unknown_safety_test.go
+++ b/internal/resources/update_unknown_safety_test.go
@@ -1,0 +1,136 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestUpdateBodyAttributesResolveUnknownsToState covers the Optional+Computed attributes
+// that Update methods read into a request body.
+//
+// The framework marks a null-in-config Computed attribute as unknown unless it has a
+// Default, and ValueString()/ValueInt64()/ValueBool() unwrap an unknown to "" / 0 / false.
+// Such an attribute must therefore resolve back to prior state at plan time, via
+// useStateForUnknown, or the provider transmits a zero value nobody asked for.
+//
+// Adding an Optional+Computed attribute to an Update request body means adding it here.
+func TestUpdateBodyAttributesResolveUnknownsToState(t *testing.T) {
+	cases := []struct {
+		name       string
+		attributes map[string]schema.Attribute
+		attrNames  []string
+	}{
+		{
+			// PutBucketRequest. Only durability_level surfaces - the API rejects "" with
+			// a 422. The rest apply silently: 0 replicas, no TTL, no RAM quota.
+			name:       "bucket",
+			attributes: BucketSchema().Attributes,
+			attrNames: []string{
+				"memory_allocation_in_mb",
+				"durability_level",
+				"replicas",
+				"time_to_live_in_seconds",
+				"flush",
+			},
+		},
+		{
+			// PutProjectRequest. An empty description wipes the existing one.
+			name:       "project",
+			attributes: ProjectSchema().Attributes,
+			attrNames:  []string{"description"},
+		},
+		{
+			// UpdateClusterAuditSettingsRequest. A false audit_enabled disables auditing.
+			name:       "audit_log_settings",
+			attributes: AuditLogSettingsSchema().Attributes,
+			attrNames:  []string{"audit_enabled"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, attrName := range tc.attrNames {
+				attr, ok := tc.attributes[attrName]
+				if !ok {
+					t.Errorf("%s: attribute not present in schema", attrName)
+					continue
+				}
+				if !attr.IsOptional() || !attr.IsComputed() {
+					// Only Optional+Computed attributes can be marked unknown this way.
+					continue
+				}
+				if !resolvesUnknownToState(t, attr) {
+					t.Errorf(
+						"%s.%s is Optional+Computed and is read into an Update request body, "+
+							"but an unconfigured value does not resolve to prior state: it would be "+
+							"transmitted as a zero value. Add useStateForUnknown to it.",
+						tc.name, attrName,
+					)
+				}
+			}
+		})
+	}
+}
+
+// resolvesUnknownToState reports whether an unconfigured value (null config, unknown
+// plan) is restored to prior state, either by a Default or by the plan modifiers.
+func resolvesUnknownToState(t *testing.T, attr schema.Attribute) bool {
+	t.Helper()
+
+	ctx := context.Background()
+
+	switch a := attr.(type) {
+	case *schema.StringAttribute:
+		if a.Default != nil {
+			return true
+		}
+		resp := planmodifier.StringResponse{PlanValue: types.StringUnknown()}
+		req := planmodifier.StringRequest{
+			StateValue:  types.StringValue("prior"),
+			PlanValue:   types.StringUnknown(),
+			ConfigValue: types.StringNull(),
+		}
+		for _, m := range a.PlanModifiers {
+			m.PlanModifyString(ctx, req, &resp)
+		}
+		return resp.PlanValue.Equal(types.StringValue("prior"))
+
+	case *schema.Int64Attribute:
+		if a.Default != nil {
+			return true
+		}
+		resp := planmodifier.Int64Response{PlanValue: types.Int64Unknown()}
+		req := planmodifier.Int64Request{
+			StateValue:  types.Int64Value(42),
+			PlanValue:   types.Int64Unknown(),
+			ConfigValue: types.Int64Null(),
+		}
+		for _, m := range a.PlanModifiers {
+			m.PlanModifyInt64(ctx, req, &resp)
+		}
+		return resp.PlanValue.Equal(types.Int64Value(42))
+
+	case *schema.BoolAttribute:
+		if a.Default != nil {
+			return true
+		}
+		resp := planmodifier.BoolResponse{PlanValue: types.BoolUnknown()}
+		req := planmodifier.BoolRequest{
+			StateValue:  types.BoolValue(true),
+			PlanValue:   types.BoolUnknown(),
+			ConfigValue: types.BoolNull(),
+		}
+		for _, m := range a.PlanModifiers {
+			m.PlanModifyBool(ctx, req, &resp)
+		}
+		return resp.PlanValue.Equal(types.BoolValue(true))
+
+	default:
+		t.Fatalf("unhandled attribute type %T - extend resolvesUnknownToState", attr)
+		return false
+	}
+}

--- a/internal/resources/update_unknown_safety_test.go
+++ b/internal/resources/update_unknown_safety_test.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // TestUpdateBodyAttributesResolveUnknownsToState covers the Optional+Computed attributes
-// that Update methods read into a request body.
-//
-// The framework marks a null-in-config Computed attribute as unknown unless it has a
-// Default, and ValueString()/ValueInt64()/ValueBool() unwrap an unknown to "" / 0 / false.
-// Such an attribute must therefore resolve back to prior state at plan time, via
-// useStateForUnknown, or the provider transmits a zero value nobody asked for.
+// that Update methods read into a request body. The framework marks a null-in-config
+// Computed attribute as unknown unless it has a Default, and ValueString()/ValueInt64()/
+// ValueBool() unwrap an unknown to "" / 0 / false, so such an attribute must resolve back
+// to prior state via useStateForUnknown or the provider transmits an unrequested zero.
 //
 // Adding an Optional+Computed attribute to an Update request body means adding it here.
 func TestUpdateBodyAttributesResolveUnknownsToState(t *testing.T) {
@@ -45,9 +44,10 @@ func TestUpdateBodyAttributesResolveUnknownsToState(t *testing.T) {
 		},
 		{
 			// UpdateClusterAuditSettingsRequest. A false audit_enabled disables auditing.
+			// The sets are read into native slices, which cannot hold an unknown.
 			name:       "audit_log_settings",
 			attributes: AuditLogSettingsSchema().Attributes,
-			attrNames:  []string{"audit_enabled"},
+			attrNames:  []string{"audit_enabled", "enabled_event_ids", "disabled_users"},
 		},
 	}
 
@@ -76,16 +76,12 @@ func TestUpdateBodyAttributesResolveUnknownsToState(t *testing.T) {
 	}
 }
 
-// resolvesUnknownToState reports whether an unconfigured value (null config, unknown
-// plan) is restored to prior state by the plan modifiers.
+// resolvesUnknownToState reports whether an unconfigured value (null config, unknown plan)
+// is restored to prior state by the plan modifiers. A Default is exempt: it is a value
+// declared in the schema, not a zero value from an unwrapped unknown.
 //
-// An attribute with a Default is exempt: a Default is a value the practitioner declared
-// in the schema, so transmitting it is what the configuration asks for. That is not the
-// same as transmitting a zero value because an unknown got unwrapped.
-//
-// Each modifier sees the plan value the previous one produced, matching the framework
-// (fwserver.AttributeModifyPlan) - a modifier that runs after one which resolved the
-// unknown must observe a known plan value, or the result here does not reflect reality.
+// Each modifier sees the plan value the previous one produced, matching
+// fwserver.AttributeModifyPlan.
 func resolvesUnknownToState(t *testing.T, attr schema.Attribute) bool {
 	t.Helper()
 
@@ -140,8 +136,39 @@ func resolvesUnknownToState(t *testing.T, attr schema.Attribute) bool {
 		}
 		return req.PlanValue.Equal(types.BoolValue(true))
 
+	case *schema.SetAttribute:
+		if a.Default != nil {
+			return true
+		}
+		return setResolvesUnknownToState(ctx, a.ElementType, a.PlanModifiers)
+
+	case *schema.SetNestedAttribute:
+		if a.Default != nil {
+			return true
+		}
+		return setResolvesUnknownToState(ctx, a.NestedObject.Type(), a.PlanModifiers)
+
 	default:
 		t.Fatalf("unhandled attribute type %T - extend resolvesUnknownToState", attr)
 		return false
 	}
+}
+
+// setResolvesUnknownToState is the set case of resolvesUnknownToState. Prior state is an
+// empty set, which is representable for any element type including nested objects.
+func setResolvesUnknownToState(ctx context.Context, elementType attr.Type, modifiers []planmodifier.Set) bool {
+	priorState := types.SetValueMust(elementType, nil)
+
+	req := planmodifier.SetRequest{
+		StateValue:  priorState,
+		PlanValue:   types.SetUnknown(elementType),
+		ConfigValue: types.SetNull(elementType),
+	}
+	for _, m := range modifiers {
+		resp := planmodifier.SetResponse{PlanValue: req.PlanValue}
+		m.PlanModifySet(ctx, req, &resp)
+		req.PlanValue = resp.PlanValue
+	}
+
+	return req.PlanValue.Equal(priorState)
 }


### PR DESCRIPTION
## Jira

* AV-138744

## Description

Unconfigured Optional+Computed attributes are marked unknown at plan time, and `Update` unwraps them with `ValueString()`/`ValueInt64()`, so they reach the API as `""` or `0`. On a bucket that means `durabilityLevel: ""` and a 422 — resizing with only `memory_allocation_in_mb` set is broken in v1.9.1. `replicas`, `time_to_live_in_seconds` and `memory_allocation_in_mb` share the defect but aren't API-validated, so they'd apply silently; fixing `durability_level` alone would unmask `memoryAllocationInMb: 0`, hence all four together. Same defect silently wipes `project.description` and disables `audit_log_settings.audit_enabled`.

Fix is `useStateForUnknown` on the affected attributes, matching how `type`, `storage_backend`, `eviction_policy` and `vbuckets` are already declared. Also renames the misleading `state` variable to `plan` in the three `Update` methods, and makes `boolAttribute` append plan modifiers instead of overwriting. `omitempty` on `PutBucketRequest` is deliberately excluded — it changes PUT semantics and needs an API-side ruling.

Full root cause analysis, including the per-attribute breakdown and the refuted destroy-and-recreate theory, is on the ticket: [AV-138744](https://couchbasecloud.atlassian.net/browse/AV-138744).

### Related

- #737 added `TestAccBucketUpdateSendsPlanValues`, the acceptance test that surfaced this defect and that this PR makes pass. It is currently the reproduction case.
- #728 (AV-138536) is the same family of bug in the app service resource — an Optional+Computed attribute with no `UseStateForUnknown`, there causing spurious replacement rather than a zero-value write. That fix stands and is unaffected by this one.
- AV-138745, the cluster equivalent originally filed alongside this, was withdrawn — see the correction on AV-138744. `RequiresReplace` ordering relative to `UseStateForUnknown` is irrelevant, because Terraform core only honours a requires-replace path when the planned value actually differs from prior state.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [x] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

1. Bucket created with `memory_allocation_in_mb = 100` and `durability_level`, `replicas`, `time_to_live_in_seconds` absent from config. The API chose `durability_level = "none"`, `replicas = 1`.
2. Then `memory_allocation_in_mb` bumped 100 → 200, nothing else changed.

### Before (schema without useStateForUnknown)

Unconfigured Computed attributes plan as unknown:
```
~ new_bucket   = {
      ~ durability_level           = "none" -> (known after apply)
        id                         = "YXYxMzg3NDQ="
      ~ memory_allocation_in_mb    = 100 -> 200
        name                       = "av138744"
      ~ replicas                   = 1 -> (known after apply)
      ~ stats                      = {
          - disk_used_in_mib   = 0
          - item_count         = 0
          - memory_used_in_mib = 0
          - ops_per_second     = 0
        } -> (known after apply)
      ~ time_to_live_in_seconds    = 0 -> (known after apply)
        # (9 unchanged attributes hidden)
    }
```

Apply fails - the unknown is transmitted as `""`:
```
╷
│ Error: Error updating bucket
│ 
│   with couchbase-capella_bucket.new_bucket,
│   on create_bucket.tf line 9, in resource "couchbase-capella_bucket" "new_bucket":
│    9: resource "couchbase-capella_bucket" "new_bucket" {
│ 
│ Could not update bucket, unexpected error: YXYxMzg3NDQ=: {"hint":"The provided durability level is not supported. The supported levels are 'none', 'majority', 'persistToMajority', and 'majorityAndPersistActive'.
│ Please choose a valid durability level for the bucket.","message":"The durability level '' provided is not supported. The supported levels are 'none', 'majority', 'persistToMajority', and
│ 'majorityAndPersistActive'.","code":6005,"httpStatusCode":422}
```

### After 

Same config, same target. The three unconfigured attributes resolve to prior state and drop out of the diff:
```
Changes to Outputs:
  ~ new_bucket   = {
        id                         = "YXYxMzg3NDQ="
      ~ memory_allocation_in_mb    = 100 -> 200
        name                       = "av138744"
      ~ stats                      = {
          - disk_used_in_mib   = 0
          - item_count         = 0
          - memory_used_in_mib = 0
          - ops_per_second     = 0
        } -> (known after apply)
        # (12 unchanged attributes hidden)
    }
couchbase-capella_bucket.new_bucket: Modifying... [id=YXYxMzg3NDQ=]
couchbase-capella_bucket.new_bucket: Modifications complete after 2s [id=YXYxMzg3NDQ=]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed. 
```

**Resulting state:** `memory_allocation_in_mb = 200`, `durability_level = "none"`, `replicas = 1` - unchanged, as intended.

```
pdeshmukh@KCQR2MGC9L bucket % terraform output new_bucket
{
  "bucket_conflict_resolution" = "seqno"
  "cluster_id" = "c7f8e77c-ac06-4492-9b65-65c2128a1441"
  "durability_level" = "none"
  "eviction_policy" = "fullEviction"
  "flush" = false
  "id" = "YXYxMzg3NDQ="
  "memory_allocation_in_mb" = 200
  "name" = "av138744"
  "organization_id" = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
  "project_id" = "c09035e8-3971-4b79-a6ec-bccd9056041f"
  "replicas" = 1
  "stats" = {
    "disk_used_in_mib" = 17
    "item_count" = 0
    "memory_used_in_mib" = 69
    "ops_per_second" = 0
  }
  "storage_backend" = "couchstore"
  "time_to_live_in_seconds" = 0
  "type" = "couchbase"
  "vbuckets" = 1024
}
```

**Expected:** succeeds, memory 200, durability_level still "none". 

</details>

## Further comments

- **Acceptance testing outstanding** — `TestAccBucketUpdateSendsPlanValues` (#737) is the direct reproduction and should run against a live cluster before merge: `TF_ACC=1 go test ./acceptance_tests/ -run TestAccBucketUpdateSendsPlanValues -v -timeout 60m`.
- Follow-up coverage, not reachable by that test: an update changing only `replicas` with `memory_allocation_in_mb` absent (asserting RAM unchanged), and the two sibling silent-wipe cases.
- No state migration needed — `Read` already populates these attributes, so `useStateForUnknown` has a value to restore from on existing buckets.
- `internal/schema` has five failing tests on this branch; they fail identically on a clean tree at the same base commit and are unrelated.


[AV-138744]: https://couchbasecloud.atlassian.net/browse/AV-138744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ