### PR TITLE
[AV-138151] Bound and back off ClientV1 retries for 503/504

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -35,20 +35,13 @@ type retryPolicy struct {
 	backoff func(attempt int) time.Duration
 
 	// maxServiceErrors is how many 503/504 responses are tolerated before the
-	// request is abandoned. It does not bound 429 retries.
+	// request is abandoned. Zero means no attempt cap, leaving the overall request
+	// deadline as the only bound. It never bounds 429 retries.
 	maxServiceErrors int
 }
 
 // RetryOption customises a Client's retry behaviour.
 type RetryOption func(*Client)
-
-// WithMaxRetries overrides how many 503/504 responses are tolerated before the
-// request is abandoned.
-func WithMaxRetries(maxRetries int) RetryOption {
-	return func(c *Client) {
-		c.retry.maxServiceErrors = maxRetries
-	}
-}
 
 // WithFastBackoff shrinks retry delays to milliseconds so that tests can exercise
 // the retry loop without waiting for the production budget.
@@ -71,8 +64,7 @@ func NewClient(timeout time.Duration, opts ...RetryOption) *Client {
 			Timeout: timeout,
 		},
 		retry: retryPolicy{
-			backoff:          exponentialJitterBackoff,
-			maxServiceErrors: maxServiceErrorRetries,
+			backoff: exponentialJitterBackoff,
 		},
 	}
 
@@ -100,17 +92,27 @@ type EndpointCfg struct {
 	// SuccessStatus represents the HTTP status code associated
 	// with a successful response from the endpoint.
 	SuccessStatus int
+
+	// MaxServiceErrorRetries bounds how many 503/504 responses are retried for
+	// this request. Zero, the default, applies no attempt cap: retries continue
+	// until the overall request deadline, which is what every endpoint relies on
+	// to wait out long transient conditions such as an in-flight bucket delete.
+	// Set it to FastFailServiceErrorRetries on endpoints that have no such
+	// condition and should surface an unavailable service quickly instead.
+	MaxServiceErrorRetries int
 }
 
-// maxServiceErrorRetries bounds retries of 503 and 504 responses so that an
-// unavailable endpoint fails fast rather than being retried until the overall
-// deadline expires. 429 is deliberately excluded: its interval is dictated by the
-// server's Retry-After header, so the deadline stays its only bound.
-const maxServiceErrorRetries = 5
+// FastFailServiceErrorRetries is a short retry budget for endpoints with no known
+// long-running transient condition, where an unavailable service should surface
+// quickly rather than consume the full request deadline. It is roughly 23 seconds
+// with the default backoff. Opt in per request via
+// EndpointCfg.MaxServiceErrorRetries; it is deliberately not the default, because
+// shortening the budget globally would stop calls such as bucket create from
+// waiting out an in-flight bucket delete.
+const FastFailServiceErrorRetries = 5
 
 // Bounds for the backoff applied between retries of a response that carries no
-// Retry-After header. Together with maxServiceErrorRetries they cap the total
-// wait at roughly 31 seconds.
+// Retry-After header.
 const (
 	retryWaitMin = time.Second
 	retryWaitMax = 30 * time.Second
@@ -227,15 +229,6 @@ func (c *Client) ExecuteWithRetry(
 				return nil, 0, errors.ErrGatewayTimeoutForIndexDDL
 			}
 
-			// A gateway timeout means the upstream was reached but did not answer in
-			// time, so the write may already have been committed. Replaying a
-			// non-idempotent request risks a duplicate create, so a POST is failed
-			// rather than retried. A 503 is still retried for POST because it
-			// indicates the request was refused before it was processed.
-			if endpointCfg.Method == http.MethodPost {
-				return nil, 0, &apiError
-			}
-
 			return nil, 0, errors.ErrGatewayTimeout
 		default:
 			var apiError Error
@@ -259,7 +252,10 @@ func (c *Client) ExecuteWithRetry(
 		}, 0, nil
 	}
 
-	return exec(ctx, fn, c.retry)
+	policy := c.retry
+	policy.maxServiceErrors = endpointCfg.MaxServiceErrorRetries
+
+	return exec(ctx, fn, policy)
 }
 
 func exec(
@@ -288,6 +284,16 @@ func exec(
 	for {
 		select {
 		case <-ctx.Done():
+			// A persistent 503/504 normally ends here rather than at an attempt cap,
+			// so report the attempts and elapsed time instead of a bare deadline.
+			if serviceErrors > 0 {
+				return nil, &RetryExhaustedError{
+					LastErr:  err,
+					Attempts: attempts,
+					Elapsed:  time.Since(start),
+				}
+			}
+
 			return nil, fmt.Errorf("timed out executing request against api: %w", ctx.Err())
 		case <-timer.C:
 			attempts++
@@ -304,7 +310,7 @@ func exec(
 				serviceErrors++
 			}
 
-			if serviceErrors > policy.maxServiceErrors {
+			if policy.maxServiceErrors > 0 && serviceErrors > policy.maxServiceErrors {
 				return nil, &RetryExhaustedError{
 					LastErr:  err,
 					Attempts: attempts,

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -7,6 +7,7 @@ import (
 	goer "errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"strconv"
 	"time"
@@ -24,15 +25,62 @@ var userAgent = fmt.Sprintf("%s/%s", clientName, version.ProviderVersion)
 // Client is responsible for constructing and executing HTTP requests.
 type Client struct {
 	*http.Client
+
+	retry retryPolicy
+}
+
+// retryPolicy bounds how a Client retries retryable 5xx responses.
+type retryPolicy struct {
+	// backoff returns how long to wait before the nth retry, 1-based.
+	backoff func(attempt int) time.Duration
+
+	// maxServiceErrors is how many 503/504 responses are tolerated before the
+	// request is abandoned. It does not bound 429 retries.
+	maxServiceErrors int
+}
+
+// RetryOption customises a Client's retry behaviour.
+type RetryOption func(*Client)
+
+// WithMaxRetries overrides how many 503/504 responses are tolerated before the
+// request is abandoned.
+func WithMaxRetries(maxRetries int) RetryOption {
+	return func(c *Client) {
+		c.retry.maxServiceErrors = maxRetries
+	}
+}
+
+// WithFastBackoff shrinks retry delays to milliseconds so that tests can exercise
+// the retry loop without waiting for the production budget.
+func WithFastBackoff() RetryOption {
+	return func(c *Client) {
+		c.retry.backoff = func(attempt int) time.Duration {
+			if attempt < 1 {
+				attempt = 1
+			}
+
+			return time.Duration(attempt) * time.Millisecond
+		}
+	}
 }
 
 // NewClient instantiates a new Client with the provided timeout.
-func NewClient(timeout time.Duration) *Client {
-	return &Client{
+func NewClient(timeout time.Duration, opts ...RetryOption) *Client {
+	client := &Client{
 		Client: &http.Client{
 			Timeout: timeout,
 		},
+		retry: retryPolicy{
+			backoff:          exponentialJitterBackoff,
+			maxServiceErrors: maxServiceErrorRetries,
+		},
 	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	return client
 }
 
 // Response struct is used to encapsulate the response details.
@@ -54,8 +102,42 @@ type EndpointCfg struct {
 	SuccessStatus int
 }
 
-// defaultWaitAttempt re-attempt http request after 2 seconds.
-const defaultWaitAttempt = time.Second * 2
+// maxServiceErrorRetries bounds retries of 503 and 504 responses so that an
+// unavailable endpoint fails fast rather than being retried until the overall
+// deadline expires. 429 is deliberately excluded: its interval is dictated by the
+// server's Retry-After header, so the deadline stays its only bound.
+const maxServiceErrorRetries = 5
+
+// Bounds for the backoff applied between retries of a response that carries no
+// Retry-After header. Together with maxServiceErrorRetries they cap the total
+// wait at roughly 31 seconds.
+const (
+	retryWaitMin = time.Second
+	retryWaitMax = 30 * time.Second
+)
+
+// exponentialJitterBackoff returns the wait before retry attempt n, 1-based:
+// retryWaitMin doubled per attempt and capped at retryWaitMax, then jittered into
+// the upper half of that interval. The jitter stops resources from retrying a
+// struggling backend in lockstep; halving rather than zeroing keeps a minimum
+// interval so the retries never become a busy loop.
+func exponentialJitterBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+
+	wait := retryWaitMax
+	if attempt < 32 {
+		if shifted := retryWaitMin << (attempt - 1); shifted > 0 && shifted < retryWaitMax {
+			wait = shifted
+		}
+	}
+
+	// The jitter only has to decorrelate retries between parallel resources, so a
+	// pseudo-random source is sufficient.
+	//nolint:gosec // G404: jitter does not require cryptographic randomness
+	return wait/2 + time.Duration(rand.Int64N(int64(wait/2)+1))
+}
 
 // ExecuteWithRetry is used to construct and execute a HTTP request with retry.
 // It then returns the response.
@@ -67,7 +149,6 @@ func (c *Client) ExecuteWithRetry(
 	headers map[string]string,
 ) (response *Response, err error) {
 	var requestBody []byte
-	var dur time.Duration
 	if payload != nil {
 		if content, ok := headers["Content-Type"]; ok && content == "application/javascript" {
 			// json.Marshal will add escape characters to the string payload which makes it invalid javascript, this is a workaround
@@ -87,7 +168,7 @@ func (c *Client) ExecuteWithRetry(
 	var fn = func() (response *Response, backoff time.Duration, err error) {
 		req, err := http.NewRequest(endpointCfg.Method, endpointCfg.Url, bytes.NewReader(requestBody))
 		if err != nil {
-			return nil, dur, fmt.Errorf("%s: %w", errors.ErrConstructingRequest, err)
+			return nil, 0, fmt.Errorf("%w: %w", errors.ErrConstructingRequest, err)
 		}
 
 		req.Header.Set("Authorization", "Bearer "+authToken)
@@ -97,7 +178,7 @@ func (c *Client) ExecuteWithRetry(
 		}
 		apiRes, err := c.Do(req)
 		if err != nil {
-			return nil, dur, fmt.Errorf("%s: %w", errors.ErrExecutingRequest, err)
+			return nil, 0, fmt.Errorf("%w: %w", errors.ErrExecutingRequest, err)
 		}
 		defer apiRes.Body.Close()
 
@@ -113,15 +194,15 @@ func (c *Client) ExecuteWithRetry(
 			header := apiRes.Header.Get("Retry-After")
 			retryAfter, err := strconv.Atoi(header)
 			if err != nil {
-				return nil, dur, fmt.Errorf("error parsing Retry-After value from response header")
+				return nil, 0, fmt.Errorf("error parsing Retry-After value from response header")
 			}
-			dur = time.Second * time.Duration(retryAfter)
+			retryAfterDur := time.Second * time.Duration(retryAfter)
 			tflog.Debug(ctx, "API rate limited", map[string]interface{}{
 				"method":      endpointCfg.Method,
 				"url":         endpointCfg.Url,
-				"retry_after": dur.Seconds(),
+				"retry_after": retryAfterDur.Seconds(),
 			})
-			return nil, dur, errors.ErrRatelimit
+			return nil, retryAfterDur, errors.ErrRatelimit
 		case http.StatusServiceUnavailable:
 			var retryAfter time.Duration
 			if header := apiRes.Header.Get("Retry-After"); header != "" {
@@ -137,7 +218,7 @@ func (c *Client) ExecuteWithRetry(
 		case http.StatusGatewayTimeout:
 			var apiError Error
 			if err := json.Unmarshal(responseBody, &apiError); err != nil {
-				return nil, dur, fmt.Errorf(
+				return nil, 0, fmt.Errorf(
 					"unexpected code: %d, expected: %d, body: %s",
 					apiRes.StatusCode, endpointCfg.SuccessStatus, responseBody)
 			}
@@ -146,34 +227,43 @@ func (c *Client) ExecuteWithRetry(
 				return nil, 0, errors.ErrGatewayTimeoutForIndexDDL
 			}
 
-			return nil, dur, errors.ErrGatewayTimeout
+			// A gateway timeout means the upstream was reached but did not answer in
+			// time, so the write may already have been committed. Replaying a
+			// non-idempotent request risks a duplicate create, so a POST is failed
+			// rather than retried. A 503 is still retried for POST because it
+			// indicates the request was refused before it was processed.
+			if endpointCfg.Method == http.MethodPost {
+				return nil, 0, &apiError
+			}
+
+			return nil, 0, errors.ErrGatewayTimeout
 		default:
 			var apiError Error
 			if err := json.Unmarshal(responseBody, &apiError); err != nil {
-				return nil, dur, fmt.Errorf(
+				return nil, 0, fmt.Errorf(
 					"unexpected code: %d, expected: %d, body: %s",
 					apiRes.StatusCode, endpointCfg.SuccessStatus, responseBody)
 			}
 			if apiError.Code == 0 {
-				return nil, dur, fmt.Errorf(
+				return nil, 0, fmt.Errorf(
 					"unexpected code: %d, expected: %d, body: %s",
 					apiRes.StatusCode, endpointCfg.SuccessStatus, responseBody)
 
 			}
-			return nil, dur, &apiError
+			return nil, 0, &apiError
 		}
 
 		return &Response{
 			Response: apiRes,
 			Body:     responseBody,
-		}, dur, nil
+		}, 0, nil
 	}
 
-	return exec(ctx, fn, defaultWaitAttempt)
+	return exec(ctx, fn, c.retry)
 }
 
 func exec(
-	ctx context.Context, fn func() (response *Response, dur time.Duration, err error), waitOnReattempt time.Duration,
+	ctx context.Context, fn func() (response *Response, dur time.Duration, err error), policy retryPolicy,
 ) (*Response, error) {
 	timer := time.NewTimer(time.Millisecond)
 	defer timer.Stop()
@@ -190,25 +280,42 @@ func exec(
 	ctx, cancel = context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	// attempts counts every request issued, whereas serviceErrors counts only the
+	// retryable 5xx responses that the attempt cap applies to.
+	var attempts, serviceErrors int
+	start := time.Now()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("timed out executing request against api: %w", ctx.Err())
 		case <-timer.C:
+			attempts++
 			response, backOff, err = fn()
 			switch {
 			case err == nil:
 				return response, nil
 			case goer.Is(err, errors.ErrRatelimit):
 			case goer.Is(err, errors.ErrServiceUnavailable):
+				serviceErrors++
 			case !goer.Is(err, errors.ErrGatewayTimeout):
 				return response, err
+			default:
+				serviceErrors++
+			}
+
+			if serviceErrors > policy.maxServiceErrors {
+				return nil, &RetryExhaustedError{
+					LastErr:  err,
+					Attempts: attempts,
+					Elapsed:  time.Since(start),
+				}
 			}
 
 			if backOff > 0 {
 				timer.Reset(backOff)
 			} else {
-				timer.Reset(waitOnReattempt)
+				timer.Reset(policy.backoff(serviceErrors))
 			}
 		}
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 // testPolicy is a retryPolicy whose backoff is short enough that the retry loop
-// can be exercised without waiting for the production budget.
+// can be exercised without waiting for the production budget. A maxServiceErrors
+// of zero reproduces the default, uncapped policy.
 func testPolicy(maxServiceErrors int) retryPolicy {
 	return retryPolicy{
 		backoff:          func(int) time.Duration { return time.Millisecond },
@@ -153,6 +154,33 @@ func TestExecRetryBudget(t *testing.T) {
 	}
 }
 
+// The default policy must not cap 5xx retries. Every endpoint relies on retrying
+// until the request deadline to wait out long transient conditions such as an
+// in-flight bucket delete, so a cap only applies when a caller opts in.
+func TestExecDefaultPolicyDoesNotCapServiceErrors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	var calls int
+	_, err := exec(ctx, scriptedFn(repeat(errors.ErrServiceUnavailable, 10000), &calls), testPolicy(0))
+
+	if calls <= FastFailServiceErrorRetries+1 {
+		t.Errorf("issued %d requests, want more than the opt-in budget of %d: the default must not cap",
+			calls, FastFailServiceErrorRetries+1)
+	}
+
+	var exhausted *RetryExhaustedError
+	if !goer.As(err, &exhausted) {
+		t.Fatalf("got error %v, want *RetryExhaustedError once the deadline expires", err)
+	}
+	if !goer.Is(err, errors.ErrServiceUnavailable) {
+		t.Errorf("error %v does not unwrap to ErrServiceUnavailable", err)
+	}
+	if exhausted.Attempts != calls {
+		t.Errorf("RetryExhaustedError.Attempts = %d, want %d", exhausted.Attempts, calls)
+	}
+}
+
 func TestExecHonoursReturnedBackoff(t *testing.T) {
 	const backoff = 120 * time.Millisecond
 
@@ -243,6 +271,15 @@ func retryServer(t *testing.T, handler func(w http.ResponseWriter, requests int3
 	return server, &requests
 }
 
+func alwaysStatus(status int, body string) func(http.ResponseWriter, int32) {
+	return func(w http.ResponseWriter, _ int32) {
+		w.WriteHeader(status)
+		if body != "" {
+			_, _ = fmt.Fprint(w, body)
+		}
+	}
+}
+
 func TestExecuteWithRetryServiceUnavailable(t *testing.T) {
 	t.Run("retries then succeeds", func(t *testing.T) {
 		server, requests := retryServer(t, func(w http.ResponseWriter, requests int32) {
@@ -263,12 +300,35 @@ func TestExecuteWithRetryServiceUnavailable(t *testing.T) {
 		}
 	})
 
-	t.Run("persistent 503 exhausts the budget", func(t *testing.T) {
-		server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
-			w.WriteHeader(http.StatusServiceUnavailable)
-		})
+	t.Run("default budget is bounded only by the deadline", func(t *testing.T) {
+		server, requests := retryServer(t, alwaysStatus(http.StatusServiceUnavailable, ""))
 
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		defer cancel()
+
+		// No MaxServiceErrorRetries: this is what every existing call site gets.
 		cfg := EndpointCfg{Url: server.URL, Method: http.MethodPost, SuccessStatus: http.StatusCreated}
+		_, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(ctx, cfg, nil, "token", nil)
+
+		var exhausted *RetryExhaustedError
+		if !goer.As(err, &exhausted) {
+			t.Fatalf("got error %v, want *RetryExhaustedError", err)
+		}
+		if got := atomic.LoadInt32(requests); got <= FastFailServiceErrorRetries+1 {
+			t.Errorf("issued %d requests, want more than %d: the default must not cap retries",
+				got, FastFailServiceErrorRetries+1)
+		}
+	})
+
+	t.Run("opt-in budget is honoured", func(t *testing.T) {
+		server, requests := retryServer(t, alwaysStatus(http.StatusServiceUnavailable, ""))
+
+		cfg := EndpointCfg{
+			Url:                    server.URL,
+			Method:                 http.MethodPut,
+			SuccessStatus:          http.StatusNoContent,
+			MaxServiceErrorRetries: FastFailServiceErrorRetries,
+		}
 		_, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil)
 
 		var exhausted *RetryExhaustedError
@@ -278,14 +338,32 @@ func TestExecuteWithRetryServiceUnavailable(t *testing.T) {
 		if !goer.Is(err, errors.ErrServiceUnavailable) {
 			t.Errorf("error %v does not unwrap to ErrServiceUnavailable", err)
 		}
-		if exhausted.Attempts != maxServiceErrorRetries+1 {
-			t.Errorf("Attempts = %d, want %d", exhausted.Attempts, maxServiceErrorRetries+1)
+		if exhausted.Attempts != FastFailServiceErrorRetries+1 {
+			t.Errorf("Attempts = %d, want %d", exhausted.Attempts, FastFailServiceErrorRetries+1)
 		}
-		if got := atomic.LoadInt32(requests); got != maxServiceErrorRetries+1 {
-			t.Errorf("issued %d requests, want %d", got, maxServiceErrorRetries+1)
+		if got := atomic.LoadInt32(requests); got != FastFailServiceErrorRetries+1 {
+			t.Errorf("issued %d requests, want %d", got, FastFailServiceErrorRetries+1)
 		}
 		if msg := ParseError(err); msg != err.Error() {
 			t.Errorf("ParseError rendered %q, want the RetryExhaustedError message %q", msg, err.Error())
+		}
+	})
+
+	t.Run("a custom budget of one still retries once", func(t *testing.T) {
+		server, requests := retryServer(t, alwaysStatus(http.StatusServiceUnavailable, ""))
+
+		cfg := EndpointCfg{
+			Url:                    server.URL,
+			Method:                 http.MethodGet,
+			SuccessStatus:          http.StatusOK,
+			MaxServiceErrorRetries: 1,
+		}
+		if _, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil); err == nil {
+			t.Fatal("expected the retry budget to be exhausted")
+		}
+
+		if got := atomic.LoadInt32(requests); got != 2 {
+			t.Errorf("issued %d requests, want 2", got)
 		}
 	})
 }
@@ -293,49 +371,31 @@ func TestExecuteWithRetryServiceUnavailable(t *testing.T) {
 func TestExecuteWithRetryGatewayTimeout(t *testing.T) {
 	const timeoutBody = `{"code":4000,"hint":"retry later","httpStatusCode":504,"message":"gateway timeout"}`
 
-	t.Run("GET is retried", func(t *testing.T) {
-		server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
-			w.WriteHeader(http.StatusGatewayTimeout)
-			_, _ = fmt.Fprint(w, timeoutBody)
+	// A 504 is retried for every method, including non-idempotent ones. Whether a
+	// POST should be replayed after a gateway timeout is a separate question.
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut} {
+		t.Run(method+" is retried", func(t *testing.T) {
+			server, requests := retryServer(t, alwaysStatus(http.StatusGatewayTimeout, timeoutBody))
+
+			cfg := EndpointCfg{
+				Url:                    server.URL,
+				Method:                 method,
+				SuccessStatus:          http.StatusOK,
+				MaxServiceErrorRetries: FastFailServiceErrorRetries,
+			}
+			_, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil)
+
+			if !goer.Is(err, errors.ErrGatewayTimeout) {
+				t.Fatalf("got error %v, want it to match ErrGatewayTimeout", err)
+			}
+			if got := atomic.LoadInt32(requests); got != FastFailServiceErrorRetries+1 {
+				t.Errorf("issued %d requests, want %d", got, FastFailServiceErrorRetries+1)
+			}
 		})
-
-		cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
-		_, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil)
-
-		if !goer.Is(err, errors.ErrGatewayTimeout) {
-			t.Fatalf("got error %v, want it to match ErrGatewayTimeout", err)
-		}
-		if got := atomic.LoadInt32(requests); got != maxServiceErrorRetries+1 {
-			t.Errorf("issued %d requests, want %d", got, maxServiceErrorRetries+1)
-		}
-	})
-
-	t.Run("POST is not retried", func(t *testing.T) {
-		server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
-			w.WriteHeader(http.StatusGatewayTimeout)
-			_, _ = fmt.Fprint(w, timeoutBody)
-		})
-
-		cfg := EndpointCfg{Url: server.URL, Method: http.MethodPost, SuccessStatus: http.StatusCreated}
-		_, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil)
-
-		var apiErr *Error
-		if !goer.As(err, &apiErr) {
-			t.Fatalf("got error %v, want *api.Error", err)
-		}
-		if apiErr.Message != "gateway timeout" {
-			t.Errorf("Message = %q, want the message from the response body", apiErr.Message)
-		}
-		if got := atomic.LoadInt32(requests); got != 1 {
-			t.Errorf("issued %d requests, want 1: a POST must not be replayed after a gateway timeout", got)
-		}
-	})
+	}
 
 	t.Run("index DDL code 7001 is not retried", func(t *testing.T) {
-		server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
-			w.WriteHeader(http.StatusGatewayTimeout)
-			_, _ = fmt.Fprint(w, `{"code":7001,"message":"index DDL timed out"}`)
-		})
+		server, requests := retryServer(t, alwaysStatus(http.StatusGatewayTimeout, `{"code":7001,"message":"index DDL timed out"}`))
 
 		cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
 		_, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil)
@@ -374,8 +434,8 @@ func TestExecuteWithRetryRateLimit(t *testing.T) {
 		}
 	})
 
-	t.Run("is not subject to the attempt cap", func(t *testing.T) {
-		const rateLimited = maxServiceErrorRetries * 3
+	t.Run("is not subject to an opt-in 5xx budget", func(t *testing.T) {
+		const rateLimited = FastFailServiceErrorRetries * 3
 
 		server, requests := retryServer(t, func(w http.ResponseWriter, requests int32) {
 			if requests <= rateLimited {
@@ -386,7 +446,12 @@ func TestExecuteWithRetryRateLimit(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+		cfg := EndpointCfg{
+			Url:                    server.URL,
+			Method:                 http.MethodGet,
+			SuccessStatus:          http.StatusOK,
+			MaxServiceErrorRetries: FastFailServiceErrorRetries,
+		}
 		if _, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -398,10 +463,7 @@ func TestExecuteWithRetryRateLimit(t *testing.T) {
 }
 
 func TestExecuteWithRetrySuccessPassthrough(t *testing.T) {
-	server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprint(w, `{"id":"abc"}`)
-	})
+	server, requests := retryServer(t, alwaysStatus(http.StatusOK, `{"id":"abc"}`))
 
 	cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
 	response, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil)
@@ -414,21 +476,5 @@ func TestExecuteWithRetrySuccessPassthrough(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(requests); got != 1 {
 		t.Errorf("issued %d requests, want 1", got)
-	}
-}
-
-func TestWithMaxRetries(t *testing.T) {
-	server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	})
-
-	cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
-	client := NewClient(time.Minute, WithFastBackoff(), WithMaxRetries(2))
-	if _, err := client.ExecuteWithRetry(context.Background(), cfg, nil, "token", nil); err == nil {
-		t.Fatal("expected the retry budget to be exhausted")
-	}
-
-	if got := atomic.LoadInt32(requests); got != 3 {
-		t.Errorf("issued %d requests, want 3", got)
 	}
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,434 @@
+package api
+
+import (
+	"context"
+	goer "errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/errors"
+)
+
+// testPolicy is a retryPolicy whose backoff is short enough that the retry loop
+// can be exercised without waiting for the production budget.
+func testPolicy(maxServiceErrors int) retryPolicy {
+	return retryPolicy{
+		backoff:          func(int) time.Duration { return time.Millisecond },
+		maxServiceErrors: maxServiceErrors,
+	}
+}
+
+// scriptedFn returns a fn for exec that yields each error in errs in turn and
+// succeeds once they are exhausted. calls reports how many times it was invoked.
+func scriptedFn(errs []error, calls *int) func() (*Response, time.Duration, error) {
+	return func() (*Response, time.Duration, error) {
+		i := *calls
+		*calls++
+		if i < len(errs) {
+			return nil, 0, errs[i]
+		}
+		return &Response{}, 0, nil
+	}
+}
+
+func repeat(err error, n int) []error {
+	errs := make([]error, n)
+	for i := range errs {
+		errs[i] = err
+	}
+	return errs
+}
+
+func TestExecRetryBudget(t *testing.T) {
+	const maxServiceErrors = 5
+
+	nonRetryable := &Error{Code: 4000, Message: "bad request", HttpStatusCode: http.StatusBadRequest}
+
+	tests := []struct {
+		name string
+		// errs is returned by successive calls to fn; fn succeeds afterwards.
+		errs []error
+		// wantErrIs, when set, must match the returned error via errors.Is.
+		wantErrIs error
+		// wantCalls is the exact number of requests the loop should issue.
+		wantCalls int
+		// wantExhausted asserts the returned error is a *RetryExhaustedError.
+		wantExhausted bool
+	}{
+		{
+			name:      "success on first attempt",
+			errs:      nil,
+			wantCalls: 1,
+		},
+		{
+			name:      "service unavailable then success",
+			errs:      repeat(errors.ErrServiceUnavailable, 2),
+			wantCalls: 3,
+		},
+		{
+			name:      "gateway timeout then success",
+			errs:      repeat(errors.ErrGatewayTimeout, 2),
+			wantCalls: 3,
+		},
+		{
+			name:          "persistent service unavailable is capped",
+			errs:          repeat(errors.ErrServiceUnavailable, 100),
+			wantErrIs:     errors.ErrServiceUnavailable,
+			wantCalls:     maxServiceErrors + 1,
+			wantExhausted: true,
+		},
+		{
+			name:          "persistent gateway timeout is capped",
+			errs:          repeat(errors.ErrGatewayTimeout, 100),
+			wantErrIs:     errors.ErrGatewayTimeout,
+			wantCalls:     maxServiceErrors + 1,
+			wantExhausted: true,
+		},
+		{
+			name:          "mixed 5xx share a single budget",
+			errs:          append(repeat(errors.ErrServiceUnavailable, 3), repeat(errors.ErrGatewayTimeout, 100)...),
+			wantErrIs:     errors.ErrGatewayTimeout,
+			wantCalls:     maxServiceErrors + 1,
+			wantExhausted: true,
+		},
+		{
+			name:      "non retryable error returns immediately",
+			errs:      repeat(nonRetryable, 100),
+			wantErrIs: nonRetryable,
+			wantCalls: 1,
+		},
+		{
+			name:      "index DDL gateway timeout is not retried",
+			errs:      repeat(errors.ErrGatewayTimeoutForIndexDDL, 100),
+			wantErrIs: errors.ErrGatewayTimeoutForIndexDDL,
+			wantCalls: 1,
+		},
+		{
+			// 429 carries a server-dictated Retry-After, so the attempt cap does
+			// not apply to it; only the overall deadline bounds those retries.
+			name:      "rate limit is not subject to the attempt cap",
+			errs:      repeat(errors.ErrRatelimit, maxServiceErrors*3),
+			wantCalls: maxServiceErrors*3 + 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int
+			_, err := exec(context.Background(), scriptedFn(tt.errs, &calls), testPolicy(maxServiceErrors))
+
+			if calls != tt.wantCalls {
+				t.Errorf("issued %d requests, want %d", calls, tt.wantCalls)
+			}
+
+			if tt.wantErrIs == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+
+			if !goer.Is(err, tt.wantErrIs) {
+				t.Fatalf("got error %v, want it to match %v", err, tt.wantErrIs)
+			}
+
+			var exhausted *RetryExhaustedError
+			if got := goer.As(err, &exhausted); got != tt.wantExhausted {
+				t.Fatalf("errors.As(*RetryExhaustedError) = %v, want %v (err: %v)", got, tt.wantExhausted, err)
+			}
+
+			if tt.wantExhausted {
+				if exhausted.Attempts != tt.wantCalls {
+					t.Errorf("RetryExhaustedError.Attempts = %d, want %d", exhausted.Attempts, tt.wantCalls)
+				}
+				if exhausted.Elapsed <= 0 {
+					t.Errorf("RetryExhaustedError.Elapsed = %v, want a positive duration", exhausted.Elapsed)
+				}
+			}
+		})
+	}
+}
+
+func TestExecHonoursReturnedBackoff(t *testing.T) {
+	const backoff = 120 * time.Millisecond
+
+	var calls int
+	fn := func() (*Response, time.Duration, error) {
+		calls++
+		if calls == 1 {
+			return nil, backoff, errors.ErrRatelimit
+		}
+		return &Response{}, 0, nil
+	}
+
+	// The policy backoff is 1ms, so anything close to backoff can only have come
+	// from the duration fn returned.
+	start := time.Now()
+	if _, err := exec(context.Background(), fn, testPolicy(5)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < backoff {
+		t.Errorf("waited %v before retrying, want at least %v", elapsed, backoff)
+	}
+}
+
+func TestExecRespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var calls int
+	_, err := exec(ctx, scriptedFn(repeat(errors.ErrServiceUnavailable, 100), &calls), testPolicy(5))
+
+	if !goer.Is(err, context.Canceled) {
+		t.Fatalf("got error %v, want context.Canceled", err)
+	}
+}
+
+func TestExponentialJitterBackoff(t *testing.T) {
+	for attempt := 1; attempt <= 8; attempt++ {
+		ceiling := retryWaitMax
+		if shifted := retryWaitMin << (attempt - 1); shifted > 0 && shifted < retryWaitMax {
+			ceiling = shifted
+		}
+
+		// Assert bounds rather than exact values: the delay is jittered, so an
+		// equality assertion here would be flaky by construction.
+		for i := 0; i < 100; i++ {
+			got := exponentialJitterBackoff(attempt)
+			if got < ceiling/2 || got > ceiling {
+				t.Fatalf("attempt %d returned %v, want within [%v, %v]", attempt, got, ceiling/2, ceiling)
+			}
+		}
+	}
+}
+
+func TestExponentialJitterBackoffIsJittered(t *testing.T) {
+	seen := make(map[time.Duration]struct{})
+	for i := 0; i < 100; i++ {
+		seen[exponentialJitterBackoff(5)] = struct{}{}
+	}
+
+	if len(seen) < 2 {
+		t.Errorf("100 samples produced %d distinct delay(s), want jittered values", len(seen))
+	}
+}
+
+func TestExponentialJitterBackoffFloorsAttempt(t *testing.T) {
+	// serviceErrors is zero when a 429 asks for no wait at all; that must not
+	// shift by a negative amount or collapse the delay to zero.
+	for _, attempt := range []int{-1, 0} {
+		got := exponentialJitterBackoff(attempt)
+		if got < retryWaitMin/2 || got > retryWaitMin {
+			t.Errorf("attempt %d returned %v, want within [%v, %v]", attempt, got, retryWaitMin/2, retryWaitMin)
+		}
+	}
+}
+
+// retryServer returns an httptest server whose handler is invoked for each
+// request, along with a counter of the requests it received.
+func retryServer(t *testing.T, handler func(w http.ResponseWriter, requests int32)) (*httptest.Server, *int32) {
+	t.Helper()
+
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handler(w, atomic.AddInt32(&requests, 1))
+	}))
+	t.Cleanup(server.Close)
+
+	return server, &requests
+}
+
+func TestExecuteWithRetryServiceUnavailable(t *testing.T) {
+	t.Run("retries then succeeds", func(t *testing.T) {
+		server, requests := retryServer(t, func(w http.ResponseWriter, requests int32) {
+			if requests < 3 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+
+		cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+		if _, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := atomic.LoadInt32(requests); got != 3 {
+			t.Errorf("issued %d requests, want 3", got)
+		}
+	})
+
+	t.Run("persistent 503 exhausts the budget", func(t *testing.T) {
+		server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+
+		cfg := EndpointCfg{Url: server.URL, Method: http.MethodPost, SuccessStatus: http.StatusCreated}
+		_, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil)
+
+		var exhausted *RetryExhaustedError
+		if !goer.As(err, &exhausted) {
+			t.Fatalf("got error %v, want *RetryExhaustedError", err)
+		}
+		if !goer.Is(err, errors.ErrServiceUnavailable) {
+			t.Errorf("error %v does not unwrap to ErrServiceUnavailable", err)
+		}
+		if exhausted.Attempts != maxServiceErrorRetries+1 {
+			t.Errorf("Attempts = %d, want %d", exhausted.Attempts, maxServiceErrorRetries+1)
+		}
+		if got := atomic.LoadInt32(requests); got != maxServiceErrorRetries+1 {
+			t.Errorf("issued %d requests, want %d", got, maxServiceErrorRetries+1)
+		}
+		if msg := ParseError(err); msg != err.Error() {
+			t.Errorf("ParseError rendered %q, want the RetryExhaustedError message %q", msg, err.Error())
+		}
+	})
+}
+
+func TestExecuteWithRetryGatewayTimeout(t *testing.T) {
+	const timeoutBody = `{"code":4000,"hint":"retry later","httpStatusCode":504,"message":"gateway timeout"}`
+
+	t.Run("GET is retried", func(t *testing.T) {
+		server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			_, _ = fmt.Fprint(w, timeoutBody)
+		})
+
+		cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+		_, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil)
+
+		if !goer.Is(err, errors.ErrGatewayTimeout) {
+			t.Fatalf("got error %v, want it to match ErrGatewayTimeout", err)
+		}
+		if got := atomic.LoadInt32(requests); got != maxServiceErrorRetries+1 {
+			t.Errorf("issued %d requests, want %d", got, maxServiceErrorRetries+1)
+		}
+	})
+
+	t.Run("POST is not retried", func(t *testing.T) {
+		server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			_, _ = fmt.Fprint(w, timeoutBody)
+		})
+
+		cfg := EndpointCfg{Url: server.URL, Method: http.MethodPost, SuccessStatus: http.StatusCreated}
+		_, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil)
+
+		var apiErr *Error
+		if !goer.As(err, &apiErr) {
+			t.Fatalf("got error %v, want *api.Error", err)
+		}
+		if apiErr.Message != "gateway timeout" {
+			t.Errorf("Message = %q, want the message from the response body", apiErr.Message)
+		}
+		if got := atomic.LoadInt32(requests); got != 1 {
+			t.Errorf("issued %d requests, want 1: a POST must not be replayed after a gateway timeout", got)
+		}
+	})
+
+	t.Run("index DDL code 7001 is not retried", func(t *testing.T) {
+		server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			_, _ = fmt.Fprint(w, `{"code":7001,"message":"index DDL timed out"}`)
+		})
+
+		cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+		_, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil)
+
+		if !goer.Is(err, errors.ErrGatewayTimeoutForIndexDDL) {
+			t.Fatalf("got error %v, want ErrGatewayTimeoutForIndexDDL", err)
+		}
+		if got := atomic.LoadInt32(requests); got != 1 {
+			t.Errorf("issued %d requests, want 1", got)
+		}
+	})
+}
+
+func TestExecuteWithRetryRateLimit(t *testing.T) {
+	t.Run("Retry-After is honoured", func(t *testing.T) {
+		server, _ := retryServer(t, func(w http.ResponseWriter, requests int32) {
+			if requests == 1 {
+				w.Header().Set("Retry-After", "1")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+
+		cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+
+		start := time.Now()
+		if _, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// WithFastBackoff would have retried in ~1ms, so a wait of a second can
+		// only have come from the Retry-After header.
+		if elapsed := time.Since(start); elapsed < time.Second {
+			t.Errorf("retried after %v, want at least the 1s the server asked for", elapsed)
+		}
+	})
+
+	t.Run("is not subject to the attempt cap", func(t *testing.T) {
+		const rateLimited = maxServiceErrorRetries * 3
+
+		server, requests := retryServer(t, func(w http.ResponseWriter, requests int32) {
+			if requests <= rateLimited {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+
+		cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+		if _, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := atomic.LoadInt32(requests); got != rateLimited+1 {
+			t.Errorf("issued %d requests, want %d", got, rateLimited+1)
+		}
+	})
+}
+
+func TestExecuteWithRetrySuccessPassthrough(t *testing.T) {
+	server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"id":"abc"}`)
+	})
+
+	cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := NewClient(time.Minute, WithFastBackoff()).ExecuteWithRetry(context.Background(), cfg, nil, "token", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(response.Body) != `{"id":"abc"}` {
+		t.Errorf("body = %q, want the response body verbatim", response.Body)
+	}
+	if got := atomic.LoadInt32(requests); got != 1 {
+		t.Errorf("issued %d requests, want 1", got)
+	}
+}
+
+func TestWithMaxRetries(t *testing.T) {
+	server, requests := retryServer(t, func(w http.ResponseWriter, _ int32) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	cfg := EndpointCfg{Url: server.URL, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	client := NewClient(time.Minute, WithFastBackoff(), WithMaxRetries(2))
+	if _, err := client.ExecuteWithRetry(context.Background(), cfg, nil, "token", nil); err == nil {
+		t.Fatal("expected the retry budget to be exhausted")
+	}
+
+	if got := atomic.LoadInt32(requests); got != 3 {
+		t.Errorf("issued %d requests, want 3", got)
+	}
+}

--- a/internal/api/error.go
+++ b/internal/api/error.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 // Error tracks the error structure received from Capella V4 APIs.
@@ -71,3 +72,26 @@ func IsForbiddenError(err error) bool {
 	var apiError *Error
 	return errors.As(err, &apiError) && apiError.HttpStatusCode == http.StatusForbidden
 }
+
+// RetryExhaustedError is returned when a retryable 503 or 504 response persisted
+// past the retry budget. It reports the attempt count and the elapsed time so an
+// operator can tell a genuinely unavailable service from a merely slow one.
+type RetryExhaustedError struct {
+	// LastErr is the error produced by the final attempt.
+	LastErr error
+
+	// Attempts is the number of requests issued, including the first.
+	Attempts int
+
+	// Elapsed is the wall-clock time spent across all attempts.
+	Elapsed time.Duration
+}
+
+func (e *RetryExhaustedError) Error() string {
+	return fmt.Sprintf("%v after %d attempts over %s",
+		e.LastErr, e.Attempts, e.Elapsed.Round(time.Millisecond))
+}
+
+// Unwrap exposes the final attempt's error so that callers can still match the
+// underlying cause with errors.Is.
+func (e *RetryExhaustedError) Unwrap() error { return e.LastErr }

--- a/internal/resources/app_endpoint_cors.go
+++ b/internal/resources/app_endpoint_cors.go
@@ -346,7 +346,15 @@ func (c *Cors) Update(ctx context.Context, req resource.UpdateRequest, resp *res
 		appServiceId,
 		appEndpointName,
 	)
-	cfg := api.EndpointCfg{Url: url, Method: http.MethodPut, SuccessStatus: http.StatusNoContent}
+	// The CORS endpoint has no long-running transient condition to wait out, so a
+	// persistent 503 here should fail the apply quickly rather than retry for the
+	// full request deadline.
+	cfg := api.EndpointCfg{
+		Url:                    url,
+		Method:                 http.MethodPut,
+		SuccessStatus:          http.StatusNoContent,
+		MaxServiceErrorRetries: api.FastFailServiceErrorRetries,
+	}
 	_, err := c.ClientV1.ExecuteWithRetry(
 		ctx,
 		cfg,


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-138151

## Description

exec() had no attempt cap, so a persistently unavailable endpoint was retried for the full 10-minute context deadline. With no Retry-After header the returned backoff was 0, so retries fell back to a flat 2s: ~300 requests at an unjittered cadence, ending in a generic "timed out executing request against api: context deadline exceeded"

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments