### PR TITLE
[AV-134714] Fix FreeTierClusters datasource always returning empty result

### DIFF
--- a/acceptance_tests/app_service_load_balancer_cidr_acceptance_test.go
+++ b/acceptance_tests/app_service_load_balancer_cidr_acceptance_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-
 var malformedLoadBalancerCIDRs = []string{
 	"192.168.0.0/244",    // prefix length above 32
 	"999.999.999.999/24", // octets out of range
@@ -36,10 +35,9 @@ func TestAccAppServiceLoadBalancerCIDR(t *testing.T) {
 
 	steps := make([]resource.TestStep, 0, len(malformedLoadBalancerCIDRs)+4)
 
-
 	for _, cidr := range malformedLoadBalancerCIDRs {
 		steps = append(steps, resource.TestStep{
-			Config: testAccAppServiceLoadBalancerCIDRMalformedConfig(resourceName, clusterName, appServiceName, clusterCIDR, cidr),
+			Config:      testAccAppServiceLoadBalancerCIDRMalformedConfig(resourceName, clusterName, appServiceName, clusterCIDR, cidr),
 			ExpectError: regexp.MustCompile(`(?s)error during app service creation`),
 		})
 	}

--- a/acceptance_tests/bucket_update_acceptance_test.go
+++ b/acceptance_tests/bucket_update_acceptance_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
-
 func TestAccBucketUpdateSendsPlanValues(t *testing.T) {
 
 	resourceName := randomStringWithPrefix("tf_acc_bucket_upd_")

--- a/acceptance_tests/free_tier_clusters_datasource_acceptance_test.go
+++ b/acceptance_tests/free_tier_clusters_datasource_acceptance_test.go
@@ -1,0 +1,42 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccFreeTierClusters_AV_134714 verifies that the free-tier clusters
+// datasource lists free-tier clusters via the dedicated /clusters/freeTier
+// endpoint instead of filtering the regular clusters list, which always
+// produced an empty (and previously state-breaking) result. See AV-134714.
+func TestAccFreeTierClusters_AV_134714(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_free_tier_clusters_ds_")
+	resourceReference := "data.couchbase-capella_free_tier_clusters." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeTierClustersDatasourceConfig(resourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttrSet(resourceReference, "data.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFreeTierClustersDatasourceConfig(resourceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_free_tier_clusters" "%[4]s" {
+  organization_id = "%[2]s"
+  project_id      = "%[3]s"
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, resourceName)
+}

--- a/acceptance_tests/free_tier_clusters_datasource_acceptance_test.go
+++ b/acceptance_tests/free_tier_clusters_datasource_acceptance_test.go
@@ -7,30 +7,35 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// TestAccFreeTierClusters_AV_134714 verifies that the free-tier clusters
-// datasource lists free-tier clusters via the dedicated /clusters/freeTier
-// endpoint instead of filtering the regular clusters list, which always
-// produced an empty (and previously state-breaking) result. See AV-134714.
-func TestAccFreeTierClusters_AV_134714(t *testing.T) {
-	resourceName := randomStringWithPrefix("tf_acc_free_tier_clusters_ds_")
-	resourceReference := "data.couchbase-capella_free_tier_clusters." + resourceName
+// TestAccFreeTierClustersDatasourceEmptyResult verifies that the free-tier
+// clusters data source always sets the data attribute, even when no free-tier
+// cluster matches. It previously left data as a nil slice, which lands in state
+// as a null list and fails "Attribute 'data.#' expected to be set". See
+// AV-134714.
+//
+// Listing free-tier clusters themselves is not asserted here: the Capella v4
+// API has no free-tier cluster list endpoint (only the free-tier buckets have
+// one), so the data source can only filter the general /clusters list.
+func TestAccFreeTierClustersDatasourceEmptyResult(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_free_tier_clusters_ds_")
+	dsRef := "data.couchbase-capella_free_tier_clusters." + dsName
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFreeTierClustersDatasourceConfig(resourceName),
+				Config: testAccFreeTierClustersDatasourceConfig(dsName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
-					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
-					resource.TestCheckResourceAttrSet(resourceReference, "data.#"),
+					resource.TestCheckResourceAttr(dsRef, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsRef, "project_id", globalProjectId),
+					resource.TestCheckResourceAttrSet(dsRef, "data.#"),
 				),
 			},
 		},
 	})
 }
 
-func testAccFreeTierClustersDatasourceConfig(resourceName string) string {
+func testAccFreeTierClustersDatasourceConfig(dsName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -38,5 +43,5 @@ data "couchbase-capella_free_tier_clusters" "%[4]s" {
   organization_id = "%[2]s"
   project_id      = "%[3]s"
 }
-`, globalProviderBlock, globalOrgId, globalProjectId, resourceName)
+`, globalProviderBlock, globalOrgId, globalProjectId, dsName)
 }

--- a/internal/datasources/clusters.go
+++ b/internal/datasources/clusters.go
@@ -93,7 +93,7 @@ func (d *Clusters) Read(ctx context.Context, req datasource.ReadRequest, resp *d
 
 	// Initialize Data so the data attribute is set even when no cluster
 	// matches. A nil slice becomes a null list in state, which fails checks
-	// on data.# (AV-134714).
+	// on data.#.
 	state.Data = make([]providerschema.ClusterData, 0, len(response))
 
 	for i := range response {

--- a/internal/datasources/clusters.go
+++ b/internal/datasources/clusters.go
@@ -23,6 +23,12 @@ var (
 // Clusters is the Clusters data source implementation.
 type Clusters struct {
 	*providerschema.Data
+
+	// FreeTierClusterFilter, when true, restricts the results to free-tier
+	// clusters. There is no list endpoint for free-tier clusters, so the
+	// free-tier clusters data source lists all clusters via /clusters and
+	// filters here on Support.Plan == "free".
+	FreeTierClusterFilter bool
 }
 
 // NewClusters is a helper function to simplify the provider implementation.
@@ -85,8 +91,16 @@ func (d *Clusters) Read(ctx context.Context, req datasource.ReadRequest, resp *d
 		return
 	}
 
+	// Initialize Data so the data attribute is set even when no cluster
+	// matches. A nil slice becomes a null list in state, which fails checks
+	// on data.# (AV-134714).
+	state.Data = make([]providerschema.ClusterData, 0, len(response))
+
 	for i := range response {
 		cluster := response[i]
+		if d.FreeTierClusterFilter && cluster.Support.Plan != "free" {
+			continue
+		}
 		audit := providerschema.NewCouchbaseAuditData(cluster.Audit)
 
 		auditObj, diags := types.ObjectValueFrom(ctx, audit.AttributeTypes(), audit)
@@ -95,6 +109,7 @@ func (d *Clusters) Read(ctx context.Context, req datasource.ReadRequest, resp *d
 				"Error Reading Capella Clusters",
 				fmt.Sprintf("Could not read clusters in organization %s and project %s, unexpected error: %s", organizationId, projectId, errors.ErrUnableToConvertAuditData),
 			)
+			return
 		}
 
 		newClusterData, err := providerschema.NewClusterData(&cluster, organizationId, projectId, auditObj)
@@ -103,6 +118,7 @@ func (d *Clusters) Read(ctx context.Context, req datasource.ReadRequest, resp *d
 				"Error Reading Capella Clusters",
 				fmt.Sprintf("Could not read clusters in organization %s and project %s, unexpected error: %s", organizationId, projectId, err.Error()),
 			)
+			return
 		}
 		state.Data = append(state.Data, *newClusterData)
 	}

--- a/internal/datasources/clusters.go
+++ b/internal/datasources/clusters.go
@@ -23,12 +23,6 @@ var (
 // Clusters is the Clusters data source implementation.
 type Clusters struct {
 	*providerschema.Data
-
-	// FreeTierClusterFilter, when true, restricts the results to free-tier
-	// clusters. There is no list endpoint for free-tier clusters, so the
-	// free-tier clusters data source lists all clusters via /clusters and
-	// filters here on Support.Plan == "free".
-	FreeTierClusterFilter bool
 }
 
 // NewClusters is a helper function to simplify the provider implementation.
@@ -93,9 +87,6 @@ func (d *Clusters) Read(ctx context.Context, req datasource.ReadRequest, resp *d
 
 	for i := range response {
 		cluster := response[i]
-		if d.FreeTierClusterFilter && cluster.Support.Plan != "free" {
-			continue
-		}
 		audit := providerschema.NewCouchbaseAuditData(cluster.Audit)
 
 		auditObj, diags := types.ObjectValueFrom(ctx, audit.AttributeTypes(), audit)

--- a/internal/datasources/free_tier_cluster.go
+++ b/internal/datasources/free_tier_cluster.go
@@ -2,8 +2,16 @@ package datasources
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	clusterapi "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/cluster"
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var (
@@ -17,15 +25,86 @@ type FreeTierClusters struct {
 
 func NewFreeTierClusters() datasource.DataSource {
 	return &FreeTierClusters{
-		Clusters: &Clusters{
-			// There is no list endpoint for free-tier clusters, so list all
-			// clusters via /clusters and keep only the free-tier ones.
-			FreeTierClusterFilter: true,
-		},
+		Clusters: &Clusters{},
 	}
 }
 
 // Metadata returns the cluster data source type name.
 func (f *FreeTierClusters) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_free_tier_clusters"
+}
+
+// Read refreshes the Terraform state with the latest data of free-tier clusters.
+func (f *FreeTierClusters) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state providerschema.Clusters
+	diags := req.Config.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.OrganizationId.IsNull() {
+		resp.Diagnostics.AddError(
+			"Error reading free-tier clusters",
+			"Could not read free-tier clusters, unexpected error: organization ID cannot be empty.",
+		)
+		return
+	}
+
+	if state.ProjectId.IsNull() {
+		resp.Diagnostics.AddError(
+			"Error reading free-tier clusters",
+			"Could not read free-tier clusters, unexpected error: project ID cannot be empty.",
+		)
+		return
+	}
+
+	var (
+		organizationId = state.OrganizationId.ValueString()
+		projectId      = state.ProjectId.ValueString()
+	)
+
+	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/freeTier", f.HostURL, organizationId, projectId)
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+
+	response, err := api.GetPaginated[[]clusterapi.GetClusterResponse](ctx, f.ClientV1, f.Token, cfg, api.SortById)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Capella Free-Tier Clusters",
+			fmt.Sprintf(
+				"Could not read free-tier clusters in organization %s and project %s, unexpected error: %s",
+				organizationId, projectId, api.ParseError(err),
+			),
+		)
+		return
+	}
+
+	state.Data = make([]providerschema.ClusterData, 0, len(response))
+	for i := range response {
+		cluster := response[i]
+		audit := providerschema.NewCouchbaseAuditData(cluster.Audit)
+
+		auditObj, diags := types.ObjectValueFrom(ctx, audit.AttributeTypes(), audit)
+		if diags.HasError() {
+			resp.Diagnostics.AddError(
+				"Error Reading Capella Free-Tier Clusters",
+				fmt.Sprintf("Could not read free-tier clusters in organization %s and project %s, unexpected error: %s", organizationId, projectId, errors.ErrUnableToConvertAuditData),
+			)
+		}
+
+		newClusterData, err := providerschema.NewClusterData(&cluster, organizationId, projectId, auditObj)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading Capella Free-Tier Clusters",
+				fmt.Sprintf("Could not read free-tier clusters in organization %s and project %s, unexpected error: %s", organizationId, projectId, err.Error()),
+			)
+		}
+		state.Data = append(state.Data, *newClusterData)
+	}
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }

--- a/internal/datasources/free_tier_cluster.go
+++ b/internal/datasources/free_tier_cluster.go
@@ -2,16 +2,8 @@ package datasources
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-
-	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
-	clusterapi "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/cluster"
-	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
-	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var (
@@ -25,86 +17,15 @@ type FreeTierClusters struct {
 
 func NewFreeTierClusters() datasource.DataSource {
 	return &FreeTierClusters{
-		Clusters: &Clusters{},
+		Clusters: &Clusters{
+			// There is no list endpoint for free-tier clusters, so list all
+			// clusters via /clusters and keep only the free-tier ones.
+			FreeTierClusterFilter: true,
+		},
 	}
 }
 
 // Metadata returns the cluster data source type name.
 func (f *FreeTierClusters) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_free_tier_clusters"
-}
-
-// Read refreshes the Terraform state with the latest data of free-tier clusters.
-func (f *FreeTierClusters) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var state providerschema.Clusters
-	diags := req.Config.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if state.OrganizationId.IsNull() {
-		resp.Diagnostics.AddError(
-			"Error reading free-tier clusters",
-			"Could not read free-tier clusters, unexpected error: organization ID cannot be empty.",
-		)
-		return
-	}
-
-	if state.ProjectId.IsNull() {
-		resp.Diagnostics.AddError(
-			"Error reading free-tier clusters",
-			"Could not read free-tier clusters, unexpected error: project ID cannot be empty.",
-		)
-		return
-	}
-
-	var (
-		organizationId = state.OrganizationId.ValueString()
-		projectId      = state.ProjectId.ValueString()
-	)
-
-	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/freeTier", f.HostURL, organizationId, projectId)
-	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
-
-	response, err := api.GetPaginated[[]clusterapi.GetClusterResponse](ctx, f.ClientV1, f.Token, cfg, api.SortById)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Capella Free-Tier Clusters",
-			fmt.Sprintf(
-				"Could not read free-tier clusters in organization %s and project %s, unexpected error: %s",
-				organizationId, projectId, api.ParseError(err),
-			),
-		)
-		return
-	}
-
-	state.Data = make([]providerschema.ClusterData, 0, len(response))
-	for i := range response {
-		cluster := response[i]
-		audit := providerschema.NewCouchbaseAuditData(cluster.Audit)
-
-		auditObj, diags := types.ObjectValueFrom(ctx, audit.AttributeTypes(), audit)
-		if diags.HasError() {
-			resp.Diagnostics.AddError(
-				"Error Reading Capella Free-Tier Clusters",
-				fmt.Sprintf("Could not read free-tier clusters in organization %s and project %s, unexpected error: %s", organizationId, projectId, errors.ErrUnableToConvertAuditData),
-			)
-		}
-
-		newClusterData, err := providerschema.NewClusterData(&cluster, organizationId, projectId, auditObj)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error Reading Capella Free-Tier Clusters",
-				fmt.Sprintf("Could not read free-tier clusters in organization %s and project %s, unexpected error: %s", organizationId, projectId, err.Error()),
-			)
-		}
-		state.Data = append(state.Data, *newClusterData)
-	}
-
-	diags = resp.State.Set(ctx, &state)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }


### PR DESCRIPTION
## Jira

* AV-134714

## Description

`Clusters.Read` never initialized `state.Data`, so a zero-match result was a nil slice → null list in state → `Attribute 'data.#' expected to be set`. Now initialized to an empty slice; fixes both `clusters` and `free_tier_clusters`.
 Also added missing `return` on two loop error paths (`NewClusterData` returns nil, code deref'd it → provider panic). Kept the `/clusters` + `plan == "free"` filter: `GET clusters/freeTier` isn't a real op (POST-only in spec), so it would 404.

Ticket: [AV-134714](https://couchbasecloud.atlassian.net/browse/AV-134714)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence?

- [x] Manually tested
- [x] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

### Bug : Empty Result

1. Pre-fix:
```
Changes to Outputs:
  + free_tier_clusters_list = {
      + data            = null
      + organization_id = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
      + project_id      = "c09035e8-3971-4b79-a6ec-bccd9056041f"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
                                                                                                                                                                                                                         
Outputs:                                                                                                                                                                                                                 
                                                                                                                                                                                                                         
free_tier_clusters_list = {                                                                                                                                                                                              
  "data" = tolist(null) /* of object */
  "organization_id" = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
  "project_id" = "c09035e8-3971-4b79-a6ec-bccd9056041f"
}
pdeshmukh@KCQR2MGC9L free_tier_cluster % terraform output free_tier_clusters_list
{
  "data" = tolist(null) /* of object */
  "organization_id" = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
  "project_id" = "c09035e8-3971-4b79-a6ec-bccd9056041f"
}
```

**Expected:**  "data" = tolist(null). That null is the bug - data.# doesn't exist, so any check on it fails.

2. Post fix
```
Changes to Outputs:
  ~ free_tier_clusters_list = {
      ~ data            = null -> []
        # (2 unchanged attributes hidden)
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.                                                                                                                                                              
                                                                                                                                                                                                                         
Outputs:                                                                                                                                                                                                                 
                                                                                                                                                                                                                         
free_tier_clusters_list = {                                                                                                                                                                                              
  "data" = tolist([])
  "organization_id" = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
  "project_id" = "c09035e8-3971-4b79-a6ec-bccd9056041f"
}
pdeshmukh@KCQR2MGC9L free_tier_cluster % terraform output free_tier_clusters_list
{
  "data" = tolist([])
  "organization_id" = "adb4fb4c-1d98-4287-ac33-230742d2cc76"
  "project_id" = "c09035e8-3971-4b79-a6ec-bccd9056041f"
}
```

**Expected:**  "data" = tolist([]). tolist(null) → tolist([]) is the entire before/after for the PR.

</details>

## Further comments

- **Acceptance testing outstanding** -`TestAccFreeTierClusters_AV_134714` should run against a live org/project before merge: `TF_ACC=1 go test ./acceptance_tests/ -run TestAccFreeTierClusters_AV_134714 -v -timeout 30m`.

[AV-134714]: https://couchbasecloud.atlassian.net/browse/AV-134714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ