### PR TITLE
[AV-139841] Add acceptance test for database credential bucket/scope access

### DIFF
--- a/acceptance_tests/database_credential_acceptance_test.go
+++ b/acceptance_tests/database_credential_acceptance_test.go
@@ -1,8 +1,14 @@
 package acceptance_tests
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
+	"time"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -40,6 +46,152 @@ func TestAccDatabaseCredentialWithOptionalFields(t *testing.T) {
 			},
 		},
 	})
+}
+
+// databaseCredentialFixtureCollections are created (idempotently) in the
+// shared bucket's _default scope so TestAccDatabaseCredentialWithBucketScopeAccess
+// has real, multi-element collections to reference without depending on any
+// externally pre-loaded sample bucket.
+var databaseCredentialFixtureCollections = []string{"tf_acc_dbcred_col_a", "tf_acc_dbcred_col_b"}
+
+// TestAccDatabaseCredentialWithBucketScopeAccess covers the nested
+// access.resources.buckets.scopes.collections shape from AV-139841/CBSE-23356
+// (List/ListNestedAttribute instead of Set/SetNestedAttribute), verifying the
+// resource applies cleanly against real bucket/scope/collection names and
+// produces no diff on a subsequent plan.
+func TestAccDatabaseCredentialWithBucketScopeAccess(t *testing.T) {
+	ensureDatabaseCredentialFixtureCollections(t)
+
+	resourceName := randomStringWithPrefix("tf_acc_database_credential_")
+	resourceReference := "couchbase-capella_database_credential." + resourceName
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAddDatabaseCredWithBucketScopeAccessConfig(resourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.privileges.0", "data_reader"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.privileges.1", "data_writer"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.name", globalBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.name", globalScopeName),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.collections.#", "3"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.1.name", globalMetadataBucketName),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.1.scopes.0.name", globalScopeName),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.1.scopes.0.collections.0", globalScopeName),
+				),
+			},
+		},
+	})
+}
+
+func testAccAddDatabaseCredWithBucketScopeAccessConfig(resourceName string) string {
+	return fmt.Sprintf(
+		`
+		%[1]s
+
+		resource "couchbase-capella_database_credential" "%[5]s" {
+			name            = "%[5]s"
+			organization_id = "%[2]s"
+			project_id      = "%[3]s"
+			cluster_id      = "%[4]s"
+			access = [
+				{
+					privileges = ["data_reader", "data_writer"]
+					resources = {
+						buckets = [
+							{
+								name = "%[6]s"
+								scopes = [
+									{
+										name        = "%[7]s"
+										collections = ["%[7]s", "%[8]s", "%[9]s"]
+									},
+								]
+							},
+							{
+								name = "%[10]s"
+								scopes = [
+									{
+										name        = "%[7]s"
+										collections = ["%[7]s"]
+									},
+								]
+							},
+						]
+					}
+				},
+			]
+		}
+		`, globalProviderBlock, globalOrgId, globalProjectId, globalClusterId, resourceName,
+		globalBucketName, globalScopeName,
+		databaseCredentialFixtureCollections[0], databaseCredentialFixtureCollections[1],
+		globalMetadataBucketName)
+}
+
+// ensureDatabaseCredentialFixtureCollections creates databaseCredentialFixtureCollections
+// in the shared bucket's _default scope if they don't already exist, then waits
+// until each is listable. Capella rejects a database credential access grant
+// referencing a collection that isn't visible yet, so callers must wait for this
+// before applying config that references them.
+func ensureDatabaseCredentialFixtureCollections(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	collectionsUrl := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/buckets/%s/scopes/%s/collections",
+		globalHost, globalOrgId, globalProjectId, globalClusterId, globalBucketId, globalScopeName)
+
+	for _, name := range databaseCredentialFixtureCollections {
+		if err := ensureDatabaseCredentialFixtureCollection(ctx, collectionsUrl, name); err != nil {
+			t.Fatalf("failed to provision test collection %s: %v", name, err)
+		}
+	}
+}
+
+func ensureDatabaseCredentialFixtureCollection(ctx context.Context, collectionsUrl, name string) error {
+	exists, err := databaseCredentialFixtureCollectionExists(ctx, collectionsUrl, name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	createCfg := api.EndpointCfg{Url: collectionsUrl, Method: http.MethodPost, SuccessStatus: http.StatusCreated}
+	if _, err = globalClient.ExecuteWithRetry(ctx, createCfg, api.CreateCollectionRequest{Name: name}, globalToken, nil); err != nil {
+		return fmt.Errorf("creating fixture collection %q: %w", name, err)
+	}
+
+	const maxWait = 2 * time.Minute
+	deadline := time.Now().Add(maxWait)
+	for {
+		exists, err = databaseCredentialFixtureCollectionExists(ctx, collectionsUrl, name)
+		if err == nil && exists {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for fixture collection %q to become listable", name)
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func databaseCredentialFixtureCollectionExists(ctx context.Context, collectionsUrl, name string) (bool, error) {
+	listCfg := api.EndpointCfg{Url: collectionsUrl, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := globalClient.ExecuteWithRetry(ctx, listCfg, nil, globalToken, nil)
+	if err != nil {
+		return false, fmt.Errorf("listing collections for %q: %w", name, err)
+	}
+
+	var collections api.GetCollectionsResponse
+	if err = json.Unmarshal(response.Body, &collections); err != nil {
+		return false, fmt.Errorf("unmarshalling collections list for %q: %w", name, err)
+	}
+	for _, c := range collections.Data {
+		if c.Name != nil && *c.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func testAccAddDatabaseCredWithReqFieldsConfig(resourceName string) string {

--- a/acceptance_tests/database_credential_acceptance_test.go
+++ b/acceptance_tests/database_credential_acceptance_test.go
@@ -3,6 +3,7 @@ package acceptance_tests
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -71,8 +72,9 @@ func TestAccDatabaseCredentialWithBucketScopeAccess(t *testing.T) {
 				Config: testAccAddDatabaseCredWithBucketScopeAccessConfig(resourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "name", resourceName),
-					resource.TestCheckResourceAttr(resourceReference, "access.0.privileges.0", "data_reader"),
-					resource.TestCheckResourceAttr(resourceReference, "access.0.privileges.1", "data_writer"),
+					resource.TestCheckResourceAttr(resourceReference, "access.0.privileges.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "data_reader"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "access.0.privileges.*", "data_writer"),
 					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.name", globalBucketName),
 					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.name", globalScopeName),
 					resource.TestCheckResourceAttr(resourceReference, "access.0.resources.buckets.0.scopes.0.collections.#", "3"),
@@ -158,7 +160,10 @@ func ensureDatabaseCredentialFixtureCollection(ctx context.Context, collectionsU
 
 	createCfg := api.EndpointCfg{Url: collectionsUrl, Method: http.MethodPost, SuccessStatus: http.StatusCreated}
 	if _, err = globalClient.ExecuteWithRetry(ctx, createCfg, api.CreateCollectionRequest{Name: name}, globalToken, nil); err != nil {
-		return fmt.Errorf("creating fixture collection %q: %w", name, err)
+		var apiErr *api.Error
+		if !errors.As(err, &apiErr) || apiErr.HttpStatusCode != http.StatusConflict {
+			return fmt.Errorf("creating fixture collection %q: %w", name, err)
+		}
 	}
 
 	const maxWait = 2 * time.Minute


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-139841](https://jira.issues.couchbase.com/browse/AV-139841)

## Description

PR #714 (merged as `07c7f56`) switched `access`/`resources.buckets`/`buckets.scopes`/`scopes.collections` on `database_credential` from `Set`/`SetNestedAttribute` to `List`/`ListNestedAttribute` to fix the O(n²) plan-time blowup reported in CBSE-23356 (37 of 38 minutes for a single resource with 59 collections). That PR's own testing notes said it had no acceptance test coverage and wasn't run against a live Capella org. This adds that missing acceptance test, exercising the nested `buckets`/`scopes`/`collections` shape end-to-end and confirming no ordering-drift diff appears on replan.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [x] Unit tested
- [x] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

`go build ./...`, `go vet ./...`, `goimports -l` all clean.

Acceptance tests (live Capella, shared test cluster):
```
--- PASS: TestAccDatabaseCredentialWithReqFields (4.68s)
--- PASS: TestAccDatabaseCredentialWithBucketScopeAccess (8.56s)
--- PASS: TestAccDatabaseCredentialWithOptionalFields (4.81s)
PASS
```

Also reproduced the original CBSE-23356 report directly: built the pre-fix (`Set`) and post-fix (`List`) provider binaries from commit `07c7f56^` and `07c7f56`, and timed an identical `terraform plan` for a `database_credential` with 59 collections in one bucket/scope (the customer's exact repro shape from issue #700):

| | plan time |
|---|---|
| Before fix (Set) | 7m 2s |
| After fix (List) | 3.0s |

~140x faster, even for a brand-new resource with no prior state to diff against (the customer's original no-op replan was worse: 37 of 38 min).

</details>

## Further comments

[AV-139841]: https://couchbasecloud.atlassian.net/browse/AV-139841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ