### PR TITLE
[AV-138292] Pin App Service version to 4.0

### DIFF
--- a/acceptance_tests/app_endpoint_environment.go
+++ b/acceptance_tests/app_endpoint_environment.go
@@ -305,13 +305,15 @@ func waitForAppEndpointTestBucket(ctx context.Context, client *api.Client, bucke
 
 func createAppEndpointTestAppService(ctx context.Context, client *api.Client) (string, error) {
 	var n int64 = 2
+	version := pinnedAppServiceVersion
 	appServiceRequest := appservice.CreateAppServiceRequest{
 		Name: appEndpointAppServiceName,
 		Compute: appservice.AppServiceCompute{
 			Cpu: 2,
 			Ram: 4,
 		},
-		Nodes: &n,
+		Nodes:   &n,
+		Version: &version,
 	}
 
 	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/appservices", globalHost, globalOrgId, globalProjectId, appEndpointClusterId)

--- a/acceptance_tests/app_service.go
+++ b/acceptance_tests/app_service.go
@@ -15,13 +15,15 @@ import (
 
 func createAppService(ctx context.Context, client *api.Client) error {
 	var n int64 = 2
+	version := pinnedAppServiceVersion
 	appServiceRequest := appservice.CreateAppServiceRequest{
 		Name: globalAppServiceName,
 		Compute: appservice.AppServiceCompute{
 			Cpu: 2,
 			Ram: 4,
 		},
-		Nodes: &n,
+		Nodes:   &n,
+		Version: &version,
 	}
 
 	url := fmt.Sprintf(

--- a/acceptance_tests/appservice_acceptance_test.go
+++ b/acceptance_tests/appservice_acceptance_test.go
@@ -177,6 +177,8 @@ data "couchbase-capella_app_services" "%[2]s" {}
 func testAccAppServiceResourceConfig(resourceName string) string {
 	clusterName := randomStringWithPrefix("tf_acc_cluster_")
 	cidr := generateRandomCIDR()
+	// Pin 4.0 due to bug CBG-5539 causing test cleanup failures. Remove once 4.1.2+ is the default version.
+	const version = "4.0"
 	return fmt.Sprintf(`
 %[1]s
 
@@ -220,12 +222,13 @@ resource "couchbase-capella_app_service" "%[4]s" {
   project_id      = "%[3]s"
   cluster_id      = couchbase-capella_cluster.%[5]s.id
   name            = "tf_acc_test_app_service"
+  version         = "%[7]s"
   compute = {
     cpu = 2
     ram = 4
   }
 }
-`, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, cidr)
+`, globalProviderBlock, globalOrgId, globalProjectId, resourceName, clusterName, cidr, version)
 }
 
 func testAccAppServiceResourceOptionalFieldsConfig(resourceName, clusterName, cidr, appServiceName, description, version string, nodes, cpu, ram int) string {

--- a/acceptance_tests/appservice_acceptance_test.go
+++ b/acceptance_tests/appservice_acceptance_test.go
@@ -48,7 +48,7 @@ func TestAccAppServiceResourceOptionalFieldsAndScale(t *testing.T) {
 	appServiceName := randomStringWithPrefix("tf_acc_app_svc_")
 	description := "terraform app service optional fields acceptance test"
 
-	const version = "4.0"
+	const version = pinnedAppServiceVersion
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
@@ -177,8 +177,7 @@ data "couchbase-capella_app_services" "%[2]s" {}
 func testAccAppServiceResourceConfig(resourceName string) string {
 	clusterName := randomStringWithPrefix("tf_acc_cluster_")
 	cidr := generateRandomCIDR()
-	// Pin 4.0 due to bug CBG-5539 causing test cleanup failures. Remove once 4.1.2+ is the default version.
-	const version = "4.0"
+	const version = pinnedAppServiceVersion
 	return fmt.Sprintf(`
 %[1]s
 

--- a/acceptance_tests/globals.go
+++ b/acceptance_tests/globals.go
@@ -142,4 +142,9 @@ var (
 
 const (
 	timeout = 60 * time.Second
+
+	// pinnedAppServiceVersion keeps every acceptance test app service on 4.0 while the default 4.1.1 carries
+	// CBG-5539, which slows Sync Gateway database deletes and makes cleanups time out. Remove once 4.1.2+ is
+	// the default version.
+	pinnedAppServiceVersion = "4.0"
 )


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-138292

## Description

- Pin App Service version to 4.0 to avoid bug CBG-5539 which is causing acceptance tests to fail. This PR can be reverted in the future once App Service version 4.1.2 is released.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

Acceptance tests pass with confirmation from QE: https://jira.issues.couchbase.com/browse/AV-138292?focusedCommentId=1464463

</details>

## Further comments