### PR TITLE
[AV-140333] Run audit log acceptance tests against the shared global cluster

### DIFF
--- a/acceptance_tests/audit_log_export_acceptance_test.go
+++ b/acceptance_tests/audit_log_export_acceptance_test.go
@@ -40,7 +40,7 @@ func TestAccAuditLogExportResource(t *testing.T) {
 	// when GET /auditLogExports/{id} is called for an export whose time
 	// window contains no audit data. The CI test cluster does not have
 	// audit logging configured (audit_log_settings.audit_enabled is the
-	// per-cluster singleton set by TestAccAuditLogSettingsResource — and
+	// per-cluster singleton set by TestAccAuditLog — and
 	// it ends with audit_enabled=false), so every export request on
 	// globalClusterId hits this 404. The provider's refreshAuditLogExport
 	// classifies any 404 as ResourceNotFound and the framework's

--- a/acceptance_tests/audit_log_settings_acceptance_test.go
+++ b/acceptance_tests/audit_log_settings_acceptance_test.go
@@ -15,77 +15,133 @@ import (
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
 
-// audit_log_settings is a per-cluster singleton — Create/Update both PUT,
-// Delete is a no-op. We exercise: Create -> Read -> Import -> Update.
+// audit_log_settings is a per-cluster singleton — Create/Update both PUT and
+// Delete disables auditing. TestAccAuditLog runs the tests that need a real
+// cluster as sequential subtests against the shared global cluster so they do
+// not overwrite each other's settings, and so the suite no longer deploys a
+// cluster per audit test.
+func TestAccAuditLog(t *testing.T) {
+	// Allow this test to run in parallel with other top-level tests, but ensure that the subtests run sequentially
+	// This is normally set by resource.ParallelTest
+	t.Parallel()
 
-func TestAccAuditLogSettingsResource(t *testing.T) {
-	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_")
+	t.Run("Audit Log Settings", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+			Steps:                    auditLogSettingsSteps(t),
+		})
+	})
+
+	t.Run("Audit Log Settings Datasource", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+			Steps:                    auditLogSettingsDatasourceSteps(),
+		})
+	})
+
+	t.Run("Audit Log Settings Disable On Removal", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+			Steps:                    auditLogSettingsDisableOnRemovalSteps(t),
+		})
+	})
+}
+
+// auditLogSettingsSteps provides the steps to test the lifecycle of the
+// audit_log_settings resource on the global cluster: Create -> Import ->
+// Update (disabled users) -> Update (audit disabled).
+func auditLogSettingsSteps(t *testing.T) []resource.TestStep {
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_")
 	databaseCredentialName := randomStringWithPrefix("tf_acc_audit_db_credential_")
-	cidr := generateRandomCIDR()
-	clusterReference := "couchbase-capella_cluster." + clusterResourceName
 	resourceReference := "couchbase-capella_audit_log_settings." + resourceName
 
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, true, []int{20488, 20490, 20491}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccExistsAuditLogSettingsResource(t, resourceReference),
-					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
-					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
-					resource.TestCheckResourceAttrPair(resourceReference, "cluster_id", clusterReference, "id"),
-					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "3"),
-					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
-					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20490"),
-					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20491"),
-					resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "0"),
-				),
-			},
-			{
-				ResourceName:                         resourceReference,
-				ImportState:                          true,
-				ImportStateIdFunc:                    generateAuditLogSettingsImportIdForResource(resourceReference),
-				ImportStateVerifyIdentifierAttribute: "cluster_id",
-			},
-			{
-				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseClusterDatabaseCredentialAndDisabledUsers(clusterResourceName, resourceName, databaseCredentialName, cidr, true, []int{20488}, `[
+	return []resource.TestStep{
+		{
+			Config: testAccAuditLogSettingsResourceConfig(resourceName, true, []int{20488, 20490, 20491}),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				testAccExistsAuditLogSettingsResource(t, resourceReference),
+				resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+				resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+				resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+				resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
+				resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "3"),
+				resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
+				resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20490"),
+				resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20491"),
+				resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "0"),
+			),
+		},
+		{
+			ResourceName:                         resourceReference,
+			ImportState:                          true,
+			ImportStateIdFunc:                    generateAuditLogSettingsImportIdForResource(resourceReference),
+			ImportStateVerifyIdentifierAttribute: "cluster_id",
+		},
+		{
+			Config: testAccAuditLogSettingsResourceConfigWithDatabaseCredentialAndDisabledUsers(resourceName, databaseCredentialName, true, []int{20488}, `[
 					{
 						domain = "local"
 						name   = "%[1]s"
 					}
 				]`),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccExistsAuditLogSettingsResource(t, resourceReference),
-					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
-					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
-					resource.TestCheckResourceAttrPair(resourceReference, "cluster_id", clusterReference, "id"),
-					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
-					resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceReference, "disabled_users.*", map[string]string{
-						"domain": "local",
-						"name":   databaseCredentialName,
-					}),
-				),
-			},
-			{
-				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseClusterDatabaseCredentialAndDisabledUsers(clusterResourceName, resourceName, databaseCredentialName, cidr, false, []int{20488}, "[]"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccExistsAuditLogSettingsResource(t, resourceReference),
-					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
-					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
-					resource.TestCheckResourceAttrPair(resourceReference, "cluster_id", clusterReference, "id"),
-					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
-				),
-			},
+			Check: resource.ComposeAggregateTestCheckFunc(
+				testAccExistsAuditLogSettingsResource(t, resourceReference),
+				resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+				resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+				resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+				resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
+				resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
+				resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
+				resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "1"),
+				resource.TestCheckTypeSetElemNestedAttrs(resourceReference, "disabled_users.*", map[string]string{
+					"domain": "local",
+					"name":   databaseCredentialName,
+				}),
+			),
 		},
-	})
+		{
+			Config: testAccAuditLogSettingsResourceConfigWithDatabaseCredentialAndDisabledUsers(resourceName, databaseCredentialName, false, []int{20488}, "[]"),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				testAccExistsAuditLogSettingsResource(t, resourceReference),
+				resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+				resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+				resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+				resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "false"),
+				resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "1"),
+				resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
+			),
+		},
+	}
+}
+
+// auditLogSettingsDisableOnRemovalSteps provides the steps to verify that removing the
+// audit_log_settings resource from the config reverts audit logging on the cluster to
+// disabled, which is what allows a later downgrade from the enterprise support plan.
+func auditLogSettingsDisableOnRemovalSteps(t *testing.T) []resource.TestStep {
+	resourceName := randomStringWithPrefix("tf_acc_audit_rm_settings_")
+	resourceReference := "couchbase-capella_audit_log_settings." + resourceName
+
+	return []resource.TestStep{
+		{
+			Config: testAccAuditLogSettingsResourceConfig(resourceName, true, []int{20488, 20490, 20491}),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				testAccExistsAuditLogSettingsResource(t, resourceReference),
+				resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
+				resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
+				resource.TestCheckResourceAttr(resourceReference, "cluster_id", globalClusterId),
+				resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
+				resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "3"),
+				resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
+				resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20490"),
+				resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20491"),
+				resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "0"),
+			),
+		},
+		{
+			Config: globalProviderBlock,
+			Check:  testAccCheckAuditLogSettingsDisabled(t),
+		},
+	}
 }
 
 func TestAccAuditLogSettingsResourceInvalidCluster(t *testing.T) {
@@ -197,6 +253,10 @@ func TestAccAuditLogSettingsResourceDisabledUserMissingName(t *testing.T) {
 	})
 }
 
+// TestAccAuditLogSettingsResourcePlanUpgrade is the one audit test that still deploys its
+// own cluster: it asserts audit log settings are rejected on a developer pro cluster and
+// accepted once the cluster is upgraded to enterprise, so it cannot run against the shared
+// global cluster, which is already on the enterprise plan.
 func TestAccAuditLogSettingsResourcePlanUpgrade(t *testing.T) {
 	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_upgrade_")
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_upgrade_")
@@ -330,15 +390,6 @@ resource "couchbase-capella_audit_log_settings" "%[2]s" {
 }
 
 func testAccAuditLogSettingsResourceConfigWithSupportPlan(clusterResourceName, auditSettingsResourceName, cidr, plan string, auditEnabled bool, enabledEventIDs []int) string {
-	ids := "["
-	for i, id := range enabledEventIDs {
-		if i > 0 {
-			ids += ", "
-		}
-		ids += fmt.Sprintf("%d", id)
-	}
-	ids += "]"
-
 	return fmt.Sprintf(`
 %[1]s
 
@@ -389,36 +440,47 @@ resource "couchbase-capella_audit_log_settings" "%[6]s" {
 	enabled_event_ids = %[9]s
 	disabled_users    = []
 }
-`, globalProviderBlock, clusterResourceName, globalOrgId, globalProjectId, cidr, auditSettingsResourceName, auditEnabled, plan, ids)
+`, globalProviderBlock, clusterResourceName, globalOrgId, globalProjectId, cidr, auditSettingsResourceName, auditEnabled, plan, formatEventIDs(enabledEventIDs))
 }
 
-func testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, auditSettingsResourceName, cidr string, auditEnabled bool, enabledEventIDs []int) string {
-	return testAccAuditLogSettingsResourceConfigWithEnterpriseClusterAndDisabledUsers(clusterResourceName, auditSettingsResourceName, cidr, auditEnabled, enabledEventIDs, "[]", "", "")
+// formatEventIDs renders event IDs as an HCL list literal.
+func formatEventIDs(enabledEventIDs []int) string {
+	ids := "["
+	for i, id := range enabledEventIDs {
+		if i > 0 {
+			ids += ", "
+		}
+		ids += fmt.Sprintf("%d", id)
+	}
+	return ids + "]"
 }
 
-func testAccAuditLogSettingsResourceConfigWithEnterpriseClusterDatabaseCredentialAndDisabledUsers(clusterResourceName, auditSettingsResourceName, databaseCredentialName, cidr string, auditEnabled bool, enabledEventIDs []int, disabledUsers string) string {
+func testAccAuditLogSettingsResourceConfig(auditSettingsResourceName string, auditEnabled bool, enabledEventIDs []int) string {
+	return testAccAuditLogSettingsResourceConfigWithDisabledUsers(auditSettingsResourceName, auditEnabled, enabledEventIDs, "[]", "", "")
+}
+
+func testAccAuditLogSettingsResourceConfigWithDatabaseCredentialAndDisabledUsers(auditSettingsResourceName, databaseCredentialName string, auditEnabled bool, enabledEventIDs []int, disabledUsers string) string {
 	databaseCredentialResource := fmt.Sprintf(`
 resource "couchbase-capella_database_credential" "%[1]s" {
 	name            = "%[1]s"
 	organization_id = "%[2]s"
 	project_id      = "%[3]s"
-	cluster_id      = couchbase-capella_cluster.%[4]s.id
+	cluster_id      = "%[4]s"
 	access = [
 		{
 			privileges = ["data_writer"]
 		},
 	]
 }
-`, databaseCredentialName, globalOrgId, globalProjectId, clusterResourceName)
+`, databaseCredentialName, globalOrgId, globalProjectId, globalClusterId)
+
 	formattedDisabledUsers := disabledUsers
 	if disabledUsers != "[]" {
 		formattedDisabledUsers = fmt.Sprintf(disabledUsers, databaseCredentialName)
 	}
 
-	return testAccAuditLogSettingsResourceConfigWithEnterpriseClusterAndDisabledUsers(
-		clusterResourceName,
+	return testAccAuditLogSettingsResourceConfigWithDisabledUsers(
 		auditSettingsResourceName,
-		cidr,
 		auditEnabled,
 		enabledEventIDs,
 		formattedDisabledUsers,
@@ -427,16 +489,7 @@ resource "couchbase-capella_database_credential" "%[1]s" {
 	)
 }
 
-func testAccAuditLogSettingsResourceConfigWithEnterpriseClusterAndDisabledUsers(clusterResourceName, auditSettingsResourceName, cidr string, auditEnabled bool, enabledEventIDs []int, disabledUsers, databaseCredentialName, databaseCredentialResource string) string {
-	ids := "["
-	for i, id := range enabledEventIDs {
-		if i > 0 {
-			ids += ", "
-		}
-		ids += fmt.Sprintf("%d", id)
-	}
-	ids += "]"
-
+func testAccAuditLogSettingsResourceConfigWithDisabledUsers(auditSettingsResourceName string, auditEnabled bool, enabledEventIDs []int, disabledUsers, databaseCredentialName, databaseCredentialResource string) string {
 	dependsOn := ""
 	if databaseCredentialResource != "" {
 		dependsOn = fmt.Sprintf(`
@@ -447,57 +500,18 @@ func testAccAuditLogSettingsResourceConfigWithEnterpriseClusterAndDisabledUsers(
 	return fmt.Sprintf(`
 %[1]s
 
-resource "couchbase-capella_cluster" "%[2]s" {
-	organization_id = "%[3]s"
-	project_id      = "%[4]s"
-	name            = "%[2]s"
+%[8]s
 
-	cloud_provider = {
-		type   = "aws"
-		region = "us-east-1"
-		cidr   = "%[5]s"
-	}
-
-	service_groups = [
-		{
-			node = {
-				compute = {
-					cpu = 4
-					ram = 16
-				}
-				disk = {
-					storage = 50
-					type    = "io2"
-					iops    = 3000
-				}
-			}
-			num_of_nodes = 3
-			services     = ["data", "index", "query"]
-		}
-	]
-
-	availability = {
-		type = "multi"
-	}
-
-	support = {
-		plan     = "enterprise"
-		timezone = "PT"
-	}
-}
-
-%[10]s
-
-resource "couchbase-capella_audit_log_settings" "%[6]s" {
+resource "couchbase-capella_audit_log_settings" "%[2]s" {
 	organization_id   = "%[3]s"
 	project_id        = "%[4]s"
-	cluster_id        = couchbase-capella_cluster.%[2]s.id
-	audit_enabled     = %[7]t
-	enabled_event_ids = %[8]s
+	cluster_id        = "%[5]s"
+	audit_enabled     = %[6]t
+	enabled_event_ids = %[7]s
 	disabled_users    = %[9]s
-%[11]s
+%[10]s
 }
-`, globalProviderBlock, clusterResourceName, globalOrgId, globalProjectId, cidr, auditSettingsResourceName, auditEnabled, ids, disabledUsers, databaseCredentialResource, dependsOn)
+`, globalProviderBlock, auditSettingsResourceName, globalOrgId, globalProjectId, globalClusterId, auditEnabled, formatEventIDs(enabledEventIDs), databaseCredentialResource, disabledUsers, dependsOn)
 }
 
 func generateAuditLogSettingsImportIdForResource(resourceReference string) resource.ImportStateIdFunc {
@@ -552,93 +566,10 @@ func testAccExistsAuditLogSettingsResource(t *testing.T, resourceReference strin
 	}
 }
 
-func TestAccAuditLogSettingsResourceDisableOnRemoval(t *testing.T) {
-	clusterResourceName := randomStringWithPrefix("tf_acc_audit_rm_cluster_")
-	resourceName := randomStringWithPrefix("tf_acc_audit_rm_settings_")
-	cidr := generateRandomCIDR()
-	clusterReference := "couchbase-capella_cluster." + clusterResourceName
-	resourceReference := "couchbase-capella_audit_log_settings." + resourceName
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAuditLogSettingsResourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, cidr, true, []int{20488, 20490, 20491}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccExistsAuditLogSettingsResource(t, resourceReference),
-					resource.TestCheckResourceAttr(resourceReference, "organization_id", globalOrgId),
-					resource.TestCheckResourceAttr(resourceReference, "project_id", globalProjectId),
-					resource.TestCheckResourceAttrSet(resourceReference, "cluster_id"),
-					resource.TestCheckResourceAttr(resourceReference, "audit_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceReference, "enabled_event_ids.#", "3"),
-					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20488"),
-					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20490"),
-					resource.TestCheckTypeSetElemAttr(resourceReference, "enabled_event_ids.*", "20491"),
-					resource.TestCheckResourceAttr(resourceReference, "disabled_users.#", "0"),
-				),
-			},
-			{
-				Config: testAccAuditClusterOnlyConfig(clusterResourceName, cidr),
-				Check:  testAccCheckAuditLogSettingsDisabled(t, clusterReference),
-			},
-		},
-	})
-}
-
-func testAccAuditClusterOnlyConfig(clusterResourceName, cidr string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "couchbase-capella_cluster" "%[2]s" {
-	organization_id = "%[3]s"
-	project_id      = "%[4]s"
-	name            = "%[2]s"
-
-	cloud_provider = {
-		type   = "aws"
-		region = "us-east-1"
-		cidr   = "%[5]s"
-	}
-
-	service_groups = [
-		{
-			node = {
-				compute = {
-					cpu = 4
-					ram = 16
-				}
-				disk = {
-					storage = 50
-					type    = "io2"
-					iops    = 3000
-				}
-			}
-			num_of_nodes = 3
-			services     = ["data", "index", "query"]
-		}
-	]
-
-	availability = {
-		type = "multi"
-	}
-
-	support = {
-		plan     = "enterprise"
-		timezone = "PT"
-	}
-}
-`, globalProviderBlock, clusterResourceName, globalOrgId, globalProjectId, cidr)
-}
-
-func testAccCheckAuditLogSettingsDisabled(t *testing.T, clusterReference string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[clusterReference]
-		if !ok {
-			return fmt.Errorf("cluster %s not found in state", clusterReference)
-		}
-		clusterId := rs.Primary.Attributes["id"]
+func testAccCheckAuditLogSettingsDisabled(t *testing.T) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
 		data := newTestClient(t)
-		settings, err := retrieveAuditLogSettingsFromServer(data, globalOrgId, globalProjectId, clusterId)
+		settings, err := retrieveAuditLogSettingsFromServer(data, globalOrgId, globalProjectId, globalClusterId)
 		if err != nil {
 			return err
 		}

--- a/acceptance_tests/audit_log_settings_datasource_test.go
+++ b/acceptance_tests/audit_log_settings_datasource_test.go
@@ -8,32 +8,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccDatasourceAuditLogSettings(t *testing.T) {
-	clusterResourceName := randomStringWithPrefix("tf_acc_audit_cluster_for_ds_")
+// auditLogSettingsDatasourceSteps provides the steps to read the audit log settings of the
+// global cluster through the datasource after they have been set by the resource.
+func auditLogSettingsDatasourceSteps() []resource.TestStep {
 	resourceName := randomStringWithPrefix("tf_acc_audit_log_settings_for_ds_")
 	dsName := randomStringWithPrefix("tf_acc_audit_log_settings_ds_")
-	cidr := generateRandomCIDR()
-	clusterReference := "couchbase-capella_cluster." + clusterResourceName
 	dsReference := "data.couchbase-capella_audit_log_settings." + dsName
 
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAuditLogSettingsResourceAndDatasourceConfigWithEnterpriseCluster(clusterResourceName, resourceName, dsName, cidr, true, []int{20488, 20489}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
-					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
-					resource.TestCheckResourceAttrPair(dsReference, "cluster_id", clusterReference, "id"),
-					resource.TestCheckResourceAttr(dsReference, "audit_enabled", "true"),
-					resource.TestCheckResourceAttr(dsReference, "enabled_event_ids.#", "2"),
-					resource.TestCheckTypeSetElemAttr(dsReference, "enabled_event_ids.*", "20488"),
-					resource.TestCheckTypeSetElemAttr(dsReference, "enabled_event_ids.*", "20489"),
-					resource.TestCheckResourceAttr(dsReference, "disabled_users.#", "0"),
-				),
-			},
+	return []resource.TestStep{
+		{
+			Config: testAccAuditLogSettingsResourceAndDatasourceConfig(resourceName, dsName, true, []int{20488, 20489}),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+				resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+				resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+				resource.TestCheckResourceAttr(dsReference, "audit_enabled", "true"),
+				resource.TestCheckResourceAttr(dsReference, "enabled_event_ids.#", "2"),
+				resource.TestCheckTypeSetElemAttr(dsReference, "enabled_event_ids.*", "20488"),
+				resource.TestCheckTypeSetElemAttr(dsReference, "enabled_event_ids.*", "20489"),
+				resource.TestCheckResourceAttr(dsReference, "disabled_users.#", "0"),
+			),
 		},
-	})
+	}
 }
 
 func TestAccDatasourceAuditLogSettingsInvalidCluster(t *testing.T) {
@@ -79,73 +75,23 @@ data "couchbase-capella_audit_log_settings" "%[2]s" {
 	})
 }
 
-func testAccAuditLogSettingsResourceAndDatasourceConfigWithEnterpriseCluster(clusterResourceName, auditSettingsResourceName, dsName, cidr string, auditEnabled bool, enabledEventIDs []int) string {
-	ids := "["
-	for i, id := range enabledEventIDs {
-		if i > 0 {
-			ids += ", "
-		}
-		ids += fmt.Sprintf("%d", id)
-	}
-	ids += "]"
-
+func testAccAuditLogSettingsResourceAndDatasourceConfig(auditSettingsResourceName, dsName string, auditEnabled bool, enabledEventIDs []int) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "couchbase-capella_cluster" "%[2]s" {
-	organization_id = "%[5]s"
-	project_id      = "%[6]s"
-	name            = "%[2]s"
+data "couchbase-capella_audit_log_settings" "%[2]s" {
+	organization_id = "%[3]s"
+	project_id      = "%[4]s"
+	cluster_id      = "%[5]s"
 
-	cloud_provider = {
-		type   = "aws"
-		region = "us-east-1"
-		cidr   = "%[4]s"
-	}
-
-	service_groups = [
-		{
-			node = {
-				compute = {
-					cpu = 4
-					ram = 16
-				}
-				disk = {
-					storage = 50
-					type    = "io2"
-					iops    = 3000
-				}
-			}
-			num_of_nodes = 3
-			services     = ["data", "index", "query"]
-		}
-	]
-
-	availability = {
-		type = "multi"
-	}
-
-	support = {
-		plan     = "enterprise"
-		timezone = "PT"
-	}
+	depends_on = [couchbase-capella_audit_log_settings.%[6]s]
 }
-
-resource "couchbase-capella_audit_log_settings" "%[3]s" {
-	organization_id   = "%[5]s"
-	project_id        = "%[6]s"
-	cluster_id        = couchbase-capella_cluster.%[2]s.id
-	audit_enabled     = %[7]t
-	enabled_event_ids = %[8]s
-  disabled_users    = []
-}
-
-data "couchbase-capella_audit_log_settings" "%[9]s" {
-	organization_id = "%[5]s"
-	project_id      = "%[6]s"
-	cluster_id      = couchbase-capella_cluster.%[2]s.id
-
-	depends_on = [couchbase-capella_audit_log_settings.%[3]s]
-}
-`, globalProviderBlock, clusterResourceName, auditSettingsResourceName, cidr, globalOrgId, globalProjectId, auditEnabled, ids, dsName)
+`,
+		testAccAuditLogSettingsResourceConfig(auditSettingsResourceName, auditEnabled, enabledEventIDs),
+		dsName,
+		globalOrgId,
+		globalProjectId,
+		globalClusterId,
+		auditSettingsResourceName,
+	)
 }

--- a/acceptance_tests/sanity.list
+++ b/acceptance_tests/sanity.list
@@ -259,11 +259,9 @@ TestAccDatasourceCloudSnapshotRestores
 # ----------------------------------------
 # 16. AUDIT LOGGING
 # ----------------------------------------
-# Tests audit log settings resource
-TestAccAuditLogSettingsResource
-
-# Tests reading audit log settings via data source
-TestAccDatasourceAuditLogSettings
+# Tests audit log settings resource and data source as sequential subtests
+# against the shared global cluster
+TestAccAuditLog
 
 # Tests reading audit log event IDs via data source
 TestAccDatasourceAuditLogEventIDs


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-140333](https://couchbasecloud.atlassian.net/browse/AV-140333)

## Description

the audit log acceptance tests each deploy their own enterprise cluster, which is wasteful since `audit_log_settings` is a per-cluster singleton. `TestAccAuditLogSettingsResource`, its data source test, and the disable-on-removal test now run as sequential subtests of `TestAccAuditLog` against the shared global cluster, following the same pattern as `TestAccAppServiceLogStreaming`. `TestAccAuditLogSettingsResourcePlanUpgrade` keeps its own cluster since it needs to start on the developer pro plan and upgrade to enterprise, which the global cluster already is.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [x] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

Compiles, `go vet` clean, provider builds successfully. Acceptance tests require live Capella credentials not available in this environment — to be run before merge.

</details>

## Further comments

[AV-140333]: https://couchbasecloud.atlassian.net/browse/AV-140333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ