### PR TITLE
[AV-132323] Clean up tainted cluster

### DIFF
--- a/internal/api/cluster/state.go
+++ b/internal/api/cluster/state.go
@@ -33,15 +33,12 @@ const (
 type State string
 
 func (s1 State) Equal(s2 State) bool {
-	return strings.EqualFold(string(s1), string(s2))
+	return strings.EqualFold(string(s1), string(s2)) // case in-sensitive equality
 }
 
-// IsFinalState checks whether cluster is successfully deployed/updated or not while creation/updation
-// TODO: Degraded, draft, peeringFailed, turningOffFailed, and turningOnFailed are not known when it occurs and What happens if rebalancing fails? Will it retry?".
-func IsFinalState(state State) bool {
-	// Returns True if the state is an end state, False otherwise.
+// IsTerminalState checks whether cluster is in a final non-healthy state.
+func IsTerminalState(state State) bool {
 	finalStates := []State{
-		Healthy,
 		Degraded,
 		DeploymentFailed,
 		DestroyFailed,

--- a/internal/api/cluster/state.go
+++ b/internal/api/cluster/state.go
@@ -1,6 +1,9 @@
 package cluster
 
-import "slices"
+import (
+	"slices"
+	"strings"
+)
 
 const (
 	Degraded         State = "degraded"
@@ -28,6 +31,10 @@ const (
 
 // State is the state that a cluster can have based on the fact if deployment of the cluster was successful or not.
 type State string
+
+func (s1 State) Equal(s2 State) bool {
+	return strings.EqualFold(string(s1), string(s2))
+}
 
 // IsFinalState checks whether cluster is successfully deployed/updated or not while creation/updation
 // TODO: Degraded, draft, peeringFailed, turningOffFailed, and turningOnFailed are not known when it occurs and What happens if rebalancing fails? Will it retry?".

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -922,6 +922,11 @@ func initializePendingClusterWithPlanAndId(plan providerschema.Cluster, id strin
 	if plan.CouchbaseServer.IsNull() || plan.CouchbaseServer.IsUnknown() {
 		plan.CouchbaseServer = types.ObjectNull(providerschema.CouchbaseServer{}.AttributeTypes())
 	}
+
+	if plan.DeletionProtection.IsNull() || plan.DeletionProtection.IsUnknown() {
+		plan.DeletionProtection = types.BoolNull()
+	}
+
 	plan.AppServiceId = types.StringNull()
 	plan.ConnectionString = types.StringNull()
 	plan.Audit = types.ObjectNull(providerschema.CouchbaseAuditData{}.AttributeTypes())

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -682,7 +682,7 @@ func (c *Cluster) checkClusterDeletionStatus(ctx context.Context, organizationId
 				return fmt.Errorf("cluster %s destroy failed", clusterResp.Id)
 			}
 
-			tflog.Info(ctx, "waiting for cluster destory to complete")
+			tflog.Info(ctx, "waiting for cluster destroy to complete")
 		}
 	}
 }

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -650,9 +650,8 @@ func (c *Cluster) checkClusterStatus(ctx context.Context, organizationId, projec
 	ctx, cancel = context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	const sleep = time.Second * 3
-
-	timer := time.NewTimer(2 * time.Minute)
+	timer := time.NewTicker(1 * time.Minute)
+	defer timer.Stop()
 
 	for {
 		select {
@@ -662,15 +661,19 @@ func (c *Cluster) checkClusterStatus(ctx context.Context, organizationId, projec
 			clusterResp, err = c.getCluster(ctx, organizationId, projectId, ClusterId)
 			switch err {
 			case nil:
-				if clusterapi.IsFinalState(clusterResp.CurrentState) {
+				if clusterResp.CurrentState.Equal(clusterapi.Healthy) {
 					return nil
 				}
+
+				if clusterapi.IsTerminalState(clusterResp.CurrentState) {
+					return fmt.Errorf("cluster %s operation failed, current state is %s", clusterResp.Id, clusterResp.CurrentState)
+				}
+
 				const msg = "waiting for cluster to complete the execution"
 				tflog.Info(ctx, msg)
 			default:
 				return err
 			}
-			timer.Reset(sleep)
 		}
 	}
 }

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -213,7 +213,7 @@ func (c *Cluster) Create(ctx context.Context, req resource.CreateRequest, resp *
 
 	err = c.checkClusterStatus(ctx, organizationId, projectId, clusterResponse.Id.String())
 	if err != nil {
-		resp.Diagnostics.AddWarning(
+		resp.Diagnostics.AddError(
 			"Error creating cluster",
 			errorMessageAfterClusterCreationInitiation+api.ParseError(err),
 		)

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -538,41 +538,14 @@ func (r *Cluster) Delete(ctx context.Context, req resource.DeleteRequest, resp *
 		return
 	}
 
-	err = r.checkClusterStatus(ctx, state.OrganizationId.ValueString(), state.ProjectId.ValueString(), state.Id.ValueString())
+	err = r.checkClusterDeletionStatus(ctx, organizationId, projectId, clusterId)
 	if err != nil {
-		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
-		if !resourceNotFound {
-			resp.Diagnostics.AddError(
-				"Error Deleting Capella Cluster",
-				"Could not delete cluster id "+state.Id.String()+": "+errString,
-			)
-			return
-		}
-		// resourceNotFound as expected
-		return
-	}
-
-	// This case will only occur when cluster deletion has failed,
-	// and the cluster record still exists in the cp metadata. Therefore,
-	// no error will be returned when performing a GET call.
-	cluster, err := r.retrieveCluster(ctx, state.OrganizationId.ValueString(), state.ProjectId.ValueString(), state.Id.ValueString())
-	if err != nil {
-		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
-		if resourceNotFound {
-			tflog.Info(ctx, "resource doesn't exist in remote server removing resource from state file")
-			resp.State.RemoveResource(ctx)
-			return
-		}
 		resp.Diagnostics.AddError(
 			"Error Deleting Capella Cluster",
-			"Could not delete cluster id "+state.Id.String()+": "+errString,
+			"Could not delete cluster id "+state.Id.String()+": "+api.ParseError(err),
 		)
 		return
 	}
-	resp.Diagnostics.AddError(
-		"Error deleting cluster",
-		fmt.Sprintf("Could not delete cluster id %s, as current Cluster state: %s", state.Id.String(), cluster.CurrentState),
-	)
 }
 
 // ImportState imports a remote cluster that is not created by Terraform.
@@ -674,6 +647,42 @@ func (c *Cluster) checkClusterStatus(ctx context.Context, organizationId, projec
 			default:
 				return err
 			}
+		}
+	}
+}
+
+// checkClusterDeletionStatus polls the cluster after a delete has been accepted until the GET
+// returns a 404, which means the cluster record is gone and deletion completed. It returns an
+// error if the cluster lands in destroyFailed, if polling encounters an unexpected error, or if
+// the operation times out.
+func (c *Cluster) checkClusterDeletionStatus(ctx context.Context, organizationId, projectId, clusterId string) error {
+	// Assuming 60 minutes is the max time deletion takes, can change after discussion
+	const timeout = time.Minute * 60
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("cluster deletion status transition timed out after initiation")
+		case <-ticker.C:
+			clusterResp, err := c.getCluster(ctx, organizationId, projectId, clusterId)
+			if err != nil {
+				if resourceNotFound, _ := api.CheckResourceNotFoundError(err); resourceNotFound {
+					return nil
+				}
+				continue
+			}
+			if clusterResp.CurrentState.Equal(clusterapi.DestroyFailed) {
+				return fmt.Errorf("cluster %s destroy failed", clusterResp.Id)
+			}
+
+			tflog.Info(ctx, "waiting for cluster destory to complete")
 		}
 	}
 }

--- a/internal/resources/free_tier_cluster.go
+++ b/internal/resources/free_tier_cluster.go
@@ -99,7 +99,7 @@ func (f *FreeTierCluster) Create(ctx context.Context, request resource.CreateReq
 
 	clusterResp, err := f.checkFreeTierClusterStatus(ctx, organizationId, projectId, freeTierClusterResponse.Id.String())
 	if err != nil {
-		response.Diagnostics.AddWarning(
+		response.Diagnostics.AddError(
 			"error getting cluster status",
 			"failed to get cluster status, please refresh state later "+api.ParseError(err),
 		)

--- a/internal/resources/free_tier_cluster.go
+++ b/internal/resources/free_tier_cluster.go
@@ -96,7 +96,8 @@ func (f *FreeTierCluster) Create(ctx context.Context, request resource.CreateReq
 	if response.Diagnostics.HasError() {
 		return
 	}
-	clusterResp, err := f.checkForFreeTierClusterDesiredStatus(ctx, organizationId, projectId, freeTierClusterResponse.Id.String())
+
+	clusterResp, err := f.checkFreeTierClusterStatus(ctx, organizationId, projectId, freeTierClusterResponse.Id.String())
 	if err != nil {
 		response.Diagnostics.AddWarning(
 			"error getting cluster status",
@@ -272,7 +273,6 @@ func (f *FreeTierCluster) Delete(ctx context.Context, request resource.DeleteReq
 		clusterId      = resourceIDs[providerschema.Id]
 	)
 
-	// Delete existing Cluster.
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/freeTier/%s", f.HostURL, organizationId, projectId, clusterId)
 	cfg := api.EndpointCfg{Url: url, Method: http.MethodDelete, SuccessStatus: http.StatusAccepted}
 	_, err = f.ClientV1.ExecuteWithRetry(
@@ -296,26 +296,13 @@ func (f *FreeTierCluster) Delete(ctx context.Context, request resource.DeleteReq
 		return
 	}
 
-	freeTierClusterResp, err := f.checkForFreeTierClusterDesiredStatus(ctx, state.OrganizationId.ValueString(), state.ProjectId.ValueString(), state.Id.ValueString())
-
+	err = f.checkFreeTierClusterDeletionStatus(ctx, organizationId, projectId, clusterId)
 	if err != nil {
-		resourceNotFound, errString := api.CheckResourceNotFoundError(err)
-		if !resourceNotFound {
-			response.Diagnostics.AddError(
-				"Error Deleting Capella Cluster",
-				"Could not delete cluster id "+state.Id.String()+": "+errString,
-			)
-			return
-		}
-		// resourceNotFound as expected.
-		return
-	}
-
-	if freeTierClusterResp.CurrentState == clusterapi.DestroyFailed {
 		response.Diagnostics.AddError(
 			"Error Deleting Free Tier Cluster",
-			"Could not delete cluster id "+state.Id.String()+": cluster in destroy failed state",
+			"Could not delete cluster id "+state.Id.String()+": "+api.ParseError(err),
 		)
+		return
 	}
 }
 
@@ -366,7 +353,7 @@ func initializePendingFreeTierClusterWithPlanAndId(plan providerschema.FreeTierC
 // organization, project, and cluster ID. It periodically fetches the cluster status using the `getCluster`
 // function and waits until the cluster reaches a final state or until a specified timeout is reached.
 // The function returns an error if the operation times out or encounters an error during status retrieval.
-func (f *FreeTierCluster) checkForFreeTierClusterDesiredStatus(ctx context.Context, organizationId, projectId, ClusterId string) (*clusterapi.GetClusterResponse, error) {
+func (f *FreeTierCluster) checkFreeTierClusterStatus(ctx context.Context, organizationId, projectId, ClusterId string) (*clusterapi.GetClusterResponse, error) {
 	var (
 		clusterResp *clusterapi.GetClusterResponse
 		err         error
@@ -379,7 +366,8 @@ func (f *FreeTierCluster) checkForFreeTierClusterDesiredStatus(ctx context.Conte
 	ctx, cancel = context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	ticker := time.NewTicker(3 * time.Second)
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -389,15 +377,53 @@ func (f *FreeTierCluster) checkForFreeTierClusterDesiredStatus(ctx context.Conte
 			clusterResp, err = f.getFreeTierCluster(ctx, organizationId, projectId, ClusterId)
 			switch err {
 			case nil:
-				if clusterapi.IsFinalState(clusterResp.CurrentState) {
-					tflog.Info(ctx, "cluster status is in final state")
+				if (clusterResp.CurrentState).Equal(clusterapi.Healthy) {
 					return clusterResp, nil
 				}
-				const msg = "waiting for cluster to complete the execution"
+				if clusterapi.IsTerminalState(clusterResp.CurrentState) {
+					return nil, fmt.Errorf("free tier cluster %s deploy failed, current state is %s", clusterResp.Id, clusterResp.CurrentState)
+				}
+
+				const msg = "waiting for free tier cluster to complete the execution"
 				tflog.Info(ctx, msg)
 			default:
 				return clusterResp, err
 			}
+		}
+	}
+}
+
+// checkFreeTierClusterDeletionStatus polls the free tier cluster after a delete has been
+// accepted until the GET returns a 404, which means the cluster record is gone and deletion
+// completed. It returns an error if the cluster lands in destroyFailed or if the operation
+// times out.
+func (f *FreeTierCluster) checkFreeTierClusterDeletionStatus(ctx context.Context, organizationId, projectId, clusterId string) error {
+	// Assuming 60 minutes is the max time deletion takes, can change after discussion.
+	const timeout = time.Minute * 60
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("cluster deletion status transition timed out after initiation")
+		case <-ticker.C:
+			clusterResp, err := f.getFreeTierCluster(ctx, organizationId, projectId, clusterId)
+			if err != nil {
+				if resourceNotFound, _ := api.CheckResourceNotFoundError(err); resourceNotFound {
+					return nil
+				}
+				continue
+			}
+			if clusterResp.CurrentState.Equal(clusterapi.DestroyFailed) {
+				return fmt.Errorf("free tier cluster destroy failed")
+			}
+			tflog.Info(ctx, "waiting for free tier cluster destroy to complete")
 		}
 	}
 }


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-132323

## Description

when a cluster deploy fails, resource is saved to state.  this is what we want, because the resource is marked as tainted and terraform replaces the resource.  we want a replace so that terraform cleans up any infra deployed for the failed cluster.

the problem is the replace never happens.  this PR fixes that

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

  validation in ticket

</details>

## Further comments