### PR TITLE
[AV-139985] Preserve credential_type and user_roles on refresh

### DIFF
--- a/internal/resources/database_credential.go
+++ b/internal/resources/database_credential.go
@@ -270,6 +270,17 @@ func (r *DatabaseCredential) Read(ctx context.Context, req resource.ReadRequest,
 	// For now, we are appending same permissions that the customer passed in the terraform files and not relying on the GET API response.
 	refreshedState.Access = mapAccess(state)
 
+	// credential_type is absent from the GET API response and user_roles cannot be trusted
+	// to be complete, so both are carried forward from prior state rather than re-derived on
+	// every refresh. Deriving credential_type from the response flips an advanced credential
+	// to basic whenever userRoles is missing, and the RequiresReplace on credential_type turns
+	// that into a destroy and recreate (AV-139985). A null credential_type means there is no
+	// prior state - the import path - where the derived value is the only one available.
+	if !state.CredentialType.IsNull() {
+		refreshedState.CredentialType = state.CredentialType
+		refreshedState.UserRoles = state.UserRoles
+	}
+
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &refreshedState)
 	resp.Diagnostics.Append(diags...)
@@ -468,9 +479,10 @@ func (r *DatabaseCredential) retrieveDatabaseCredential(ctx context.Context, org
 		auditObj,
 	)
 
-	// The GET API response does not include the credential type, but user roles are
-	// only present for advanced credentials, so the type is derived from them. This
-	// keeps the credential type populated when a credential is imported.
+	// The GET API response does not include the credential type, but user roles are only
+	// present for advanced credentials, so the type is derived from them. This derivation
+	// serves the import path alone: Create and Update overwrite both fields from the plan,
+	// and Read overwrites them from prior state whenever prior state exists.
 	refreshedState.CredentialType = types.StringValue(credentialTypeBasic)
 	if len(dbResp.UserRoles) > 0 {
 		refreshedState.CredentialType = types.StringValue(credentialTypeAdvanced)

--- a/internal/resources/database_credential.go
+++ b/internal/resources/database_credential.go
@@ -270,12 +270,9 @@ func (r *DatabaseCredential) Read(ctx context.Context, req resource.ReadRequest,
 	// For now, we are appending same permissions that the customer passed in the terraform files and not relying on the GET API response.
 	refreshedState.Access = mapAccess(state)
 
-	// credential_type is absent from the GET API response and user_roles cannot be trusted
-	// to be complete, so both are carried forward from prior state rather than re-derived on
-	// every refresh. Deriving credential_type from the response flips an advanced credential
-	// to basic whenever userRoles is missing, and the RequiresReplace on credential_type turns
-	// that into a destroy and recreate (AV-139985). A null credential_type means there is no
-	// prior state - the import path - where the derived value is the only one available.
+	// credential_type is absent from the GET API response and user_roles cannot be trusted to
+	// be complete, so both are carried forward from prior state; re-deriving them destroys and
+	// recreates the credential (AV-139985). A null credential_type means no prior state: import.
 	if !state.CredentialType.IsNull() {
 		refreshedState.CredentialType = state.CredentialType
 		refreshedState.UserRoles = state.UserRoles

--- a/internal/resources/database_credential_test.go
+++ b/internal/resources/database_credential_test.go
@@ -2,51 +2,58 @@ package resources
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"gotest.tools/assert"
 
-	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
 
 const (
-	testCredentialID   = "e8d94b7a-d03e-4f28-b14a-65e0487c764a"
+	testCredentialID   = "e8d94b7a-d03e-4f28-b14a-65e0487c764a" //nolint:gosec // G101: a resource UUID, not a credential
 	testCredentialName = "AdvancedCredential"
 	testUserRole       = "developer"
 )
 
-// databaseCredentialGetHandler serves the V4 GET database credential endpoint with a
-// fixed credential, carrying userRoles only when withUserRoles is set. Omitting them
-// is the response shape that used to flip credential_type to basic (AV-139985); the
-// omitempty tag on the field drops it from the body entirely.
+// databaseCredentialGetHandler serves the V4 GET database credential endpoint, carrying
+// userRoles only when withUserRoles is set - omitting them is the response shape that used
+// to flip credential_type to basic (AV-139985).
+//
+// The body is a literal rather than a marshalled api.GetDatabaseCredentialResponse so the
+// test pins the real wire format: marshalling the provider's own struct would round-trip
+// successfully even if its json tags did not match what the API sends.
 func databaseCredentialGetHandler(t *testing.T, withUserRoles bool, gotPath *string) http.HandlerFunc {
 	t.Helper()
+
+	var userRoles string
+	if withUserRoles {
+		userRoles = fmt.Sprintf(`"userRoles": [%q],`, testUserRole)
+	}
+	body := fmt.Sprintf(`{
+		"id": %q,
+		"name": %q,
+		"organizationId": %q,
+		"projectId": %q,
+		"clusterId": %q,
+		"access": [],
+		%s
+		"audit": {
+			"createdAt": "2026-08-01T00:00:00Z", "createdBy": "tf-acc",
+			"modifiedAt": "2026-08-01T00:00:00Z", "modifiedBy": "tf-acc", "version": 1
+		}
+	}`, testCredentialID, testCredentialName, testOrgID, testProjectID, testClusterID, userRoles)
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		*gotPath = r.URL.Path
-
-		body := api.GetDatabaseCredentialResponse{
-			Id:             uuid.MustParse(testCredentialID),
-			Name:           testCredentialName,
-			OrganizationId: testOrgID,
-			ProjectId:      testProjectID,
-			ClusterId:      testClusterID,
-		}
-		if withUserRoles {
-			body.UserRoles = []string{testUserRole}
-		}
-
-		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(body); err != nil {
-			t.Errorf("encoding stub response: %v", err)
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Errorf("writing stub response: %v", err)
 		}
 	}
 }

--- a/internal/resources/database_credential_test.go
+++ b/internal/resources/database_credential_test.go
@@ -1,0 +1,202 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"gotest.tools/assert"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+const (
+	testCredentialID   = "e8d94b7a-d03e-4f28-b14a-65e0487c764a"
+	testCredentialName = "AdvancedCredential"
+	testUserRole       = "developer"
+)
+
+// databaseCredentialGetHandler serves the V4 GET database credential endpoint with a
+// fixed credential, carrying userRoles only when withUserRoles is set. Omitting them
+// is the response shape that used to flip credential_type to basic (AV-139985); the
+// omitempty tag on the field drops it from the body entirely.
+func databaseCredentialGetHandler(t *testing.T, withUserRoles bool, gotPath *string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		*gotPath = r.URL.Path
+
+		body := api.GetDatabaseCredentialResponse{
+			Id:             uuid.MustParse(testCredentialID),
+			Name:           testCredentialName,
+			OrganizationId: testOrgID,
+			ProjectId:      testProjectID,
+			ClusterId:      testClusterID,
+		}
+		if withUserRoles {
+			body.UserRoles = []string{testUserRole}
+		}
+
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			t.Errorf("encoding stub response: %v", err)
+		}
+	}
+}
+
+// managedCredentialState is the prior state Create or Update would have written for a
+// Terraform-managed credential: every ID resolved and credential_type concrete.
+func managedCredentialState(credentialType string, userRoles []types.String, access []providerschema.Access) providerschema.DatabaseCredential {
+	return providerschema.DatabaseCredential{
+		Id:             types.StringValue(testCredentialID),
+		Name:           types.StringValue(testCredentialName),
+		Password:       types.StringValue("Secret12$#"),
+		OrganizationId: types.StringValue(testOrgID),
+		ProjectId:      types.StringValue(testProjectID),
+		ClusterId:      types.StringValue(testClusterID),
+		Audit:          types.ObjectNull(providerschema.CouchbaseAuditData{}.AttributeTypes()),
+		CredentialType: types.StringValue(credentialType),
+		UserRoles:      userRoles,
+		Access:         access,
+	}
+}
+
+// importedCredentialState is the state ImportState leaves behind: the comma separated
+// import string in id and every other attribute null, credential_type included. This is
+// the only case where the credential type has to be derived from the GET response.
+func importedCredentialState() providerschema.DatabaseCredential {
+	importID := fmt.Sprintf("id=%s,organization_id=%s,project_id=%s,cluster_id=%s",
+		testCredentialID, testOrgID, testProjectID, testClusterID)
+
+	return providerschema.DatabaseCredential{
+		Id:             types.StringValue(importID),
+		Name:           types.StringNull(),
+		Password:       types.StringNull(),
+		OrganizationId: types.StringNull(),
+		ProjectId:      types.StringNull(),
+		ClusterId:      types.StringNull(),
+		Audit:          types.ObjectNull(providerschema.CouchbaseAuditData{}.AttributeTypes()),
+		CredentialType: types.StringNull(),
+	}
+}
+
+// TestDatabaseCredentialReadPreservesCredentialType covers the refresh path for
+// credential_type and user_roles. The V4 GET response reports neither reliably -
+// credential_type is absent from it altogether - so Read carries both forward from prior
+// state and derives them only on import. Before AV-139985 Read re-derived credential_type
+// from the presence of userRoles, so a response omitting them rewrote an advanced
+// credential as basic and the RequiresReplace on credential_type destroyed it.
+func TestDatabaseCredentialReadPreservesCredentialType(t *testing.T) {
+	ctx := context.Background()
+
+	advancedRoles := []types.String{types.StringValue(testUserRole)}
+	basicAccess := []providerschema.Access{{Privileges: []types.String{types.StringValue("read")}}}
+
+	tests := []struct {
+		name          string
+		prior         providerschema.DatabaseCredential
+		withUserRoles bool
+		wantType      string
+		wantRoles     []string
+	}{
+		{
+			name:          "advanced credential, response carries roles",
+			prior:         managedCredentialState(credentialTypeAdvanced, advancedRoles, nil),
+			withUserRoles: true,
+			wantType:      credentialTypeAdvanced,
+			wantRoles:     []string{testUserRole},
+		},
+		{
+			// The regression. Identical to the case above but for the missing roles.
+			name:          "advanced credential, response omits roles",
+			prior:         managedCredentialState(credentialTypeAdvanced, advancedRoles, nil),
+			withUserRoles: false,
+			wantType:      credentialTypeAdvanced,
+			wantRoles:     []string{testUserRole},
+		},
+		{
+			name:          "basic credential stays basic with no roles",
+			prior:         managedCredentialState(credentialTypeBasic, nil, basicAccess),
+			withUserRoles: false,
+			wantType:      credentialTypeBasic,
+			wantRoles:     nil,
+		},
+		{
+			// A basic credential must not be promoted if the response ever reports roles.
+			name:          "basic credential is not promoted by roles in the response",
+			prior:         managedCredentialState(credentialTypeBasic, nil, basicAccess),
+			withUserRoles: true,
+			wantType:      credentialTypeBasic,
+			wantRoles:     nil,
+		},
+		{
+			name:          "import derives advanced from roles in the response",
+			prior:         importedCredentialState(),
+			withUserRoles: true,
+			wantType:      credentialTypeAdvanced,
+			wantRoles:     []string{testUserRole},
+		},
+		{
+			name:          "import derives basic when the response has no roles",
+			prior:         importedCredentialState(),
+			withUserRoles: false,
+			wantType:      credentialTypeBasic,
+			wantRoles:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			r := &DatabaseCredential{
+				Data: newTestProviderData(t, databaseCredentialGetHandler(t, tc.withUserRoles, &gotPath)),
+			}
+
+			priorState := tfsdk.State{Schema: DatabaseCredentialSchema()}
+			assertNoDiags(t, priorState.Set(ctx, tc.prior))
+
+			// The framework seeds the response state with prior state before calling Read.
+			resp := resource.ReadResponse{State: priorState}
+			r.Read(ctx, resource.ReadRequest{State: priorState}, &resp)
+			assertNoDiags(t, resp.Diagnostics)
+
+			var got providerschema.DatabaseCredential
+			assertNoDiags(t, resp.State.Get(ctx, &got))
+
+			assert.Equal(t, got.CredentialType.ValueString(), tc.wantType,
+				"credential_type must never change on a refresh")
+			assert.DeepEqual(t, roleNames(got.UserRoles), tc.wantRoles)
+			assert.Equal(t, got.Id.ValueString(), testCredentialID,
+				"the credential id must be resolved to the id from the response")
+			assert.Equal(t, gotPath, fmt.Sprintf("/v4/organizations/%s/projects/%s/clusters/%s/users/%s",
+				testOrgID, testProjectID, testClusterID, testCredentialID))
+		})
+	}
+}
+
+// roleNames unwraps user role names for comparison, preserving a nil slice so that a
+// null user_roles attribute is distinguishable from an empty one.
+func roleNames(roles []types.String) []string {
+	if roles == nil {
+		return nil
+	}
+	names := make([]string, len(roles))
+	for i, role := range roles {
+		names[i] = role.ValueString()
+	}
+	return names
+}
+
+func assertNoDiags(t *testing.T, diags diag.Diagnostics) {
+	t.Helper()
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags.Errors())
+	}
+}

--- a/internal/resources/helpers_test.go
+++ b/internal/resources/helpers_test.go
@@ -1,0 +1,23 @@
+package resources
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+// newTestProviderData starts an httptest server backed by handler and returns the
+// provider data a resource needs to talk to it. The server is closed on test cleanup.
+func newTestProviderData(t *testing.T, handler http.HandlerFunc) *providerschema.Data {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	return &providerschema.Data{
+		ClientV1: &api.Client{Client: srv.Client()},
+		HostURL:  srv.URL,
+	}
+}

--- a/internal/resources/private_endpoint_service_test.go
+++ b/internal/resources/private_endpoint_service_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"net/http"
-	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
-	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
 )
 
 const (
@@ -94,15 +92,7 @@ func (b *fakeBackend) handler(w http.ResponseWriter, r *http.Request) {
 // by the supplied fakeBackend.
 func newTestResource(t *testing.T, b *fakeBackend) *PrivateEndpointService {
 	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(b.handler))
-	t.Cleanup(srv.Close)
-
-	return &PrivateEndpointService{
-		Data: &providerschema.Data{
-			ClientV1: &api.Client{Client: srv.Client()},
-			HostURL:  srv.URL,
-		},
-	}
+	return &PrivateEndpointService{Data: newTestProviderData(t, b.handler)}
 }
 
 func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## Jira

* AV-139985

## Description

The V4 GET response does not include credentialType, so Read derived it from the presence of userRoles: advanced when roles came back, basic otherwise. Any refresh whose response omitted userRoles therefore rewrote an advanced credential's state as basic with null roles, and the RequiresReplace on credential_type turned the next plan into a destroy and recreate that rotated the password - on a routine plan with no configuration change.

Read now carries both fields forward from prior state, as it already does for password and access (SURF-7366). The derivation in retrieveDatabaseCredential is kept for import, where there is no prior state to carry forward; a null
credential_type is what identifies that case.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [x] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments