### PR TITLE
[AV-139841] Use List/ListNestedAttribute instead of Set for access/buckets/scopes/collections

### DIFF
--- a/docs/resources/database_credential.md
+++ b/docs/resources/database_credential.md
@@ -35,7 +35,7 @@ resource "couchbase-capella_database_credential" "new_database_credential" {
 
 ### Required
 
-- `access` (Attributes Set) - Describes the access information of the database credential. (see [below for nested schema](#nestedatt--access))
+- `access` (Attributes List) - Describes the access information of the database credential. (see [below for nested schema](#nestedatt--access))
 - `cluster_id` (String) The GUID4 ID of the cluster.
 - `name` (String) - Username for the database credential. The name should adhere to the following rules: The name must be between 2 & 128 characters. The name cannot contain spaces. The name cannot contain the following characters - `) ( > < , ; : " \ / ] [ ? = } {` The name cannot begin with `@` character.
  - **Constraints**: Minimum length: 2 characters, Maximum length: 128 characters
@@ -69,7 +69,7 @@ Optional:
 
 Optional:
 
-- `buckets` (Attributes Set) (see [below for nested schema](#nestedatt--access--resources--buckets))
+- `buckets` (Attributes List) (see [below for nested schema](#nestedatt--access--resources--buckets))
 
 <a id="nestedatt--access--resources--buckets"></a>
 ### Nested Schema for `access.resources.buckets`
@@ -81,7 +81,7 @@ Required:
 
 Optional:
 
-- `scopes` (Attributes Set) (see [below for nested schema](#nestedatt--access--resources--buckets--scopes))
+- `scopes` (Attributes List) (see [below for nested schema](#nestedatt--access--resources--buckets--scopes))
 
 <a id="nestedatt--access--resources--buckets--scopes"></a>
 ### Nested Schema for `access.resources.buckets.scopes`
@@ -93,7 +93,7 @@ Required:
 
 Optional:
 
-- `collections` (Set of String)
+- `collections` (List of String)
 
 
 

--- a/internal/resources/database_credential_schema.go
+++ b/internal/resources/database_credential_schema.go
@@ -31,11 +31,11 @@ func DatabaseCredentialSchema() schema.Schema {
 
 	scopeAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(scopeAttrs, "name", databaseCredentialBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(scopeAttrs, "collections", databaseCredentialBuilder, stringSetAttribute(optional))
+	capellaschema.AddAttr(scopeAttrs, "collections", databaseCredentialBuilder, stringListAttribute(optional))
 
 	bucketAttrs := make(map[string]schema.Attribute)
 	capellaschema.AddAttr(bucketAttrs, "name", databaseCredentialBuilder, stringAttribute([]string{required}))
-	capellaschema.AddAttr(bucketAttrs, "scopes", databaseCredentialBuilder, &schema.SetNestedAttribute{
+	capellaschema.AddAttr(bucketAttrs, "scopes", databaseCredentialBuilder, &schema.ListNestedAttribute{
 		Optional: true,
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: scopeAttrs,
@@ -43,7 +43,7 @@ func DatabaseCredentialSchema() schema.Schema {
 	})
 
 	resourcesAttrs := make(map[string]schema.Attribute)
-	capellaschema.AddAttr(resourcesAttrs, "buckets", databaseCredentialBuilder, &schema.SetNestedAttribute{
+	capellaschema.AddAttr(resourcesAttrs, "buckets", databaseCredentialBuilder, &schema.ListNestedAttribute{
 		Optional: true,
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: bucketAttrs,
@@ -57,7 +57,7 @@ func DatabaseCredentialSchema() schema.Schema {
 		Attributes: resourcesAttrs,
 	})
 
-	capellaschema.AddAttr(attrs, "access", databaseCredentialBuilder, &schema.SetNestedAttribute{
+	capellaschema.AddAttr(attrs, "access", databaseCredentialBuilder, &schema.ListNestedAttribute{
 		Required: true,
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: accessAttrs,


### PR DESCRIPTION
## Jira

* AV-139841

## Description

`access`, `access.resources.buckets`, `buckets.scopes` and `scopes.collections` in `database_credential` are declared as `Set`/`SetNestedAttribute`. Set elements have no stable index, so `terraform-plugin-go` resolves each element via a linear scan + recursive `deepEqual` (`tftypes/value.go`, `ApplyTerraform5AttributePathStep`, case `ElementKeyValue`). With nested sets and a large `collections` list this scales very poorly - we measured a single `database_credential` with ~59 collections taking 37+ minutes of a 39-minute `terraform plan` (see #700 for full trace analysis), while ~56 other credentials with 1-5 collections each finished in seconds.

This PR switches these four attributes to `List`/`ListNestedAttribute`. Order isn't semantically meaningful for access grants, and List path resolution is `ElementKeyInt` - a plain O(1) index, no scan, no deep-equal. This also makes the resource schema consistent with the existing `database_credentials` **data source**, which already uses `ListNestedAttribute`/`ListAttribute` for the same `buckets`/`scopes`/`collections` shape.

No Go struct changes were needed - `internal/schema/database_credential.go` already models these fields as plain slices (`[]Access`, `[]BucketResource`, `[]types.String`), and `internal/resources/database_credential.go` (`createAccess`/`mapAccess`) already does index-based iteration, not Set-specific conversion.

**Note on compatibility:** for `for_each`-driven configs (our case) this is a drop-in replacement - HCL syntax for the `access` block is unchanged. For statically-written configs where element order previously didn't matter (Set semantics), Terraform will now show reordering as a diff at the next `plan` (state values are unaffected; this does not change access itself, only how it's declared/diffed). Happy to add a `CHANGELOG`/upgrade-notes entry if maintainers want one - this repo doesn't have a `.changelog/` fragment convention, so I didn't add one on my own.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). See compatibility note above - I don't believe this qualifies, but flagging for maintainer judgment given the Set to List switch.
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [x] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

  `go build ./...`, `go vet ./internal/resources/...`, `gofmt -l` clean.
  `go test ./internal/resources/... ./internal/datasources/...` pass.
  Reran the real-world `terraform plan` that originally took 37m17s for this resource against the schema change locally.
  Docs regenerated by hand for `docs/resources/database_credential.md` (`tfplugindocs generate` errored in my sandbox on an unrelated provider-name mismatch, not caused by this change - happy to have a maintainer regenerate via CI if the manual edit looks off).
  Existing acceptance tests for this resource use index-based `TestCheckResourceAttr` checks (e.g. `access.0.privileges.0`), which are compatible with both Set and List representations, but I did not run them against a live Capella org (no test credentials available to me).

</details>

## Further comments