### PR TITLE
AV-141834 Add acceptance tests granular rbac phase 3

### DIFF
--- a/acceptance_tests/database_credential_acceptance_test.go
+++ b/acceptance_tests/database_credential_acceptance_test.go
@@ -21,6 +21,7 @@ func TestAccDatabaseCredentialWithReqFields(t *testing.T) {
 	resourceReference := "couchbase-capella_database_credential." + resourceName
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseCredentialDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAddDatabaseCredWithReqFieldsConfig(resourceName),
@@ -41,6 +42,7 @@ func TestAccDatabaseCredentialWithOptionalFields(t *testing.T) {
 	resourceReference := "couchbase-capella_database_credential." + resourceName
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseCredentialDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAddDatabaseCredWithOptionalFieldsConfig(resourceName),
@@ -65,6 +67,7 @@ func TestAccDatabaseCredentialAdvanced(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRBACDestroy,
 		Steps: []resource.TestStep{
 			// Create and Read
 			{

--- a/acceptance_tests/database_credential_rbac_test.go
+++ b/acceptance_tests/database_credential_rbac_test.go
@@ -1,0 +1,338 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// Gaps in database_credential coverage introduced alongside fine-grained RBAC.
+//
+// The existing suite covers the two credential types and the four
+// access/user_roles/credential_type conflict combinations. What it did not cover is the
+// size validator on user_roles, the credential_type enum, the requires-replace
+// behaviour when switching type, updating a basic credential's access in place, and
+// the API's answer to a user role that does not exist.
+
+// TestAccDatabaseCredentialEmptyUserRoles covers the SizeAtLeast(1) validator on
+// user_roles. `user_roles = []` satisfies ExactlyOneOf but carries no permission, the
+// mirror of the `access = []` case already covered for basic credentials.
+func TestAccDatabaseCredentialEmptyUserRoles(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_cred_empty_roles_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_credential" %[5]q {
+  name            = %[5]q
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  credential_type = "advanced"
+  user_roles      = []
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName),
+				ExpectError: regexp.MustCompile(`(?s)user_roles.*(must contain at least 1|Invalid Attribute Combination)`),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseCredentialInvalidCredentialType covers the OneOf validator attached to
+// credential_type. The validator is wired by hand because the published OpenAPI spec
+// does not yet carry the enum, so it is worth pinning.
+func TestAccDatabaseCredentialInvalidCredentialType(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_cred_bad_type_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_credential" %[5]q {
+  name            = %[5]q
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  credential_type = "superuser"
+  access = [
+    {
+      privileges = ["data_writer"]
+    },
+  ]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName),
+				ExpectError: regexp.MustCompile(`(?s)credential_type.*must be one of`),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseCredentialTypeRequiresReplace verifies that switching a credential from
+// basic to advanced replaces it. credential_type carries a RequiresReplace plan modifier
+// because the V4 API cannot convert an existing credential between the two forms.
+func TestAccDatabaseCredentialTypeRequiresReplace(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_cred_retype_")
+	resourceReference := "couchbase-capella_database_credential." + resourceName
+	roleName := randomStringWithPrefix("tf_acc_db_role_")
+
+	var originalID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRBACDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseCredentialBasicWithRoleConfig(resourceName, roleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseCredentialResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "credential_type", "basic"),
+					testAccCheckCaptureResourceID(resourceReference, &originalID),
+				),
+			},
+			{
+				Config: testAccDatabaseCredentialAdvancedWithRoleConfig(resourceName, roleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseCredentialResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "credential_type", "advanced"),
+					resource.TestCheckResourceAttr(resourceReference, "user_roles.#", "1"),
+					resource.TestCheckNoResourceAttr(resourceReference, "access.#"),
+					testAccCheckResourceIDChanged(resourceReference, &originalID),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseCredentialBasicAccessUpdate updates a basic credential's access in
+// place: first widening the privileges, then narrowing the resources to one bucket.
+func TestAccDatabaseCredentialBasicAccessUpdate(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_cred_access_upd_")
+	resourceReference := "couchbase-capella_database_credential." + resourceName
+
+	clusterWideAccess := `[
+    {
+      privileges = ["data_reader"]
+    },
+  ]`
+	widenedAccess := `[
+    {
+      privileges = ["data_reader", "data_writer"]
+    },
+  ]`
+	bucketScopedAccess := fmt.Sprintf(`[
+    {
+      privileges = ["data_reader"]
+      resources = {
+        buckets = [
+          {
+            name = %q
+          },
+        ]
+      }
+    },
+  ]`, globalBucketName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseCredentialAccessConfig(resourceName, clusterWideAccess),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseCredentialResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.privileges.#", "1"),
+				),
+			},
+			{
+				Config: testAccDatabaseCredentialAccessConfig(resourceName, widenedAccess),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseCredentialResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.privileges.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "data_reader"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "data_writer"),
+				),
+			},
+			{
+				Config: testAccDatabaseCredentialAccessConfig(resourceName, bucketScopedAccess),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseCredentialResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.privileges.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.name", globalBucketName),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseCredentialUntrimmedName covers the trimmed-name check on create.
+func TestAccDatabaseCredentialUntrimmedName(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_cred_untrimmed_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_credential" %[5]q {
+  name            = "  %[5]s  "
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  access = [
+    {
+      privileges = ["data_writer"]
+    },
+  ]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName),
+				ExpectError: regexp.MustCompile(`(?s)leading.*trailing spaces`),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseCredentialNonExistentUserRole covers an advanced credential naming a
+// role that was never created. Nothing client-side resolves role names, so the API is
+// what rejects it.
+func TestAccDatabaseCredentialNonExistentUserRole(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_cred_bad_role_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_credential" %[5]q {
+  name            = %[5]q
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  password        = "Secret12$#"
+  credential_type = "advanced"
+  user_roles      = ["tf_acc_no_such_role"]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName),
+				ExpectError: apiErrorPattern("Error creating database credential",
+					"application user roles do not exist on this cluster", "422"),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseCredentialInvalidCluster covers a well-formed but unknown cluster UUID.
+func TestAccDatabaseCredentialInvalidCluster(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_cred_bad_cluster_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_credential" %[4]q {
+  name            = %[4]q
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = "00000000-0000-0000-0000-000000000000"
+  access = [
+    {
+      privileges = ["data_writer"]
+    },
+  ]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, resourceName),
+				ExpectError: apiErrorPattern("Error creating database credential", "", "(403|404)"),
+			},
+		},
+	})
+}
+
+// --- Config builders ---
+
+func testAccDatabaseCredentialAccessConfig(resourceName, accessHCL string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_credential" %[5]q {
+  name            = %[5]q
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  password        = "Secret12$#"
+  access          = %[6]s
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName, accessHCL)
+}
+
+// testAccDatabaseCredentialBasicWithRoleConfig renders a basic credential alongside the
+// role the advanced variant will reference, so the two steps of the requires-replace
+// test differ only in the credential itself.
+func testAccDatabaseCredentialBasicWithRoleConfig(resourceName, roleName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_role" "retype_role" {
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  name            = %[6]q
+  access = %[7]s
+}
+
+resource "couchbase-capella_database_credential" %[5]q {
+  name            = %[5]q
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  password        = "Secret12$#"
+  credential_type = "basic"
+  access = [
+    {
+      privileges = ["data_writer"]
+    },
+  ]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName, roleName,
+		accessCollectionLevel("dataRead"))
+}
+
+func testAccDatabaseCredentialAdvancedWithRoleConfig(resourceName, roleName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_role" "retype_role" {
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  name            = %[6]q
+  access = %[7]s
+}
+
+resource "couchbase-capella_database_credential" %[5]q {
+  name            = %[5]q
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  password        = "Secret12$#"
+  credential_type = "advanced"
+  user_roles      = [couchbase-capella_database_role.retype_role.name]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName, roleName,
+		accessCollectionLevel("dataRead"))
+}

--- a/acceptance_tests/database_credentials_datasource_test.go
+++ b/acceptance_tests/database_credentials_datasource_test.go
@@ -16,6 +16,7 @@ func TestAccDatasourceDatabaseCredentials(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseCredentialDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseCredentialsDataSourceConfig(resourceName, dsName),
@@ -50,6 +51,7 @@ func TestAccDatasourceDatabaseCredentialsAdvanced(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRBACDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseCredentialsAdvancedDataSourceConfig(resourceName, dsName, roleName),

--- a/acceptance_tests/database_privileges_datasource_test.go
+++ b/acceptance_tests/database_privileges_datasource_test.go
@@ -141,3 +141,139 @@ data "couchbase-capella_database_privileges" "%[2]s" {
 }
 `, globalProviderBlock, dsName, globalOrgId, globalProjectId, clusterID)
 }
+
+// privilegeLevel is the deepest resource level a privilege may be granted at, as
+// declared by the RBAC template in the data source's resources attribute.
+type privilegeLevel int
+
+const (
+	// privilegeLevelCluster has no resources block at all.
+	privilegeLevelCluster privilegeLevel = iota
+	// privilegeLevelBucket has a bucket with no scopes.
+	privilegeLevelBucket
+	// privilegeLevelScope has a bucket and a scope but no collections.
+	privilegeLevelScope
+	// privilegeLevelCollection nests all the way down to collections.
+	privilegeLevelCollection
+)
+
+func (l privilegeLevel) String() string {
+	switch l {
+	case privilegeLevelCluster:
+		return "cluster"
+	case privilegeLevelBucket:
+		return "bucket"
+	case privilegeLevelScope:
+		return "scope"
+	case privilegeLevelCollection:
+		return "collection"
+	}
+	return "unknown"
+}
+
+// TestAccDatasourceDatabasePrivilegesRBACTemplate asserts the data source reproduces the
+// RBAC template faithfully, not merely that it returned something.
+//
+// This is the regression guard for AV-141822, where the privileges endpoint's
+// {"data": [...]} envelope was unmarshalled into a bare slice and every read failed. It
+// also pins the level each privilege may be granted at, which is what a config author
+// consults to avoid the 422 covered by TestAccDatabaseRolePrivilegeLevelMismatch.
+func TestAccDatasourceDatabasePrivilegesRBACTemplate(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_db_privs_tmpl_")
+	dsReference := "data.couchbase-capella_database_privileges." + dsName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabasePrivilegesDataSourceConfig(dsName, globalClusterId),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Every privilege in the catalogue must carry a group.
+					testAccCheckDatabasePrivilegesAllPopulated(dsReference),
+					// One representative privilege per level.
+					testAccCheckDatabasePrivilegeLevel(dsReference, "dataRead", "data", privilegeLevelCollection),
+					testAccCheckDatabasePrivilegeLevel(dsReference, "queryManage", "query", privilegeLevelScope),
+					testAccCheckDatabasePrivilegeLevel(dsReference, "viewsReader", "data", privilegeLevelBucket),
+					testAccCheckDatabasePrivilegeLevel(dsReference, "statsRead", "global", privilegeLevelCluster),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckDatabasePrivilegesAllPopulated requires every returned privilege to have
+// both a name and a group. The pre-existing non-empty check passes as soon as one entry
+// is well formed, which would hide a partially decoded envelope.
+func testAccCheckDatabasePrivilegesAllPopulated(dsReference string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attrs, count, err := databasePrivilegeAttrs(s, dsReference)
+		if err != nil {
+			return err
+		}
+		for i := 0; i < count; i++ {
+			if attrs[fmt.Sprintf("data.%d.name", i)] == "" {
+				return fmt.Errorf("privilege at index %d has no name", i)
+			}
+			if attrs[fmt.Sprintf("data.%d.group", i)] == "" {
+				return fmt.Errorf("privilege %q at index %d has no group",
+					attrs[fmt.Sprintf("data.%d.name", i)], i)
+			}
+		}
+		return nil
+	}
+}
+
+// testAccCheckDatabasePrivilegeLevel finds privilegeName in the data source output and
+// asserts its group and the depth of its RBAC template.
+func testAccCheckDatabasePrivilegeLevel(dsReference, privilegeName, wantGroup string, wantLevel privilegeLevel) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attrs, count, err := databasePrivilegeAttrs(s, dsReference)
+		if err != nil {
+			return err
+		}
+
+		for i := 0; i < count; i++ {
+			prefix := fmt.Sprintf("data.%d.", i)
+			if attrs[prefix+"name"] != privilegeName {
+				continue
+			}
+
+			if got := attrs[prefix+"group"]; got != wantGroup {
+				return fmt.Errorf("privilege %q group = %q, want %q", privilegeName, got, wantGroup)
+			}
+
+			gotLevel := privilegeLevelCluster
+			switch {
+			case attrs[prefix+"resources.buckets.0.scopes.0.collections.#"] != "":
+				gotLevel = privilegeLevelCollection
+			case attrs[prefix+"resources.buckets.0.scopes.#"] != "":
+				gotLevel = privilegeLevelScope
+			case attrs[prefix+"resources.buckets.#"] != "":
+				gotLevel = privilegeLevelBucket
+			}
+
+			if gotLevel != wantLevel {
+				return fmt.Errorf("privilege %q level = %s, want %s", privilegeName, gotLevel, wantLevel)
+			}
+			return nil
+		}
+
+		return fmt.Errorf("privilege %q not found among the %d privileges returned by %s",
+			privilegeName, count, dsReference)
+	}
+}
+
+func databasePrivilegeAttrs(s *terraform.State, dsReference string) (map[string]string, int, error) {
+	ds, ok := s.RootModule().Resources[dsReference]
+	if !ok {
+		return nil, 0, fmt.Errorf("datasource %s not found in state", dsReference)
+	}
+	count, err := strconv.Atoi(ds.Primary.Attributes["data.#"])
+	if err != nil {
+		return nil, 0, fmt.Errorf("datasource %s has no data count: %w", dsReference, err)
+	}
+	if count == 0 {
+		return nil, 0, fmt.Errorf("datasource %s returned no database privileges", dsReference)
+	}
+	return ds.Primary.Attributes, count, nil
+}

--- a/acceptance_tests/database_rbac_helpers_test.go
+++ b/acceptance_tests/database_rbac_helpers_test.go
@@ -1,0 +1,177 @@
+package acceptance_tests
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+)
+
+// apiErrorPattern builds an ExpectError regex for a diagnostic the V4 API produced.
+//
+// Terraform hard-wraps diagnostic text, so a phrase that is contiguous in the JSON
+// response arrives split across lines with leading indentation: "is not a valid
+// privilege" is rendered as "is not a valid\n        privilege". Matching a literal
+// phrase therefore fails for reasons that have nothing to do with the behaviour under
+// test. Every space in summary and phrase is matched as arbitrary whitespace instead.
+//
+// Always pass a phrase. Matching on statusCode alone passes for the wrong reason:
+// this endpoint answers several unrelated problems with a 422, so a name that is too
+// long or a malformed body satisfies a status-only pattern just as well as the case
+// the test means to pin.
+//
+// statusCode is a regex fragment, so both "422" and "(403|404)" are valid.
+func apiErrorPattern(summary, phrase, statusCode string) *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf(
+		`(?s)%s.*%s.*"httpStatusCode":%s`,
+		whitespaceTolerant(summary), whitespaceTolerant(phrase), statusCode,
+	))
+}
+
+// whitespaceTolerant quotes each word and joins them so any run of whitespace,
+// including a line break Terraform inserted, matches between them.
+func whitespaceTolerant(phrase string) string {
+	words := strings.Fields(phrase)
+	for i, word := range words {
+		words[i] = regexp.QuoteMeta(word)
+	}
+	return strings.Join(words, `\s+`)
+}
+
+// Shared helpers for the fine-grained RBAC acceptance tests: database roles,
+// database credentials and the data sources that list them.
+//
+// Naming constraint: Capella rejects a database role name longer than 32 characters
+// with a 422. randomStringWithPrefix appends 10 characters, so any prefix used as a
+// role name must be at most 22. Overshooting is easy to miss because the resulting
+// 422 satisfies a loosely written ExpectError and the test passes for the wrong
+// reason - match on the message, not just the status code. Database credential names
+// are not subject to this limit.
+
+func databaseRoleURL(organizationId, projectId, clusterId, roleId string) string {
+	return fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/roles/%s",
+		globalHost, organizationId, projectId, clusterId, roleId,
+	)
+}
+
+func databaseCredentialURL(organizationId, projectId, clusterId, credentialId string) string {
+	return fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/users/%s",
+		globalHost, organizationId, projectId, clusterId, credentialId,
+	)
+}
+
+// assertGoneFromServer confirms url no longer resolves. Capella answers a GET for a
+// deleted role or credential with 404. A 403 is accepted too, because the API returns
+// forbidden rather than not-found once the enclosing cluster is no longer readable,
+// which is indistinguishable from deletion for the purposes of this check.
+func assertGoneFromServer(url, label string) error {
+	cfg := api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	_, err := globalClient.ExecuteWithRetry(context.Background(), cfg, nil, globalToken, nil)
+	if err == nil {
+		return fmt.Errorf("%s still exists after destroy", label)
+	}
+	if notFound, _ := api.CheckResourceNotFoundError(err); notFound {
+		return nil
+	}
+	if api.IsForbiddenError(err) {
+		return nil
+	}
+	return fmt.Errorf("unexpected error verifying destroy of %s: %w", label, err)
+}
+
+// testAccCheckDatabaseRoleDestroy verifies every database role left in state was
+// actually removed from Capella, not merely dropped from the state file.
+func testAccCheckDatabaseRoleDestroy(s *terraform.State) error {
+	for name, rs := range s.RootModule().Resources {
+		if rs.Type != "couchbase-capella_database_role" {
+			continue
+		}
+		attrs := rs.Primary.Attributes
+		url := databaseRoleURL(attrs["organization_id"], attrs["project_id"], attrs["cluster_id"], attrs["id"])
+		if err := assertGoneFromServer(url, fmt.Sprintf("database role %q (%s)", attrs["name"], name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// testAccCheckDatabaseCredentialDestroy verifies every database credential left in
+// state was actually removed from Capella.
+func testAccCheckDatabaseCredentialDestroy(s *terraform.State) error {
+	for name, rs := range s.RootModule().Resources {
+		if rs.Type != "couchbase-capella_database_credential" {
+			continue
+		}
+		attrs := rs.Primary.Attributes
+		url := databaseCredentialURL(attrs["organization_id"], attrs["project_id"], attrs["cluster_id"], attrs["id"])
+		if err := assertGoneFromServer(url, fmt.Sprintf("database credential %q (%s)", attrs["name"], name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// testAccCheckDatabaseRBACDestroy covers configs that create roles and credentials together.
+func testAccCheckDatabaseRBACDestroy(s *terraform.State) error {
+	if err := testAccCheckDatabaseRoleDestroy(s); err != nil {
+		return err
+	}
+	return testAccCheckDatabaseCredentialDestroy(s)
+}
+
+// testAccDatabaseRoleDeleteOOB deletes the role behind resourceReference directly
+// through the V4 API, simulating removal outside Terraform so the next refresh
+// exercises the not-found branch of Read.
+func testAccDatabaseRoleDeleteOOB(resourceReference string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attrs := databaseRoleAttrsFromState(s, resourceReference)
+		if attrs == nil {
+			return fmt.Errorf("resource %s not found in state", resourceReference)
+		}
+		url := databaseRoleURL(attrs["organization_id"], attrs["project_id"], attrs["cluster_id"], attrs["id"])
+		cfg := api.EndpointCfg{Url: url, Method: http.MethodDelete, SuccessStatus: http.StatusNoContent}
+		if _, err := globalClient.ExecuteWithRetry(context.Background(), cfg, nil, globalToken, nil); err != nil {
+			return fmt.Errorf("out-of-band delete of %s failed: %w", resourceReference, err)
+		}
+		return nil
+	}
+}
+
+// testAccCheckResourceIDChanged asserts the resource was replaced rather than updated
+// in place between two steps, which is how requires-replace behaviour is verified.
+// It reads the id at check time and compares it with the id captured by a prior
+// testAccCheckCaptureResourceID against the same holder.
+func testAccCheckCaptureResourceID(resourceReference string, holder *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attrs := databaseRoleAttrsFromState(s, resourceReference)
+		if attrs == nil {
+			return fmt.Errorf("resource %s not found in state", resourceReference)
+		}
+		*holder = attrs["id"]
+		return nil
+	}
+}
+
+func testAccCheckResourceIDChanged(resourceReference string, previous *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attrs := databaseRoleAttrsFromState(s, resourceReference)
+		if attrs == nil {
+			return fmt.Errorf("resource %s not found in state", resourceReference)
+		}
+		if *previous == "" {
+			return fmt.Errorf("no prior id captured for %s", resourceReference)
+		}
+		if attrs["id"] == *previous {
+			return fmt.Errorf("expected %s to be replaced, but id stayed %s", resourceReference, *previous)
+		}
+		return nil
+	}
+}

--- a/acceptance_tests/database_role_acceptance_test.go
+++ b/acceptance_tests/database_role_acceptance_test.go
@@ -25,6 +25,7 @@ func TestAccDatabaseRoleResource(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
 		Steps: []resource.TestStep{
 			// Create and Read
 			{
@@ -79,6 +80,7 @@ func TestAccDatabaseRoleResourceWithRequiredFieldsOnly(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseRoleResourceConfig(resourceName, "", "", `"dataRead"`),
@@ -104,6 +106,7 @@ func TestAccDatabaseRoleResourceWithScopedAccess(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseRoleResourceConfigWithScopedAccess(resourceName),
@@ -145,6 +148,7 @@ func TestAccDatasourceDatabaseRoles(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseRolesDatasourceConfig(resourceName, dsName),

--- a/acceptance_tests/database_role_access_test.go
+++ b/acceptance_tests/database_role_access_test.go
@@ -1,0 +1,602 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// Access-shape coverage for the database_role resource.
+//
+// Every Capella privilege declares, in the RBAC template returned by the cluster's
+// /privileges endpoint, the deepest resource level it may be granted at: collection,
+// scope, bucket, or cluster-wide with no resources at all. Granting a privilege below
+// its permitted level is rejected by the V4 API with a 422 (see
+// TestAccDatabaseRolePrivilegeLevelMismatch in the negative tests).
+//
+// These tests pin one role per level plus a role combining all three scoped levels,
+// which is what exercises reconcileAccess/reconcileBuckets/reconcileScopes/
+// reconcileCollections end to end. Each apply is followed by the framework's built-in
+// post-apply plan check, so a clean run also proves the round-trip through the API
+// leaves no perpetual diff.
+
+// TestAccDatabaseRoleCollectionLevelAccess grants a collection-level privilege at its
+// deepest level: bucket -> scope -> collection.
+func TestAccDatabaseRoleCollectionLevelAccess(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_role_coll_")
+	resourceReference := "couchbase-capella_database_role." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "collection level", accessCollectionLevel("dataRead")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.privileges.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "dataRead"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.name", globalBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.name", globalScopeName),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.collections.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.collections.0", globalCollectionName),
+				),
+			},
+			{
+				ResourceName:      resourceReference,
+				ImportStateIdFunc: generateDatabaseRoleImportId(resourceReference),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleScopeLevelAccess grants a scope-level privilege with the
+// collections list omitted. queryManage cannot be narrowed to collections, so omitting
+// it is the only valid shape; supplying collections is what AV-141821 hit.
+func TestAccDatabaseRoleScopeLevelAccess(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_role_scope_")
+	resourceReference := "couchbase-capella_database_role." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "scope level", accessScopeLevel("queryManage")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "queryManage"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.name", globalBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.name", globalScopeName),
+					// collections omitted stays null rather than becoming an empty list.
+					resource.TestCheckNoResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.collections.#"),
+				),
+			},
+			{
+				ResourceName:      resourceReference,
+				ImportStateIdFunc: generateDatabaseRoleImportId(resourceReference),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleBucketLevelAccess grants a bucket-level privilege with no scopes.
+func TestAccDatabaseRoleBucketLevelAccess(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_role_bucket_")
+	resourceReference := "couchbase-capella_database_role." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "bucket level", accessBucketLevel("viewsReader")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "viewsReader"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.name", globalBucketName),
+					// scopes omitted stays null.
+					resource.TestCheckNoResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.#"),
+				),
+			},
+			{
+				ResourceName:      resourceReference,
+				ImportStateIdFunc: generateDatabaseRoleImportId(resourceReference),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleGlobalPrivilege grants a cluster-level privilege with the resources
+// block omitted entirely, which is the only valid shape for privileges such as statsRead.
+//
+// This is the round-trip the provider works hardest to hide. createAccessFromSlice sends
+// an empty buckets slice for an entry with no resources, and the V4 API answers the
+// subsequent read with an implicit wildcard bucket, which mergeAccessEntry suppresses via
+// isWildcardOnlyResourcesSchema. If that suppression regresses, the post-apply plan
+// stops being empty and this test fails rather than the drift reaching a user.
+//
+// No import step: on import there is no prior state to reconcile against, so the wildcard
+// the API supplies is kept and ImportStateVerify would compare it against the null the
+// original apply stored. See the note in the summary for AV-141821/AV-141822 follow-up.
+func TestAccDatabaseRoleGlobalPrivilege(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_role_global_")
+	resourceReference := "couchbase-capella_database_role." + resourceName
+
+	accessHCL := `[
+    {
+      privileges = ["statsRead"]
+    },
+  ]`
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "cluster level", accessHCL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "statsRead"),
+					// The wildcard bucket the API adds must not surface in state.
+					resource.TestCheckNoResourceAttr(resourceReference, "access.0.resources.buckets.#"),
+				),
+			},
+			// Re-applying the identical config must be a no-op. An empty plan here is the
+			// assertion that the implicit wildcard is still being suppressed on read.
+			{
+				Config:   testAccDatabaseRoleConfigAccess(resourceName, resourceName, "cluster level", accessHCL),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleAllScopedLevels combines collection, scope and bucket level entries
+// in a single role. The V4 API returns access entries keyed by their resources, so this
+// is the case that exercises the whole reconcile chain: entries are paired by privilege
+// set, buckets by name, scopes by name and collections by value. A clean post-apply plan
+// means the ordering survived the round-trip.
+func TestAccDatabaseRoleAllScopedLevels(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_role_multi_")
+	resourceReference := "couchbase-capella_database_role." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "all scoped levels", accessAllScopedLevels()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.#", "3"),
+					// Entry order must match the configured order.
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "dataRead"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.1.privileges.*", "queryManage"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.2.privileges.*", "viewsReader"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.collections.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "access.1.resources.buckets.0.scopes.0.name", globalScopeName),
+					resource.TestCheckResourceAttr(resourceReference, "access.2.resources.buckets.0.name", globalBucketName),
+				),
+			},
+			{
+				ResourceName:      resourceReference,
+				ImportStateIdFunc: generateDatabaseRoleImportId(resourceReference),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleAccessAddAndRemove grows the access list from one entry to three
+// and back down to one, so both the append and the drop paths of the update are covered.
+func TestAccDatabaseRoleAccessAddAndRemove(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_role_addrm_")
+	resourceReference := "couchbase-capella_database_role." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "", accessCollectionLevel("dataRead")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.#", "1"),
+				),
+			},
+			// Grow to three entries.
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "", accessAllScopedLevels()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.2.privileges.*", "viewsReader"),
+				),
+			},
+			// Shrink back to one.
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "", accessCollectionLevel("dataRead")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "dataRead"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleMultiplePrivilegesInOneEntry grants several privileges that share
+// one resource block. The API returns them as a single entry, so the privilege set must
+// round-trip without reordering into a diff.
+func TestAccDatabaseRoleMultiplePrivilegesInOneEntry(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_role_mpriv_")
+	resourceReference := "couchbase-capella_database_role." + resourceName
+
+	accessHCL := fmt.Sprintf(`[
+    {
+      privileges = ["dataRead", "dataManage", "dataMonitor"]
+      resources = {
+        buckets = [
+          {
+            name = %q
+            scopes = [
+              {
+                name        = %q
+                collections = [%q]
+              },
+            ]
+          },
+        ]
+      }
+    },
+  ]`, globalBucketName, globalScopeName, globalCollectionName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "", accessHCL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.#", "1"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.privileges.#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "dataRead"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "dataManage"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "dataMonitor"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleMultipleCollections grants one privilege across several collections
+// in the same scope, covering reconcileCollections with more than one element.
+//
+// The collections are created in the same config rather than assumed: the V4 API
+// answers a role referencing a keyspace that does not exist with a 400, so the role
+// must depend on collections that really are present on the cluster.
+func TestAccDatabaseRoleMultipleCollections(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_role_mcoll_")
+	resourceReference := "couchbase-capella_database_role." + resourceName
+	collectionA := randomStringWithPrefix("tfacccolla")
+	collectionB := randomStringWithPrefix("tfacccollb")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleMultiCollectionConfig(resourceName, collectionA, collectionB),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.collections.#", "2"),
+					// Configured order must be preserved: collections is a List, not a Set.
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.collections.0", collectionA),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.collections.1", collectionB),
+				),
+			},
+		},
+	})
+}
+
+// testAccDatabaseRoleMultiCollectionConfig provisions two collections in the shared
+// bucket's default scope and grants a role access to both.
+func testAccDatabaseRoleMultiCollectionConfig(resourceName, collectionA, collectionB string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_collection" %[6]q {
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  bucket_id       = %[5]q
+  scope_name      = %[8]q
+  collection_name = %[6]q
+}
+
+resource "couchbase-capella_collection" %[7]q {
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  bucket_id       = %[5]q
+  scope_name      = %[8]q
+  collection_name = %[7]q
+}
+
+resource "couchbase-capella_database_role" %[9]q {
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  name            = %[9]q
+  access = [
+    {
+      privileges = ["dataRead"]
+      resources = {
+        buckets = [
+          {
+            name = %[10]q
+            scopes = [
+              {
+                name        = %[8]q
+                collections = [%[6]q, %[7]q]
+              },
+            ]
+          },
+        ]
+      }
+    },
+  ]
+
+  depends_on = [
+    couchbase-capella_collection.%[6]s,
+    couchbase-capella_collection.%[7]s,
+  ]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, globalBucketId,
+		collectionA, collectionB, globalScopeName, resourceName, globalBucketName)
+}
+
+// TestAccDatabaseRoleNameRequiresReplace verifies that renaming a role replaces it
+// rather than updating in place: name carries a RequiresReplace plan modifier because
+// the V4 API has no rename operation.
+func TestAccDatabaseRoleNameRequiresReplace(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_role_replace_")
+	resourceReference := "couchbase-capella_database_role." + resourceName
+	originalRoleName := randomStringWithPrefix("tf_acc_role_original_")
+	renamedRoleName := randomStringWithPrefix("tf_acc_role_renamed_")
+
+	var originalID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, originalRoleName, "", accessCollectionLevel("dataRead")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "name", originalRoleName),
+					testAccCheckCaptureResourceID(resourceReference, &originalID),
+				),
+			},
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, renamedRoleName, "", accessCollectionLevel("dataRead")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "name", renamedRoleName),
+					testAccCheckResourceIDChanged(resourceReference, &originalID),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleDescriptionLifecycle covers description being set, changed and
+// dropped. description is Optional+Computed, so removing it from config leaves the last
+// known value in state rather than clearing it.
+func TestAccDatabaseRoleDescriptionLifecycle(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_role_desc_")
+	resourceReference := "couchbase-capella_database_role." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "first description", accessCollectionLevel("dataRead")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "description", "first description"),
+				),
+			},
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "second description", accessCollectionLevel("dataRead")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "description", "second description"),
+				),
+			},
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "", accessCollectionLevel("dataRead")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccExistsDatabaseRoleResource(t, resourceReference),
+					resource.TestCheckResourceAttrSet(resourceReference, "description"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleDeletedOutOfBand deletes the role behind Terraform's back and
+// verifies the next refresh drops it from state instead of erroring, which is the
+// not-found branch of Read.
+func TestAccDatabaseRoleDeletedOutOfBand(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_db_role_oob_")
+	resourceReference := "couchbase-capella_database_role." + resourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccDatabaseRoleConfigAccess(resourceName, resourceName, "", accessCollectionLevel("dataRead")),
+				Check:              testAccDatabaseRoleDeleteOOB(resourceReference),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// --- Config builders ---
+
+// testAccDatabaseRoleConfigAccess renders a database role whose access list is the
+// caller-supplied HCL, so each level of the Capella RBAC template can be exercised
+// independently. roleName is separate from resourceName so rename tests can vary the
+// role name without moving the resource address.
+func testAccDatabaseRoleConfigAccess(resourceName, roleName, description, accessHCL string) string {
+	descBlock := ""
+	if description != "" {
+		descBlock = fmt.Sprintf("description     = %q", description)
+	}
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_role" %[2]q {
+  organization_id = %[3]q
+  project_id      = %[4]q
+  cluster_id      = %[5]q
+  name            = %[6]q
+  %[7]s
+  access = %[8]s
+}
+`, globalProviderBlock, resourceName, globalOrgId, globalProjectId, globalClusterId, roleName, descBlock, accessHCL)
+}
+
+// accessCollectionLevel grants privilege at bucket -> scope -> collection, the deepest
+// level the RBAC template allows for privileges such as dataRead.
+func accessCollectionLevel(privilege string) string {
+	return fmt.Sprintf(`[
+    {
+      privileges = [%q]
+      resources = {
+        buckets = [
+          {
+            name = %q
+            scopes = [
+              {
+                name        = %q
+                collections = [%q]
+              },
+            ]
+          },
+        ]
+      }
+    },
+  ]`, privilege, globalBucketName, globalScopeName, globalCollectionName)
+}
+
+// accessScopeLevel grants privilege at bucket -> scope with collections omitted, the
+// only valid shape for scope-level privileges such as queryManage.
+func accessScopeLevel(privilege string) string {
+	return fmt.Sprintf(`[
+    {
+      privileges = [%q]
+      resources = {
+        buckets = [
+          {
+            name = %q
+            scopes = [
+              {
+                name = %q
+              },
+            ]
+          },
+        ]
+      }
+    },
+  ]`, privilege, globalBucketName, globalScopeName)
+}
+
+// accessBucketLevel grants privilege at bucket level with scopes omitted, the only
+// valid shape for bucket-level privileges such as viewsReader.
+func accessBucketLevel(privilege string) string {
+	return fmt.Sprintf(`[
+    {
+      privileges = [%q]
+      resources = {
+        buckets = [
+          {
+            name = %q
+          },
+        ]
+      }
+    },
+  ]`, privilege, globalBucketName)
+}
+
+// accessAllScopedLevels combines the three scoped levels in one access list. The
+// entries carry distinct resources, so the API keeps them as three separate entries.
+func accessAllScopedLevels() string {
+	return fmt.Sprintf(`[
+    {
+      privileges = ["dataRead"]
+      resources = {
+        buckets = [
+          {
+            name = %[1]q
+            scopes = [
+              {
+                name        = %[2]q
+                collections = [%[3]q]
+              },
+            ]
+          },
+        ]
+      }
+    },
+    {
+      privileges = ["queryManage"]
+      resources = {
+        buckets = [
+          {
+            name = %[1]q
+            scopes = [
+              {
+                name = %[2]q
+              },
+            ]
+          },
+        ]
+      }
+    },
+    {
+      privileges = ["viewsReader"]
+      resources = {
+        buckets = [
+          {
+            name = %[1]q
+          },
+        ]
+      }
+    },
+  ]`, globalBucketName, globalScopeName, globalCollectionName)
+}

--- a/acceptance_tests/database_role_negative_test.go
+++ b/acceptance_tests/database_role_negative_test.go
@@ -1,0 +1,383 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// Negative and edge-case coverage for the database_role resource.
+//
+// The cases split into two groups. Schema validators and Terraform core reject the
+// first group before any request is made, so those steps never reach the V4 API. The
+// second group is only caught server-side, and the expected messages below were taken
+// from live 4xx responses rather than inferred, so a change in API behaviour surfaces
+// here rather than silently widening what the provider accepts.
+
+// --- Rejected before the request is sent ---
+
+// TestAccDatabaseRoleEmptyAccess covers the SizeAtLeast(1) validator on access.
+// `access = []` satisfies Required but would send a role carrying no privileges.
+func TestAccDatabaseRoleEmptyAccess(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_role_noacc_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDatabaseRoleConfigAccess(resourceName, resourceName, "", `[]`),
+				ExpectError: regexp.MustCompile(`(?s)access.*must contain at least 1`),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleMissingAccess covers access being Required.
+func TestAccDatabaseRoleMissingAccess(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_role_missacc_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_role" %[5]q {
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  name            = %[5]q
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName),
+				ExpectError: regexp.MustCompile(`(?s)(argument "access" is required|Missing required argument)`),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleMissingRequiredIDs covers each of the three required IDs being
+// absent. Terraform core rejects the config before the provider is consulted.
+func TestAccDatabaseRoleMissingRequiredIDs(t *testing.T) {
+	testCases := []struct {
+		name    string
+		omitted string
+	}{
+		{name: "organization_id", omitted: "organization_id"},
+		{name: "project_id", omitted: "project_id"},
+		{name: "cluster_id", omitted: "cluster_id"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resourceName := randomStringWithPrefix("tf_acc_role_missid_")
+			ids := map[string]string{
+				"organization_id": globalOrgId,
+				"project_id":      globalProjectId,
+				"cluster_id":      globalClusterId,
+			}
+			delete(ids, tc.omitted)
+
+			idBlock := ""
+			for _, key := range []string{"organization_id", "project_id", "cluster_id"} {
+				if value, ok := ids[key]; ok {
+					idBlock += fmt.Sprintf("  %s = %q\n", key, value)
+				}
+			}
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_role" %[3]q {
+%[2]s  name = %[3]q
+  access = %[4]s
+}
+`, globalProviderBlock, idBlock, resourceName, accessCollectionLevel("dataRead")),
+						ExpectError: regexp.MustCompile(
+							fmt.Sprintf(`(?s)(argument "%s" is required|Missing required argument)`, tc.omitted)),
+					},
+				},
+			})
+		})
+	}
+}
+
+// TestAccDatabaseRoleInvalidUUID covers the UUID regex validator carried by the three
+// ID attributes.
+func TestAccDatabaseRoleInvalidUUID(t *testing.T) {
+	testCases := []struct {
+		name           string
+		organizationId string
+		projectId      string
+		clusterId      string
+	}{
+		{name: "organization_id", organizationId: "not-a-uuid", projectId: globalProjectId, clusterId: globalClusterId},
+		{name: "project_id", organizationId: globalOrgId, projectId: "not-a-uuid", clusterId: globalClusterId},
+		{name: "cluster_id", organizationId: globalOrgId, projectId: globalProjectId, clusterId: "not-a-uuid"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resourceName := randomStringWithPrefix("tf_acc_role_baduuid_")
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_role" %[5]q {
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  name            = %[5]q
+  access = %[6]s
+}
+`, globalProviderBlock, tc.organizationId, tc.projectId, tc.clusterId, resourceName,
+							accessCollectionLevel("dataRead")),
+						ExpectError: regexp.MustCompile(`(?s)must be a valid UUID`),
+					},
+				},
+			})
+		})
+	}
+}
+
+// --- Rejected by the V4 API ---
+
+// TestAccDatabaseRolePrivilegeLevelMismatch is the AV-141821 regression: queryManage is
+// a scope-level privilege, so narrowing it to collections is rejected. The example
+// shipped in examples/database_role carried exactly this shape.
+func TestAccDatabaseRolePrivilegeLevelMismatch(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_role_lvlmis_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "",
+					accessCollectionLevel("queryManage")),
+				ExpectError: apiErrorPattern("Error creating database role",
+					"collection-level access is not a allowed for the mentioned privilege", "422"),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleUnknownPrivilege covers a privilege name absent from the cluster's
+// RBAC template. Nothing client-side validates privilege names, so this reaches the API.
+func TestAccDatabaseRoleUnknownPrivilege(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_role_badpriv_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "",
+					accessCollectionLevel("notARealPrivilege")),
+				ExpectError: apiErrorPattern("Error creating database role",
+					"is not a valid privilege", "422"),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleEmptyPrivileges covers `privileges = []`. The privileges attribute
+// carries no SizeAtLeast validator, so an empty set is only rejected server-side.
+func TestAccDatabaseRoleEmptyPrivileges(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_role_nopriv_")
+
+	accessHCL := fmt.Sprintf(`[
+    {
+      privileges = []
+      resources = {
+        buckets = [
+          {
+            name = %q
+          },
+        ]
+      }
+    },
+  ]`, globalBucketName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRoleConfigAccess(resourceName, resourceName, "", accessHCL),
+				ExpectError: apiErrorPattern("Error creating database role",
+					"Provided privileges list must not be empty", "422"),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleNonExistentKeyspace covers a role naming a bucket, scope or
+// collection that is not present on the cluster. The V4 API answers each with a 400.
+func TestAccDatabaseRoleNonExistentKeyspace(t *testing.T) {
+	testCases := []struct {
+		name      string
+		accessHCL func() string
+	}{
+		{
+			name: "bucket",
+			accessHCL: func() string {
+				return `[
+    {
+      privileges = ["dataRead"]
+      resources = {
+        buckets = [
+          {
+            name = "tf_acc_no_such_bucket"
+          },
+        ]
+      }
+    },
+  ]`
+			},
+		},
+		{
+			name: "scope",
+			accessHCL: func() string {
+				return fmt.Sprintf(`[
+    {
+      privileges = ["dataRead"]
+      resources = {
+        buckets = [
+          {
+            name = %q
+            scopes = [
+              {
+                name = "tf_acc_no_such_scope"
+              },
+            ]
+          },
+        ]
+      }
+    },
+  ]`, globalBucketName)
+			},
+		},
+		{
+			name: "collection",
+			accessHCL: func() string {
+				return fmt.Sprintf(`[
+    {
+      privileges = ["dataRead"]
+      resources = {
+        buckets = [
+          {
+            name = %q
+            scopes = [
+              {
+                name        = %q
+                collections = ["tf_acc_no_such_collection"]
+              },
+            ]
+          },
+        ]
+      }
+    },
+  ]`, globalBucketName, globalScopeName)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resourceName := randomStringWithPrefix("tf_acc_role_badks_")
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+				Steps: []resource.TestStep{
+					{
+						Config:      testAccDatabaseRoleConfigAccess(resourceName, resourceName, "", tc.accessHCL()),
+						ExpectError: apiErrorPattern("Error creating database role", "Bad Request", "400"),
+					},
+				},
+			})
+		})
+	}
+}
+
+// TestAccDatabaseRoleDuplicateName covers two roles sharing a name on one cluster.
+// Role names are unique per cluster and the API rejects the second create.
+//
+// The two roles are applied in separate steps on purpose. Declaring both in one config
+// lets Terraform create them concurrently, and the uniqueness check did not hold under
+// that race: an earlier version of this test declared both together and the apply
+// succeeded with no error. Sequencing the creates keeps the test about the uniqueness
+// rule rather than about concurrency.
+func TestAccDatabaseRoleDuplicateName(t *testing.T) {
+	firstResource := randomStringWithPrefix("tf_acc_role_dup_a_")
+	secondResource := randomStringWithPrefix("tf_acc_role_dup_b_")
+	sharedRoleName := randomStringWithPrefix("tf_acc_role_shared_")
+
+	firstConfig := testAccDatabaseRoleConfigAccess(firstResource, sharedRoleName, "",
+		accessCollectionLevel("dataRead"))
+
+	// Second resource, same role name. The provider block comes from firstConfig.
+	secondRoleBlock := fmt.Sprintf(`
+resource "couchbase-capella_database_role" %[1]q {
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  name            = %[5]q
+  access = %[6]s
+}
+`, secondResource, globalOrgId, globalProjectId, globalClusterId, sharedRoleName,
+		accessBucketLevel("viewsReader"))
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: firstConfig,
+				Check:  testAccExistsDatabaseRoleResource(t, "couchbase-capella_database_role."+firstResource),
+			},
+			{
+				Config: firstConfig + secondRoleBlock,
+				ExpectError: apiErrorPattern("Error creating database role",
+					"is already in use", "422"),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseRoleInvalidCluster covers a well-formed but unknown cluster UUID.
+func TestAccDatabaseRoleInvalidCluster(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_role_badclus_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_role" %[4]q {
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = "00000000-0000-0000-0000-000000000000"
+  name            = %[4]q
+  access = %[5]s
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, resourceName,
+					accessCollectionLevel("dataRead")),
+				ExpectError: apiErrorPattern("Error creating database role", "", "(403|404)"),
+			},
+		},
+	})
+}

--- a/acceptance_tests/database_roles_datasource_test.go
+++ b/acceptance_tests/database_roles_datasource_test.go
@@ -1,0 +1,195 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// Coverage for the database_roles data source. The lifecycle test in
+// database_role_acceptance_test.go only asserts the list is populated; these tests
+// assert the created role is actually in it and that its nested access and audit
+// blocks survive the trip through the list endpoint.
+
+// TestAccDatasourceDatabaseRolesContent verifies the role created in the same config is
+// returned by the data source with its identifiers, description and audit populated.
+func TestAccDatasourceDatabaseRolesContent(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_role_dsrole_")
+	dsName := randomStringWithPrefix("tf_acc_db_roles_ds_")
+	dsReference := "data.couchbase-capella_database_roles." + dsName
+	description := "listed by the roles datasource"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		CheckDestroy:             testAccCheckDatabaseRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRolesDatasourceContentConfig(resourceName, dsName, description),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dsReference, "organization_id", globalOrgId),
+					resource.TestCheckResourceAttr(dsReference, "project_id", globalProjectId),
+					resource.TestCheckResourceAttr(dsReference, "cluster_id", globalClusterId),
+					// The role created above must be one of the listed entries.
+					resource.TestCheckTypeSetElemNestedAttrs(dsReference, "data.*", map[string]string{
+						"name":            resourceName,
+						"description":     description,
+						"organization_id": globalOrgId,
+						"project_id":      globalProjectId,
+						"cluster_id":      globalClusterId,
+					}),
+					testAccCheckDatabaseRolesEntryComplete(dsReference, resourceName),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatasourceDatabaseRolesInvalidCluster covers a well-formed but unknown cluster.
+func TestAccDatasourceDatabaseRolesInvalidCluster(t *testing.T) {
+	dsName := randomStringWithPrefix("tf_acc_db_roles_ds_bad_cluster_")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_database_roles" %[2]q {
+  organization_id = %[3]q
+  project_id      = %[4]q
+  cluster_id      = "00000000-0000-0000-0000-000000000000"
+}
+`, globalProviderBlock, dsName, globalOrgId, globalProjectId),
+				ExpectError: regexp.MustCompile(`(?s)Error Reading Capella Database Roles.*"httpStatusCode":(403|404)`),
+			},
+		},
+	})
+}
+
+// TestAccDatasourceDatabaseRolesMissingIDs covers each required ID being absent.
+func TestAccDatasourceDatabaseRolesMissingIDs(t *testing.T) {
+	testCases := []string{"organization_id", "project_id", "cluster_id"}
+
+	for _, omitted := range testCases {
+		t.Run(omitted, func(t *testing.T) {
+			dsName := randomStringWithPrefix("tf_acc_db_roles_ds_missing_")
+			ids := map[string]string{
+				"organization_id": globalOrgId,
+				"project_id":      globalProjectId,
+				"cluster_id":      globalClusterId,
+			}
+			delete(ids, omitted)
+
+			idBlock := ""
+			for _, key := range []string{"organization_id", "project_id", "cluster_id"} {
+				if value, ok := ids[key]; ok {
+					idBlock += fmt.Sprintf("  %s = %q\n", key, value)
+				}
+			}
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+				Steps: []resource.TestStep{
+					{
+						Config: fmt.Sprintf(`
+%[1]s
+
+data "couchbase-capella_database_roles" %[2]q {
+%[3]s}
+`, globalProviderBlock, dsName, idBlock),
+						ExpectError: regexp.MustCompile(
+							fmt.Sprintf(`(?s)(%s|argument.*required)`, omitted)),
+					},
+				},
+			})
+		})
+	}
+}
+
+func testAccDatabaseRolesDatasourceContentConfig(resourceName, dsName, description string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "couchbase-capella_database_role" %[5]q {
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+  name            = %[5]q
+  description     = %[7]q
+  access = %[8]s
+}
+
+data "couchbase-capella_database_roles" %[6]q {
+  organization_id = %[2]q
+  project_id      = %[3]q
+  cluster_id      = %[4]q
+
+  depends_on = [couchbase-capella_database_role.%[5]s]
+}
+`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName, dsName,
+		description, accessCollectionLevel("dataRead"))
+}
+
+// testAccCheckDatabaseRolesEntryComplete locates roleName in the data source output and
+// asserts the nested attributes the list endpoint is responsible for populating: the
+// role id, the audit block, and the access entry down to its collection.
+//
+// TestCheckTypeSetElemNestedAttrs cannot express "id is set" or reach two levels of
+// nested list, so the entry is found by index and checked directly.
+func testAccCheckDatabaseRolesEntryComplete(dsReference, roleName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ds, ok := s.RootModule().Resources[dsReference]
+		if !ok {
+			return fmt.Errorf("datasource %s not found in state", dsReference)
+		}
+		attrs := ds.Primary.Attributes
+
+		count, err := strconv.Atoi(attrs["data.#"])
+		if err != nil {
+			return fmt.Errorf("datasource %s has no data count: %w", dsReference, err)
+		}
+		if count == 0 {
+			return fmt.Errorf("datasource %s returned no database roles", dsReference)
+		}
+
+		for i := 0; i < count; i++ {
+			prefix := fmt.Sprintf("data.%d.", i)
+			if attrs[prefix+"name"] != roleName {
+				continue
+			}
+
+			required := []string{
+				"id",
+				"audit.created_at",
+				"audit.created_by",
+				"audit.modified_at",
+				"audit.modified_by",
+				"audit.version",
+				"access.0.privileges.0",
+				"access.0.resources.buckets.0.name",
+				"access.0.resources.buckets.0.scopes.0.name",
+				"access.0.resources.buckets.0.scopes.0.collections.0",
+			}
+			for _, suffix := range required {
+				if attrs[prefix+suffix] == "" {
+					return fmt.Errorf("role %q in %s is missing %s", roleName, dsReference, suffix)
+				}
+			}
+
+			if got := attrs[prefix+"access.0.privileges.0"]; got != "dataRead" {
+				return fmt.Errorf("role %q privilege = %q, want dataRead", roleName, got)
+			}
+			if got := attrs[prefix+"access.0.resources.buckets.0.name"]; got != globalBucketName {
+				return fmt.Errorf("role %q bucket = %q, want %q", roleName, got, globalBucketName)
+			}
+			return nil
+		}
+
+		return fmt.Errorf("role %q not found among the %d roles returned by %s", roleName, count, dsReference)
+	}
+}

--- a/acceptance_tests/utils.go
+++ b/acceptance_tests/utils.go
@@ -56,8 +56,8 @@ func generateRandomCIDR() string {
 		thirdOctet := int(buf[2]) & 0xFE // even for /23
 		return fmt.Sprintf("10.%d.%d.0/23", secondOctet, thirdOctet)
 	case 1: // 172.C.D.0/21
-		secondOctet := 16 + int(buf[1])%16    // 16..31
-		thirdOctet := (int(buf[2]) % 32) * 8  // 0, 8, 16, ..., 248
+		secondOctet := 16 + int(buf[1])%16   // 16..31
+		thirdOctet := (int(buf[2]) % 32) * 8 // 0, 8, 16, ..., 248
 		return fmt.Sprintf("172.%d.%d.0/21", secondOctet, thirdOctet)
 	default: // 192.168.E.0/24
 		thirdOctet := int(buf[2])

--- a/internal/api/database_privilege.go
+++ b/internal/api/database_privilege.go
@@ -12,3 +12,9 @@ type GetDatabasePrivilegeResponse struct {
 	// Resources is the RBAC template indicating which resource levels (bucket/scope/collection) are configurable.
 	Resources *AccessibleResources `json:"resources,omitempty"`
 }
+
+// GetDatabasePrivilegesResponse is the envelope wrapping the privileges returned by the
+// GET /v4/organizations/{organizationId}/projects/{projectId}/clusters/{clusterId}/privileges endpoint.
+type GetDatabasePrivilegesResponse struct {
+	Data []GetDatabasePrivilegeResponse `json:"data"`
+}

--- a/internal/datasources/database_privileges.go
+++ b/internal/datasources/database_privileges.go
@@ -94,12 +94,12 @@ func (d *DatabasePrivileges) listPrivileges(ctx context.Context, organizationId,
 		return nil, fmt.Errorf("executing request: %w", err)
 	}
 
-	var privileges []api.GetDatabasePrivilegeResponse
+	var privileges api.GetDatabasePrivilegesResponse
 	if err := json.Unmarshal(response.Body, &privileges); err != nil {
 		return nil, fmt.Errorf("unmarshalling response: %w", err)
 	}
 
-	return privileges, nil
+	return privileges.Data, nil
 }
 
 func (d *DatabasePrivileges) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-141834 — acceptance test coverage for granular RBAC phase 3
* AV-141822 — `database_privileges` data source fails on every read (fix included here, see note below)

## Description

Extends acceptance coverage for the fine-grained RBAC surface — `database_role`, `database_credential`, and the `database_roles` / `database_privileges` data sources — and fixes the one provider defect that made a data source completely unusable.

**32 new tests (44 cases including subtests), all passing against a live cluster.**



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments