### PR TITLE
[AV-135211] Recognize "Created" as a deferred index build status

### DIFF
--- a/acceptance_tests/query_index_acceptance_test.go
+++ b/acceptance_tests/query_index_acceptance_test.go
@@ -264,8 +264,10 @@ func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
 				Config: testAccQueryIndexOnlyConfigWithDeferBuild(idxName, "deferred_field", true),
 			},
 			{
-				Config:      testAccQueryIndexMonitorDeferredConfig(idxName, monitorName),
-				ExpectError: regexp.MustCompile(`(?is)Error monitoring query indexes.*is in Deferred state and will not become Ready without a BUILD INDEX statement`),
+				Config: testAccQueryIndexMonitorDeferredConfig(idxName, monitorName),
+				// terraform's diagnostic renderer word-wraps the message at the terminal width, so
+				// whitespace between words (e.g. "BUILD INDEX\nstatement") can become a newline.
+				ExpectError: regexp.MustCompile(`(?is)Error\s+monitoring\s+query\s+indexes.*is\s+in\s+Deferred\s+state\s+and\s+will\s+not\s+become\s+Ready\s+without\s+a\s+BUILD\s+INDEX\s+statement`),
 			},
 		},
 	})

--- a/acceptance_tests/query_index_acceptance_test.go
+++ b/acceptance_tests/query_index_acceptance_test.go
@@ -228,10 +228,7 @@ func TestAccDatasourceQueryIndexMonitorMultipleIndexes(t *testing.T) {
 	})
 }
 
-// AV-132671: API returns 200 OK with non-"Deferred" status for a deferred index; WatchIndexes polls
-// at 1 req/sec indefinitely since the status never becomes Ready. Skip until the API behavior is known.
 func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
-	t.Skip("AV-132671: monitor polls indefinitely for deferred index; re-enable once API behavior for deferred state is confirmed")
 	idxName := randomStringWithPrefix("tf_acc_qm_defer_idx_")
 	monitorName := randomStringWithPrefix("tf_acc_qm_defer_ds_")
 

--- a/acceptance_tests/query_index_acceptance_test.go
+++ b/acceptance_tests/query_index_acceptance_test.go
@@ -4,9 +4,17 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+// queryIndexCatalogPropagationDelay gives the query service's index-list catalog
+// time to converge after a CREATE INDEX, so the query_indexes datasource doesn't
+// race a freshly created index under concurrent DDL load on the shared cluster
+// (the DDL and single-index read endpoints confirm the index immediately, but the
+// list endpoint used by the datasource lags behind under load).
+const queryIndexCatalogPropagationDelay = 15 * time.Second
 
 func TestAccDatasourceQueryIndexes(t *testing.T) {
 	idxName := randomStringWithPrefix("tf_acc_qi_ds_idx_")
@@ -18,7 +26,7 @@ func TestAccDatasourceQueryIndexes(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccQueryIndexesDatasourceConfig(idxName, dsName),
+				Config: testAccQueryIndexOnlyConfig(idxName, "f1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(idxReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(idxReference, "project_id", globalProjectId),
@@ -27,7 +35,12 @@ func TestAccDatasourceQueryIndexes(t *testing.T) {
 					resource.TestCheckResourceAttr(idxReference, "scope_name", globalScopeName),
 					resource.TestCheckResourceAttr(idxReference, "collection_name", globalCollectionName),
 					resource.TestCheckResourceAttr(idxReference, "index_name", idxName),
-
+				),
+			},
+			{
+				PreConfig: func() { time.Sleep(queryIndexCatalogPropagationDelay) },
+				Config:    testAccQueryIndexesDatasourceConfig(idxName, dsName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
 					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
@@ -52,7 +65,11 @@ func TestAccDatasourceQueryIndexesBucketLevelOnly(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccQueryIndexesDatasourceBucketOnlyConfig(idxName, dsName),
+				Config: testAccQueryIndexOnlyConfig(idxName, "bkt_field"),
+			},
+			{
+				PreConfig: func() { time.Sleep(queryIndexCatalogPropagationDelay) },
+				Config:    testAccQueryIndexesDatasourceBucketOnlyConfig(idxName, dsName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
@@ -76,7 +93,11 @@ func TestAccDatasourceQueryIndexesScopeOnly(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccQueryIndexesDatasourceScopeOnlyConfig(idxName, dsName),
+				Config: testAccQueryIndexOnlyConfig(idxName, "scope_field"),
+			},
+			{
+				PreConfig: func() { time.Sleep(queryIndexCatalogPropagationDelay) },
+				Config:    testAccQueryIndexesDatasourceScopeOnlyConfig(idxName, dsName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
 					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
@@ -322,6 +343,30 @@ data "couchbase-capella_query_index_monitor" "%[2]s" {
 			},
 		},
 	})
+}
+
+// testAccQueryIndexOnlyConfig returns the HCL config for just the query_indexes
+// resource, without a dependent datasource, so tests can create the index and
+// let PreConfig sleep before reading it back through a datasource in a later step.
+func testAccQueryIndexOnlyConfig(idxName, indexKey string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_query_indexes" "%[2]s" {
+  organization_id = "%[3]s"
+  project_id      = "%[4]s"
+  cluster_id      = "%[5]s"
+  bucket_name     = "%[6]s"
+  scope_name      = "%[7]s"
+  collection_name = "%[8]s"
+  index_name      = "%[2]s"
+  index_keys      = ["%[9]s"]
+  with = {
+    defer_build = false
+  }
+}
+`, globalProviderBlock, idxName, globalOrgId, globalProjectId, globalClusterId,
+		globalBucketName, globalScopeName, globalCollectionName, indexKey)
 }
 
 func testAccQueryIndexesDatasourceConfig(idxName, dsName string) string {

--- a/acceptance_tests/query_index_acceptance_test.go
+++ b/acceptance_tests/query_index_acceptance_test.go
@@ -257,8 +257,15 @@ func TestAccDatasourceQueryIndexMonitorDeferred(t *testing.T) {
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
 			{
+				// Create the deferred index on its own first: it must apply
+				// cleanly (no ExpectError) so it lands in state and the
+				// framework's automatic destroy cleans it up, even though the
+				// next step's monitor read is expected to error.
+				Config: testAccQueryIndexOnlyConfigWithDeferBuild(idxName, "deferred_field", true),
+			},
+			{
 				Config:      testAccQueryIndexMonitorDeferredConfig(idxName, monitorName),
-				ExpectError: regexp.MustCompile(`(?i)Error monitoring query indexes`),
+				ExpectError: regexp.MustCompile(`(?is)Error monitoring query indexes.*is in Deferred state and will not become Ready without a BUILD INDEX statement`),
 			},
 		},
 	})
@@ -349,6 +356,10 @@ data "couchbase-capella_query_index_monitor" "%[2]s" {
 // resource, without a dependent datasource, so tests can create the index and
 // let PreConfig sleep before reading it back through a datasource in a later step.
 func testAccQueryIndexOnlyConfig(idxName, indexKey string) string {
+	return testAccQueryIndexOnlyConfigWithDeferBuild(idxName, indexKey, false)
+}
+
+func testAccQueryIndexOnlyConfigWithDeferBuild(idxName, indexKey string, deferBuild bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -362,11 +373,11 @@ resource "couchbase-capella_query_indexes" "%[2]s" {
   index_name      = "%[2]s"
   index_keys      = ["%[9]s"]
   with = {
-    defer_build = false
+    defer_build = %[10]t
   }
 }
 `, globalProviderBlock, idxName, globalOrgId, globalProjectId, globalClusterId,
-		globalBucketName, globalScopeName, globalCollectionName, indexKey)
+		globalBucketName, globalScopeName, globalCollectionName, indexKey, deferBuild)
 }
 
 func testAccQueryIndexesDatasourceConfig(idxName, dsName string) string {

--- a/internal/api/gsi.go
+++ b/internal/api/gsi.go
@@ -140,7 +140,8 @@ func WatchIndexes(
 					return err
 				}
 
-				if status.Status == "Deferred" {
+				// AV-135211: a defer_build=true index reports "Created", not "Deferred", so both count as deferred.
+				if status.Status == "Created" || status.Status == "Deferred" {
 					return internalerrors.ErrIndexDeferred
 				}
 

--- a/internal/api/gsi.go
+++ b/internal/api/gsi.go
@@ -140,12 +140,14 @@ func WatchIndexes(
 					return err
 				}
 
-				// AV-135211: a defer_build=true index reports "Created", not "Deferred", so both count as deferred.
-				if status.Status == "Created" || status.Status == "Deferred" {
-					return internalerrors.ErrIndexDeferred
-				}
-
 				if status.Status != desiredState {
+					// AV-135211: a defer_build=true index reports "Created", not "Deferred", and never
+					// progresses to "Ready" on its own, so only treat that as the permanent deferred
+					// state when "Ready" is what we're actually waiting for (not the BUILD INDEX flow,
+					// which waits for "Created" itself).
+					if desiredState == "Ready" && (status.Status == "Created" || status.Status == "Deferred") {
+						return internalerrors.ErrIndexDeferred
+					}
 					d := min(maxDuration, 1<<attempt)
 					timer.Reset(time.Duration(d) * time.Minute)
 					attempt++

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -266,6 +266,8 @@ var (
 
 	ErrConcurrentIndexCreation = errors.New("another index create request is in progress")
 
+	ErrIndexDropPending = errors.New("index cannot be dropped yet as it is still being created in the background")
+
 	ErrTimeoutWaitingForClientResponse = errors.New("timeout waiting for index build")
 
 	ErrorMessageWhileFreeTierBucketCreation = errors.New("There is an error during free tier bucket creation. Please check in Capella to see if any hanging resources")

--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -550,14 +550,52 @@ func (g *GSI) Delete(ctx context.Context, req resource.DeleteRequest, resp *reso
 		state.CollectionName.ValueString(),
 	)
 
-	if err := g.executeGsiDdl(ctx, &state, ddl); err != nil {
-		resp.Diagnostics.AddError(
-			"An error occurred while executing index DDL",
-			"Error during index DDL execution: "+err.Error(),
+	// The index-drop retry mirrors the tolerance already given to a transient
+	// not-found on Read: a non-deferred index's CREATE can still be finishing in
+	// the background under concurrent DDL load, and the API rejects a DROP of an
+	// index it hasn't finished creating yet with ErrIndexDropPending.
+	const (
+		dropPendingRetries = 3
+		dropPendingDelay   = 3 * time.Second
+	)
+
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = g.executeGsiDdl(ctx, &state, ddl)
+		if err == nil {
+			return
+		}
+
+		if resourceNotFound, _ := api.CheckResourceNotFoundError(err); resourceNotFound {
+			// already gone: deleting a nonexistent index is a no-op success.
+			return
+		}
+
+		if !errors.Is(err, internalerrors.ErrIndexDropPending) || attempt >= dropPendingRetries {
+			break
+		}
+		time.Sleep(dropPendingDelay)
+	}
+
+	if errors.Is(err, internalerrors.ErrIndexDropPending) {
+		resp.Diagnostics.AddWarning(
+			"Index deletion is pending",
+			fmt.Sprintf(
+				"Could not drop index %s in %s.%s.%s as its creation is still finishing in the background. "+
+					`Please run "terraform apply --refresh-only" after some time to confirm removal.`,
+				indexName,
+				state.BucketName.ValueString(),
+				state.ScopeName.ValueString(),
+				state.CollectionName.ValueString(),
+			),
 		)
 		return
 	}
 
+	resp.Diagnostics.AddError(
+		"An error occurred while executing index DDL",
+		"Error during index DDL execution: "+err.Error(),
+	)
 }
 
 // Importstate is used to import an index on the data plane cluster.
@@ -705,6 +743,12 @@ func (g *GSI) executeGsiDdl(ctx context.Context, plan *providerschema.GsiDefinit
 			strings.Contains(strings.ToLower(apiError.Message), "concurrent create index request") {
 
 			return internalerrors.ErrConcurrentIndexCreation
+		}
+
+		// DROP INDEX on an index whose CREATE is still finishing in the background
+		// (a non-deferred index build the indexer hasn't caught up on yet).
+		if strings.Contains(strings.ToLower(apiError.Message), "scheduled for background creation") {
+			return internalerrors.ErrIndexDropPending
 		}
 
 		// Some other error from the API server.

--- a/internal/resources/gsi.go
+++ b/internal/resources/gsi.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -361,18 +362,44 @@ func (g *GSI) Read(ctx context.Context, req resource.ReadRequest, resp *resource
 		indexName      = attrs[providerschema.IndexName]
 	)
 
-	index, err := g.getQueryIndex(
-		ctx,
-		organizationID,
-		projectID,
-		clusterID,
-		bucketName,
-		scopeName,
-		collectionName,
-		indexName,
+	// The index-by-name lookup can transiently 404 for a few seconds right after
+	// CREATE INDEX under concurrent DDL load, before the query service's catalog
+	// converges across nodes. Retry a bounded number of times (mirroring the same
+	// tolerance WatchIndexes gives consecutive 404s) before treating the index as
+	// genuinely gone, so a Terraform refresh run moments after apply doesn't wipe
+	// state and report a spurious recreate.
+	const (
+		notFoundRetries = 3
+		notFoundDelay   = 3 * time.Second
 	)
+
+	var index *api.IndexDefinitionResponse
+	var resourceNotFound bool
+	var errString string
+
+	for attempt := 0; ; attempt++ {
+		index, err = g.getQueryIndex(
+			ctx,
+			organizationID,
+			projectID,
+			clusterID,
+			bucketName,
+			scopeName,
+			collectionName,
+			indexName,
+		)
+		if err == nil {
+			break
+		}
+
+		resourceNotFound, errString = api.CheckResourceNotFoundError(err)
+		if !resourceNotFound || attempt >= notFoundRetries {
+			break
+		}
+		time.Sleep(notFoundDelay)
+	}
+
 	if err != nil {
-		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
 		if resourceNotFound {
 			tflog.Info(ctx, "resource doesn't exist in remote server removing resource from state file")
 			resp.State.RemoveResource(ctx)


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-135211](https://couchbasecloud.atlassian.net/browse/AV-135211)

## Description

`couchbase-capella_query_index_monitor` polled to its own timeout (~60 min) on a `defer_build = true` index instead of returning immediately. The root cause: the V4 `queryService/indexBuildStatus` endpoint returns `"Created"`, not `"Deferred"`, for a deferred index, so `WatchIndexes` never matched its early-exit check (`internal/api/gsi.go`). `WatchIndexes` now treats `"Created"` the same as `"Deferred"` **only when the caller is waiting for `"Ready"`** — `WatchIndexes` is also called by the BUILD INDEX flow with `desiredState="Created"`, where reaching `"Created"` is success, not a stuck index, so the check has to be conditional on that. `TestAccDatasourceQueryIndexMonitorDeferred` is un-skipped now that the actual status value is confirmed.

Un-skipping that test added real concurrent `CREATE`/`DROP INDEX` load to the shared sanity-suite cluster for the first time, and CI runs on this PR surfaced three more pre-existing eventual-consistency gaps in the GSI resource's handling of the query service's distributed catalog — not new bugs introduced here, just latent ones this extra load finally triggered:

- `internal/resources/gsi.go` (`Read`): a fresh index's single-item lookup could transiently 404 right after `CREATE INDEX` under load, wiping it from state and causing a spurious "will be created" on the next `terraform plan`. Now retries a bounded few times before concluding the index is genuinely gone.
- `internal/resources/gsi.go` (`Delete`) / `internal/errors/errors.go`: `DROP INDEX` on an index still finishing its background build failed hard with a 500 ("scheduled for background creation"), and a 404 on an already-gone index also failed hard instead of being treated as a no-op. Added `ErrIndexDropPending`, retried with the same bounded backoff, and made not-found idempotent.
- `acceptance_tests/query_index_acceptance_test.go`: the `query_indexes` datasource's list endpoint lagged behind a freshly created index under load (a separate, less consistent endpoint than the single-item lookup above); split the affected tests into a create step + a datasource-read step with a short delay. Also split `TestAccDatasourceQueryIndexMonitorDeferred` so the deferred index is created in its own (non-erroring) step for reliable cleanup, and tightened its `ExpectError` regex to match terraform's word-wrapped diagnostic text and the specific `ErrIndexDeferred` message rather than a generic substring.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Acceptance tested

### Testing

<details open>
  <summary>Testing</summary>

Confirmed against a live tenant locally (`TestAccGSI`, `TestAccDatasourceQueryIndexes`, `TestAccDatasourceQueryIndexMonitorDeferred`, `TestAccDatasourceQueryIndexMonitorReady` all PASS), and via the CI Sanity suite on this PR: `TestAccGSI` PASS, `TestAccDatasourceQueryIndexes` PASS, `TestAccDatasourceQueryIndexMonitorReady` PASS, `TestAccDatasourceQueryIndexMonitorDeferred` PASS. Remaining CI failures on this PR (`TestAccProjectResource`/`TestAccProjectCreateWithReqFields` on a tenant project-quota limit, `TestAccFlushBucketResource` on a raw API 500, `TestAccAppServiceLogStreaming/App_Endpoint_Logging_Config` on a timeout, `TestAccClusterResourceAzureDiskAutoExpansion` on a `deploymentFailed` cluster) are pre-existing shared-tenant flakiness unrelated to any file this PR touches.

</details>

## Further comments

[AV-135211]: https://couchbasecloud.atlassian.net/browse/AV-135211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ