### PR TITLE
[AV-138726] Handle App Services entering a failed state properly

### DIFF
--- a/internal/api/appservice/state.go
+++ b/internal/api/appservice/state.go
@@ -54,3 +54,17 @@ func IsFinalState(state State) bool {
 	}
 	return slices.Contains(finalStates, state)
 }
+
+// IsFailureState reports whether the App Service state is a final failure state.
+// All states here must also be in IsFinalState
+func IsFailureState(state State) bool {
+	failureStates := []State{
+		DeploymentFailed,
+		DestroyFailed,
+		ScaleFailed,
+		UpgradeFailed,
+		TurnOnFailed,
+		TurnOffFailed,
+	}
+	return slices.Contains(failureStates, state)
+}

--- a/internal/api/appservice/state_test.go
+++ b/internal/api/appservice/state_test.go
@@ -1,0 +1,46 @@
+package appservice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatePredicates(t *testing.T) {
+	tests := []struct {
+		name        string
+		state       State
+		wantFinal   bool
+		wantFailure bool
+	}{
+		{name: "pending is transitional", state: Pending, wantFinal: false, wantFailure: false},
+		{name: "deploying is transitional", state: Deploying, wantFinal: false, wantFailure: false},
+		{name: "destroying is transitional", state: Destroying, wantFinal: false, wantFailure: false},
+		{name: "scaling is transitional", state: Scaling, wantFinal: false, wantFailure: false},
+		{name: "upgrading is transitional", state: Upgrading, wantFinal: false, wantFailure: false},
+		{name: "turningOn is transitional", state: TurningOn, wantFinal: false, wantFailure: false},
+		{name: "turningOff is transitional", state: TurningOff, wantFinal: false, wantFailure: false},
+		{name: "healthy is a success", state: Healthy, wantFinal: true, wantFailure: false},
+		{name: "degraded is a success", state: Degraded, wantFinal: true, wantFailure: false},
+		{name: "turnedOff is a success", state: TurnedOff, wantFinal: true, wantFailure: false},
+		{name: "deploymentFailed is a failure", state: DeploymentFailed, wantFinal: true, wantFailure: true},
+		{name: "destroyFailed is a failure", state: DestroyFailed, wantFinal: true, wantFailure: true},
+		{name: "scaleFailed is a failure", state: ScaleFailed, wantFinal: true, wantFailure: true},
+		{name: "upgradeFailed is a failure", state: UpgradeFailed, wantFinal: true, wantFailure: true},
+		{name: "turnOnFailed is a failure", state: TurnOnFailed, wantFinal: true, wantFailure: true},
+		{name: "turnOffFailed is a failure", state: TurnOffFailed, wantFinal: true, wantFailure: true},
+		{name: "unrecognised state is transitional", state: State("somethingElse"), wantFinal: false, wantFailure: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantFinal, IsFinalState(tt.state))
+			assert.Equal(t, tt.wantFailure, IsFailureState(tt.state))
+
+			// Every failure state must also be a final state
+			if tt.wantFailure {
+				assert.True(t, IsFinalState(tt.state))
+			}
+		})
+	}
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -260,6 +260,9 @@ var (
 
 	ErrAppServiceCreationStatusTimeout = errors.New("app service creation status transition timed out after initiation")
 
+	// ErrAppServiceFailedState is returned when the App Service reports that it is in a terminal failed state (e.g. deployment failed).
+	ErrAppServiceFailedState = errors.New("app service operation failed")
+
 	ErrMonitorTimeout = errors.New("timed out while watching indexes")
 
 	ErrIndexDeferred = errors.New("index is in Deferred state and will not become Ready without a BUILD INDEX statement")

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -167,13 +168,24 @@ func (a *AppService) Create(ctx context.Context, req resource.CreateRequest, res
 	}
 
 	err = a.checkAppServiceStatus(ctx, organizationId, projectId, clusterId, createAppServiceResponse.Id.String())
-	if err != nil {
+	switch {
+	case err == nil:
+	case stderrors.Is(err, errors.ErrAppServiceFailedState):
+		// Fall through to record the current state alongside the error
+		resp.Diagnostics.AddError(
+			"App Service creation failed",
+			"App Service has been created but is in a failed state. "+
+				"Please contact Couchbase Capella support for further guidance. "+
+				"Error: "+api.ParseError(err),
+		)
+	default:
 		resp.Diagnostics.AddWarning(
 			"Error creating app service",
 			errorMessageAfterAppServiceCreationInitiation+api.ParseError(err),
 		)
 		return
 	}
+
 	refreshedState, err := a.refreshAppService(ctx, organizationId, projectId, clusterId, createAppServiceResponse.Id.String())
 	if err != nil {
 		resp.Diagnostics.AddWarning(
@@ -322,7 +334,17 @@ func (a *AppService) Update(ctx context.Context, req resource.UpdateRequest, res
 	}
 
 	err = a.checkAppServiceStatus(ctx, organizationId, projectId, clusterId, appServiceId)
-	if err != nil {
+	switch {
+	case err == nil:
+	case stderrors.Is(err, errors.ErrAppServiceFailedState):
+		// Fall through to record the current state alongside the error
+		resp.Diagnostics.AddError(
+			"App Service update failed",
+			"App Service has entered a failed state after the update was applied. "+
+				"Please contact Couchbase Capella support for further guidance. "+
+				"Error: "+api.ParseError(err),
+		)
+	default:
 		resp.Diagnostics.AddError(
 			"Error updating app service",
 			"Could not update app service id "+state.Id.String()+": "+api.ParseError(err),
@@ -400,41 +422,50 @@ func (a *AppService) Delete(ctx context.Context, req resource.DeleteRequest, res
 		return
 	}
 
-	err = a.checkAppServiceStatus(ctx, state.OrganizationId.ValueString(), state.ProjectId.ValueString(), state.ClusterId.ValueString(), state.Id.ValueString())
-	if err != nil {
+	err = a.checkAppServiceStatus(ctx, organizationId, projectId, clusterId, appServiceId)
+	switch {
+	case err == nil:
+		// This case should never happen as it means a destroy operation started but the App Service has entered a different
+		// state then a destroy failed or destroying state. Add an error just in-case.
+		resp.Diagnostics.AddError(
+			"Error deleting app service",
+			"App Service "+state.Id.String()+" has entered an unexpected state. "+
+				"Please retry the destroy operation.",
+		)
+	case stderrors.Is(err, errors.ErrAppServiceFailedState):
+		resp.Diagnostics.AddError(
+			"App Service deletion failed",
+			"App Service has entered a failed state while attempting to delete. "+
+				"Please contact Couchbase Capella support for further guidance. "+
+				"Error: "+api.ParseError(err),
+		)
+	default:
 		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
-		if !resourceNotFound {
-			resp.Diagnostics.AddError(
-				"Error deleting app service",
-				"Could not delete app service id "+state.Id.String()+": "+errString,
-			)
+		if resourceNotFound {
+			// Deleted as expected, all good to return now
 			return
 		}
-		// resourceNotFound as expected
-		return
+
+		resp.Diagnostics.AddError(
+			"Error deleting app service",
+			"Could not delete app service id "+state.Id.String()+": "+errString,
+		)
 	}
 
-	// This will only be reached when app service deletion has failed,
-	// and the app service record still exists in the cp metadata. Therefore,
-	// no error will be returned when performing a GET call.
-	appService, err := a.refreshAppService(ctx, state.OrganizationId.ValueString(), state.ProjectId.ValueString(), state.ClusterId.ValueString(), state.Id.ValueString())
+	currentState, err := a.refreshAppService(ctx, state.OrganizationId.ValueString(), state.ProjectId.ValueString(), state.ClusterId.ValueString(), state.Id.ValueString())
 	if err != nil {
-		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
+		resourceNotFound, _ := api.CheckResourceNotFoundError(err)
 		if resourceNotFound {
 			tflog.Info(ctx, "resource doesn't exist in remote server removing resource from state file")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Error deleting app service",
-			"Could not delete app service id "+state.Id.String()+": "+errString,
-		)
+		tflog.Error(ctx, fmt.Sprintf("failed to refresh App Service state after failed deletion: %v", err))
 		return
 	}
-	resp.Diagnostics.AddError(
-		"Error deleting app service",
-		fmt.Sprintf("Could not delete app service id %s, as current app service state: %s", state.Id.String(), appService.CurrentState),
-	)
+
+	diags = resp.State.Set(ctx, currentState)
+	resp.Diagnostics.Append(diags...)
 }
 
 // Configure adds the provider configured client to the app service resource.
@@ -533,17 +564,22 @@ func (a *AppService) checkAppServiceStatus(ctx context.Context, organizationId, 
 
 		case <-timer.C:
 			appServiceResp, err = a.getAppService(ctx, organizationId, projectId, clusterId, appServiceId)
-			switch err {
-			case nil:
-				if appservice.IsFinalState(appServiceResp.CurrentState) {
-					return nil
-				}
-				const msg = "waiting for app service to complete the execution"
-				tflog.Info(ctx, msg)
-			default:
+			if err != nil {
 				return err
 			}
-			timer.Reset(sleep)
+
+			if !appservice.IsFinalState(appServiceResp.CurrentState) {
+				const msg = "waiting for app service to complete the execution"
+				tflog.Info(ctx, msg)
+				timer.Reset(sleep)
+				continue
+			}
+
+			if appservice.IsFailureState(appServiceResp.CurrentState) {
+				return fmt.Errorf("%w, current state: %s", errors.ErrAppServiceFailedState, appServiceResp.CurrentState)
+			}
+
+			return nil
 		}
 	}
 }

--- a/internal/resources/appservice.go
+++ b/internal/resources/appservice.go
@@ -172,10 +172,11 @@ func (a *AppService) Create(ctx context.Context, req resource.CreateRequest, res
 	case err == nil:
 	case stderrors.Is(err, errors.ErrAppServiceFailedState):
 		// Fall through to record the current state alongside the error
-		resp.Diagnostics.AddError(
+		resp.Diagnostics.AddWarning(
 			"App Service creation failed",
 			"App Service has been created but is in a failed state. "+
 				"Please contact Couchbase Capella support for further guidance. "+
+				"Additionally, run `terraform apply --refresh-only` to get the latest App Service state from the remote. "+
 				"Error: "+api.ParseError(err),
 		)
 	default:

--- a/internal/resources/free_tier_appservice.go
+++ b/internal/resources/free_tier_appservice.go
@@ -98,10 +98,10 @@ func (f *FreeTierAppService) Create(ctx context.Context, request resource.Create
 	case err == nil:
 	case stderrors.Is(err, errors.ErrAppServiceFailedState):
 		// Fall through to record the current state alongside the error
-		response.Diagnostics.AddError(
+		response.Diagnostics.AddWarning(
 			"Free tier app service creation failed",
 			"Free tier app service has been created but is in a failed state. "+
-				"Please contact Couchbase Capella support for further guidance. "+
+				"Run `terraform apply --refresh-only` to get the latest App Service state from the remote. "+
 				"Error: "+api.ParseError(err),
 		)
 	default:

--- a/internal/resources/free_tier_appservice.go
+++ b/internal/resources/free_tier_appservice.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -93,7 +94,17 @@ func (f *FreeTierAppService) Create(ctx context.Context, request resource.Create
 	}
 
 	err = f.checkFreeTierAppServiceStatus(ctx, organizationId, projectId, clusterId, freeTierCreateAppServiceResponse.Id.String())
-	if err != nil {
+	switch {
+	case err == nil:
+	case stderrors.Is(err, errors.ErrAppServiceFailedState):
+		// Fall through to record the current state alongside the error
+		response.Diagnostics.AddError(
+			"Free tier app service creation failed",
+			"Free tier app service has been created but is in a failed state. "+
+				"Please contact Couchbase Capella support for further guidance. "+
+				"Error: "+api.ParseError(err),
+		)
+	default:
 		response.Diagnostics.AddWarning(
 			"Error creating app service",
 			errors.ErrFreeTierAppServiceAfterCreation.Error()+api.ParseError(err),
@@ -212,11 +223,22 @@ func (f *FreeTierAppService) Update(ctx context.Context, request resource.Update
 		return
 	}
 	err = f.checkFreeTierAppServiceStatus(ctx, organizationId, projectId, clusterId, appServiceId)
-	if err != nil {
+	switch {
+	case err == nil:
+	case stderrors.Is(err, errors.ErrAppServiceFailedState):
+		// Fall through to record the current state alongside the error
+		response.Diagnostics.AddError(
+			"Free tier app service update failed",
+			"Free tier app service has entered a failed state after the update was applied. "+
+				"Please contact Couchbase Capella support for further guidance. "+
+				"Error: "+api.ParseError(err),
+		)
+	default:
 		response.Diagnostics.AddError(
 			"Error updating free tier app service",
 			"could not update app service with id "+state.Id.String()+api.ParseError(err),
 		)
+		return
 	}
 
 	refreshedState, err := f.refreshFreeTierAppService(ctx, organizationId, projectId, clusterId, appServiceId)
@@ -280,39 +302,49 @@ func (f *FreeTierAppService) Delete(ctx context.Context, request resource.Delete
 	}
 
 	err = f.checkFreeTierAppServiceStatus(ctx, organizationId, projectId, clusterId, appserviceId)
-	if err != nil {
+	switch {
+	case err == nil:
+		// This case should never happen as it means a destroy operation started but the App Service has entered a different
+		// state then a destroy failed or destroying state. Add an error just in-case.
+		response.Diagnostics.AddError(
+			"Error deleting free tier app service",
+			"Free tier app service "+state.Id.String()+" has entered an unexpected state. "+
+				"Please retry the destroy operation.",
+		)
+	case stderrors.Is(err, errors.ErrAppServiceFailedState):
+		response.Diagnostics.AddError(
+			"Free tier app service deletion failed",
+			"Free tier app service has entered a failed state while attempting to delete. "+
+				"Please contact Couchbase Capella support for further guidance. "+
+				"Error: "+api.ParseError(err),
+		)
+	default:
 		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
-		if !resourceNotFound {
-			response.Diagnostics.AddError(
-				"Failed to delete free tier app service",
-				"could not delete app service with id "+state.Id.String()+errString,
-			)
+		if resourceNotFound {
+			// Deleted as expected, all good to return now
 			return
 		}
-		return
+
+		response.Diagnostics.AddError(
+			"Failed to delete free tier app service",
+			"could not delete app service with id "+state.Id.String()+errString,
+		)
 	}
 
-	// This will only be reached when app service deletion has failed,
-	// and the app service record still exists in the cp metadata. Therefore,
-	// no error will be returned when performing a GET call.
-	freeTierAppService, err := f.refreshFreeTierAppService(ctx, state.OrganizationId.ValueString(), state.ProjectId.ValueString(), state.ClusterId.ValueString(), state.Id.ValueString())
+	currentState, err := f.refreshFreeTierAppService(ctx, state.OrganizationId.ValueString(), state.ProjectId.ValueString(), state.ClusterId.ValueString(), state.Id.ValueString())
 	if err != nil {
-		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
+		resourceNotFound, _ := api.CheckResourceNotFoundError(err)
 		if resourceNotFound {
 			tflog.Info(ctx, "resource doesn't exist in remote server removing resource from state file")
 			response.State.RemoveResource(ctx)
 			return
 		}
-		response.Diagnostics.AddError(
-			"Error deleting app service",
-			"Could not delete app service id "+state.Id.String()+": "+errString,
-		)
+		tflog.Error(ctx, fmt.Sprintf("failed to refresh free tier App Service state after failed deletion: %v", err))
 		return
 	}
-	response.Diagnostics.AddError(
-		"Error deleting app service",
-		fmt.Sprintf("Could not delete free-tier app service id %s, as current app service state: %s", state.Id.String(), freeTierAppService.CurrentState),
-	)
+
+	diags = response.State.Set(ctx, currentState)
+	response.Diagnostics.Append(diags...)
 }
 
 // Configure adds the provider configured client to the free-tier app service resource.
@@ -439,17 +471,22 @@ func (f *FreeTierAppService) checkFreeTierAppServiceStatus(ctx context.Context, 
 
 		case <-timer.C:
 			appServiceResp, err = f.getFreeTierAppService(ctx, organizationId, projectId, clusterId, appServiceId)
-			switch err {
-			case nil:
-				if appservice.IsFinalState(appServiceResp.CurrentState) {
-					return nil
-				}
-				const msg = "waiting for app service to complete the execution"
-				tflog.Info(ctx, msg)
-			default:
+			if err != nil {
 				return err
 			}
-			timer.Reset(sleep)
+
+			if !appservice.IsFinalState(appServiceResp.CurrentState) {
+				const msg = "waiting for app service to complete the execution"
+				tflog.Info(ctx, msg)
+				timer.Reset(sleep)
+				continue
+			}
+
+			if appservice.IsFailureState(appServiceResp.CurrentState) {
+				return fmt.Errorf("%w, current state: %s", errors.ErrAppServiceFailedState, appServiceResp.CurrentState)
+			}
+
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-138726

## Description

Handle what to do if an App Service enters a failed state during a C-UD op by writing it to the state file with a nice error message

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

Force creation failure

```
resource "couchbase-capella_app_service" "new_app_service" {
  organization_id = var.org_id
  project_id      = local.project_id
  cluster_id      = local.cluster_id
  name            = "isaac"
  description     = "App service"
  nodes           = 1
  version         = "4.0"
  compute = {
    cpu = 4
    ram = 8
  }
}

$ terraform apply
...
couchbase-capella_app_service.new_app_service: Still creating... [02m00s elapsed]
couchbase-capella_app_service.new_app_service: Creation complete after 2m2s [id=49f04268-2ed1-406b-932e-d0294382090d]
╷
│ Warning: App Service creation failed
│
│   with couchbase-capella_app_service.new_app_service,
│   on terraform.tf line 110, in resource "couchbase-capella_app_service" "new_app_service":
│  110: resource "couchbase-capella_app_service" "new_app_service" {
│
│ App Service has been created but is in a failed state. Please contact Couchbase Capella support for further guidance. Additionally, run `terraform apply --refresh-only` to get the latest App
│ Service state from the remote. Error: app service operation failed, current state: deploymentFailed
╵

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Make app service healthy then refresh
```
$ terraform apply -refresh-only

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have affected this plan:

  # couchbase-capella_app_service.new_app_service has changed
  ~ resource "couchbase-capella_app_service" "new_app_service" {
      ~ audit           = {
          ~ modified_at = "2026-08-11 11:27:14.528360427 +0000 UTC" -> "2026-08-11 12:10:36.442704257 +0000 UTC"
          ~ modified_by = "apikey-B9bj6JJAwdVyPG7AaP2DKJH0X3bbZiek" -> "internal-support"
          ~ version     = 4 -> 11
            # (2 unchanged attributes hidden)
        }
      ~ current_state   = "deploymentFailed" -> "healthy"
      ~ etag            = "Version: 4" -> "Version: 11"
        id              = "49f04268-2ed1-406b-932e-d0294382090d"
        name            = "isaac"
        # (8 unchanged attributes hidden)
    }
...
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

Scale app service with failure
```
...
  compute = {
    cpu = 2
    ram = 4
  }
...

$ terraform apply
...
couchbase-capella_app_service.new_app_service: Still modifying... [id=49f04268-2ed1-406b-932e-d0294382090d, 02m00s elapsed]
╷
│ Error: App Service update failed
│
│   with couchbase-capella_app_service.new_app_service,
│   on terraform.tf line 110, in resource "couchbase-capella_app_service" "new_app_service":
│  110: resource "couchbase-capella_app_service" "new_app_service" {
│
│ App Service has entered a failed state after the update was applied. Please contact Couchbase Capella support for further guidance. Error: app service
│ operation failed, current state: scaleFailed

State except
...
"current_state": "scaleFailed",
"compute": {"cpu": 2, "ram": 4},
...
```

Make app service healthy and refresh

```
$ terraform apply -refresh-only

couchbase-capella_app_service.new_app_service: Refreshing state... [id=49f04268-2ed1-406b-932e-d0294382090d]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have affected this plan:

  # couchbase-capella_app_service.new_app_service has changed
...
      ~ current_state   = "scaleFailed" -> "healthy"
...
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

Destroy app service with failure

```
...
couchbase-capella_app_service.new_app_service: Still destroying... [id=49f04268-2ed1-406b-932e-d0294382090d, 02m00s elapsed]

Error: App Service deletion failed

App Service has entered a failed state while attempting to delete. Please
contact Couchbase Capella support for further guidance. Error: app service
operation failed, current state: destroyFailed
```

  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments