### PR TITLE
[AV-132323] Add unit tests for failed terminal cluster states

### DIFF
--- a/internal/api/cluster/state_test.go
+++ b/internal/api/cluster/state_test.go
@@ -1,0 +1,53 @@
+package cluster
+
+import "testing"
+
+func TestIsTerminalState(t *testing.T) {
+	tests := []struct {
+		name  string
+		state State
+		want  bool
+	}{
+		{name: "healthy is not terminal", state: Healthy, want: false},
+		{name: "deploying is not terminal", state: Deploying, want: false},
+		{name: "rebalancing is not terminal", state: Rebalancing, want: false},
+		{name: "deploymentFailed is terminal", state: DeploymentFailed, want: true},
+		{name: "destroyFailed is terminal", state: DestroyFailed, want: true},
+		{name: "peeringFailed is terminal", state: PeeringFailed, want: true},
+		{name: "rebalanceFailed is terminal", state: RebalanceFailed, want: true},
+		{name: "scaleFailed is terminal", state: ScaleFailed, want: true},
+		{name: "upgradeFailed is terminal", state: UpgradeFailed, want: true},
+		{name: "degraded is terminal", state: Degraded, want: true},
+		{name: "unknown state is not terminal", state: State("somethingElse"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTerminalState(tt.state); got != tt.want {
+				t.Errorf("IsTerminalState(%q) = %v, want %v", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestState_Equal(t *testing.T) {
+	tests := []struct {
+		name string
+		s1   State
+		s2   State
+		want bool
+	}{
+		{name: "exact match", s1: Healthy, s2: Healthy, want: true},
+		{name: "case insensitive match", s1: State("Healthy"), s2: Healthy, want: true},
+		{name: "mismatch", s1: Healthy, s2: DeploymentFailed, want: false},
+		{name: "empty states are equal", s1: State(""), s2: State(""), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.s1.Equal(tt.s2); got != tt.want {
+				t.Errorf("%q.Equal(%q) = %v, want %v", tt.s1, tt.s2, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -199,7 +199,7 @@ func (c *Cluster) Create(ctx context.Context, req resource.CreateRequest, resp *
 	if err = c.checkClusterStatus(ctx, organizationId, projectId, clusterResponse.Id.String()); err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating cluster",
-			fmt.Sprintf("Could not create cluster. error: %v", api.ParseError(err)),
+			fmt.Sprintf("Could not create cluster id %s. error: %v", clusterResponse.Id.String(), api.ParseError(err)),
 		)
 		return
 	}

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -594,6 +594,14 @@ func (c *Cluster) retrieveCluster(
 	return refreshedState, nil
 }
 
+// clusterStatusPollInterval and clusterStatusTimeout are overridden in tests to avoid waiting on real
+// wall-clock time while exercising checkClusterStatus's polling loop.
+var (
+	clusterStatusPollInterval = time.Minute
+	// Assuming 60 minutes is the max time deployment takes, can change after discussion.
+	clusterStatusTimeout = time.Minute * 60
+)
+
 // checkClusterStatus monitors the status of a cluster creation, update and deletion operation for a specified
 // organization, project, and cluster ID. It periodically fetches the cluster status using the `getCluster`
 // function and waits until the cluster reaches a final state or until a specified timeout is reached.
@@ -604,14 +612,11 @@ func (c *Cluster) checkClusterStatus(ctx context.Context, organizationId, projec
 		err         error
 	)
 
-	// Assuming 60 minutes is the max time deployment takes, can change after discussion
-	const timeout = time.Minute * 60
-
 	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, timeout)
+	ctx, cancel = context.WithTimeout(ctx, clusterStatusTimeout)
 	defer cancel()
 
-	ticker := time.NewTicker(1 * time.Minute)
+	ticker := time.NewTicker(clusterStatusPollInterval)
 	defer ticker.Stop()
 
 	for {

--- a/internal/resources/cluster_status_test.go
+++ b/internal/resources/cluster_status_test.go
@@ -1,0 +1,180 @@
+package resources
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	clusterapi "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/cluster"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+// clusterStatusBackend is an in-memory control-plane stand-in that answers GET
+// cluster status polls from a scripted queue of states (the last entry repeats
+// once the queue is drained) so tests can drive checkClusterStatus's poll loop
+// deterministically.
+type clusterStatusBackend struct {
+	mu     sync.Mutex
+	states []clusterapi.State
+	idx    int
+}
+
+func (b *clusterStatusBackend) handler(w http.ResponseWriter, r *http.Request) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	idx := b.idx
+	if idx >= len(b.states) {
+		idx = len(b.states) - 1
+	}
+	b.idx++
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(clusterapi.GetClusterResponse{CurrentState: b.states[idx]})
+}
+
+// fastClusterPolling shrinks the package-level poll timing for the duration of
+// a test so checkClusterStatus's poll loop resolves in milliseconds.
+func fastClusterPolling(t *testing.T) {
+	t.Helper()
+	origInterval, origTimeout := clusterStatusPollInterval, clusterStatusTimeout
+	clusterStatusPollInterval = time.Millisecond
+	clusterStatusTimeout = 2 * time.Second
+	t.Cleanup(func() {
+		clusterStatusPollInterval = origInterval
+		clusterStatusTimeout = origTimeout
+	})
+}
+
+func newTestCluster(t *testing.T, handler http.HandlerFunc) *Cluster {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	return &Cluster{
+		Data: &providerschema.Data{
+			ClientV1: &api.Client{Client: srv.Client()},
+			HostURL:  srv.URL,
+		},
+	}
+}
+
+func TestCheckClusterStatus(t *testing.T) {
+	fastClusterPolling(t)
+
+	tests := []struct {
+		name        string
+		states      []clusterapi.State
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:   "reaches healthy after transient deploying states",
+			states: []clusterapi.State{clusterapi.Deploying, clusterapi.Deploying, clusterapi.Healthy},
+		},
+		{
+			name:        "deploymentFailed surfaces an error instead of success",
+			states:      []clusterapi.State{clusterapi.Deploying, clusterapi.DeploymentFailed},
+			wantErr:     true,
+			errContains: "deploymentFailed",
+		},
+		{
+			name:        "scaleFailed surfaces an error",
+			states:      []clusterapi.State{clusterapi.Scaling, clusterapi.ScaleFailed},
+			wantErr:     true,
+			errContains: "scaleFailed",
+		},
+		{
+			name:        "rebalanceFailed surfaces an error",
+			states:      []clusterapi.State{clusterapi.RebalanceFailed},
+			wantErr:     true,
+			errContains: "rebalanceFailed",
+		},
+		{
+			name:        "upgradeFailed surfaces an error",
+			states:      []clusterapi.State{clusterapi.UpgradeFailed},
+			wantErr:     true,
+			errContains: "upgradeFailed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &clusterStatusBackend{states: tt.states}
+			c := newTestCluster(t, backend.handler)
+
+			err := c.checkClusterStatus(t.Context(), "org-1", "proj-1", "cluster-1")
+
+			if tt.wantErr {
+				assert.ErrorContains(t, err, tt.errContains)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}
+
+func TestCheckClusterStatus_TimesOutWithoutReachingTerminalState(t *testing.T) {
+	fastClusterPolling(t)
+
+	backend := &clusterStatusBackend{states: []clusterapi.State{clusterapi.Deploying}}
+	c := newTestCluster(t, backend.handler)
+
+	err := c.checkClusterStatus(t.Context(), "org-1", "proj-1", "cluster-1")
+
+	assert.ErrorContains(t, err, "timed out")
+}
+
+func TestCheckClusterStatus_RetriesOnTransientGetErrors(t *testing.T) {
+	fastClusterPolling(t)
+
+	var mu sync.Mutex
+	calls := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(clusterapi.GetClusterResponse{CurrentState: clusterapi.Healthy})
+	}
+
+	c := newTestCluster(t, handler)
+
+	err := c.checkClusterStatus(t.Context(), "org-1", "proj-1", "cluster-1")
+
+	assert.NilError(t, err)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Assert(t, calls >= 3, "expected checkClusterStatus to retry past the transient errors, got %d call(s)", calls)
+}
+
+func TestCheckClusterStatus_UsesGetClusterEndpoint(t *testing.T) {
+	fastClusterPolling(t)
+
+	var gotPath string
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(clusterapi.GetClusterResponse{CurrentState: clusterapi.Healthy})
+	}
+
+	c := newTestCluster(t, handler)
+
+	err := c.checkClusterStatus(t.Context(), "org-1", "proj-1", "cluster-1")
+
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(gotPath, "/organizations/org-1/projects/proj-1/clusters/cluster-1"), "unexpected path: %s", gotPath)
+}

--- a/internal/resources/cluster_status_test.go
+++ b/internal/resources/cluster_status_test.go
@@ -164,9 +164,12 @@ func TestCheckClusterStatus_RetriesOnTransientGetErrors(t *testing.T) {
 func TestCheckClusterStatus_UsesGetClusterEndpoint(t *testing.T) {
 	fastClusterPolling(t)
 
+	var mu sync.Mutex
 	var gotPath string
 	handler := func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		gotPath = r.URL.Path
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(clusterapi.GetClusterResponse{CurrentState: clusterapi.Healthy})
 	}
@@ -176,5 +179,7 @@ func TestCheckClusterStatus_UsesGetClusterEndpoint(t *testing.T) {
 	err := c.checkClusterStatus(t.Context(), "org-1", "proj-1", "cluster-1")
 
 	assert.NilError(t, err)
+	mu.Lock()
+	defer mu.Unlock()
 	assert.Assert(t, strings.Contains(gotPath, "/organizations/org-1/projects/proj-1/clusters/cluster-1"), "unexpected path: %s", gotPath)
 }

--- a/internal/resources/free_tier_cluster.go
+++ b/internal/resources/free_tier_cluster.go
@@ -95,7 +95,7 @@ func (f *FreeTierCluster) Create(ctx context.Context, request resource.CreateReq
 	if err != nil {
 		response.Diagnostics.AddError(
 			"Error creating free tier cluster",
-			fmt.Sprintf("Could not create free tier cluster. error: %v", api.ParseError(err)),
+			fmt.Sprintf("Could not create free tier cluster id %s. error: %v", freeTierClusterResponse.Id.String(), api.ParseError(err)),
 		)
 		return
 	}

--- a/internal/resources/free_tier_cluster.go
+++ b/internal/resources/free_tier_cluster.go
@@ -315,6 +315,14 @@ func (f *FreeTierCluster) Configure(_ context.Context, request resource.Configur
 	f.Data = data
 }
 
+// freeTierClusterStatusPollInterval and freeTierClusterStatusTimeout are overridden in tests to avoid
+// waiting on real wall-clock time while exercising checkForFreeTierClusterStatus's polling loop.
+var (
+	freeTierClusterStatusPollInterval = time.Minute
+	// Assuming 60 minutes is the max time deployment takes, can change after discussion.
+	freeTierClusterStatusTimeout = time.Minute * 60
+)
+
 // checkFreeTierClusterStatus monitors the status of a cluster creation, update and deletion operation for a specified,
 // organization, project, and cluster ID. It periodically fetches the cluster status using the `getCluster`
 // function and waits until the cluster reaches a final state or until a specified timeout is reached.
@@ -325,14 +333,11 @@ func (f *FreeTierCluster) checkForFreeTierClusterStatus(ctx context.Context, org
 		err         error
 	)
 
-	// Assuming 60 minutes is the max time deployment takes, can change after discussion.
-	const timeout = time.Minute * 60
-
 	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, timeout)
+	ctx, cancel = context.WithTimeout(ctx, freeTierClusterStatusTimeout)
 	defer cancel()
 
-	ticker := time.NewTicker(1 * time.Minute)
+	ticker := time.NewTicker(freeTierClusterStatusPollInterval)
 	defer ticker.Stop()
 
 	for {

--- a/internal/resources/free_tier_cluster_status_test.go
+++ b/internal/resources/free_tier_cluster_status_test.go
@@ -1,0 +1,164 @@
+package resources
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api"
+	clusterapi "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/cluster"
+	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
+)
+
+// freeTierClusterStatusBackend is an in-memory control-plane stand-in that
+// answers GET free tier cluster status polls from a scripted queue of states
+// (the last entry repeats once the queue is drained) so tests can drive
+// checkForFreeTierClusterStatus's poll loop deterministically.
+type freeTierClusterStatusBackend struct {
+	mu     sync.Mutex
+	states []clusterapi.State
+	idx    int
+}
+
+func (b *freeTierClusterStatusBackend) handler(w http.ResponseWriter, r *http.Request) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	idx := b.idx
+	if idx >= len(b.states) {
+		idx = len(b.states) - 1
+	}
+	b.idx++
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(clusterapi.GetClusterResponse{CurrentState: b.states[idx]})
+}
+
+// fastFreeTierClusterPolling shrinks the package-level poll timing for the
+// duration of a test so checkForFreeTierClusterStatus's poll loop resolves in
+// milliseconds.
+func fastFreeTierClusterPolling(t *testing.T) {
+	t.Helper()
+	origInterval, origTimeout := freeTierClusterStatusPollInterval, freeTierClusterStatusTimeout
+	freeTierClusterStatusPollInterval = time.Millisecond
+	freeTierClusterStatusTimeout = 2 * time.Second
+	t.Cleanup(func() {
+		freeTierClusterStatusPollInterval = origInterval
+		freeTierClusterStatusTimeout = origTimeout
+	})
+}
+
+func newTestFreeTierCluster(t *testing.T, handler http.HandlerFunc) *FreeTierCluster {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	return &FreeTierCluster{
+		Data: &providerschema.Data{
+			ClientV1: &api.Client{Client: srv.Client()},
+			HostURL:  srv.URL,
+		},
+	}
+}
+
+func TestCheckForFreeTierClusterStatus(t *testing.T) {
+	fastFreeTierClusterPolling(t)
+
+	tests := []struct {
+		name        string
+		states      []clusterapi.State
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:   "reaches healthy after transient deploying states",
+			states: []clusterapi.State{clusterapi.Deploying, clusterapi.Deploying, clusterapi.Healthy},
+		},
+		{
+			name:        "deploymentFailed surfaces an error instead of success",
+			states:      []clusterapi.State{clusterapi.Deploying, clusterapi.DeploymentFailed},
+			wantErr:     true,
+			errContains: "deploymentFailed",
+		},
+		{
+			name:        "destroyFailed surfaces an error",
+			states:      []clusterapi.State{clusterapi.Destroying, clusterapi.DestroyFailed},
+			wantErr:     true,
+			errContains: "destroyFailed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &freeTierClusterStatusBackend{states: tt.states}
+			f := newTestFreeTierCluster(t, backend.handler)
+
+			resp, err := f.checkForFreeTierClusterStatus(t.Context(), "org-1", "proj-1", "cluster-1")
+
+			if tt.wantErr {
+				assert.ErrorContains(t, err, tt.errContains)
+				assert.Assert(t, resp == nil, "expected a nil response on failure")
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, resp.CurrentState, clusterapi.Healthy)
+		})
+	}
+}
+
+func TestCheckForFreeTierClusterStatus_TimesOutWithoutReachingTerminalState(t *testing.T) {
+	fastFreeTierClusterPolling(t)
+
+	backend := &freeTierClusterStatusBackend{states: []clusterapi.State{clusterapi.Deploying}}
+	f := newTestFreeTierCluster(t, backend.handler)
+
+	_, err := f.checkForFreeTierClusterStatus(t.Context(), "org-1", "proj-1", "cluster-1")
+
+	assert.ErrorContains(t, err, "timed out")
+}
+
+func TestCheckForFreeTierClusterStatus_ReturnsImmediatelyOnGetError(t *testing.T) {
+	fastFreeTierClusterPolling(t)
+
+	var mu sync.Mutex
+	calls := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	f := newTestFreeTierCluster(t, handler)
+
+	_, err := f.checkForFreeTierClusterStatus(t.Context(), "org-1", "proj-1", "cluster-1")
+
+	assert.Assert(t, err != nil, "expected an error from a failing GET")
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, calls, 1, "expected checkForFreeTierClusterStatus to return on the first GET error, not retry")
+}
+
+func TestCheckForFreeTierClusterStatus_UsesFreeTierGetClusterEndpoint(t *testing.T) {
+	fastFreeTierClusterPolling(t)
+
+	var gotPath string
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(clusterapi.GetClusterResponse{CurrentState: clusterapi.Healthy})
+	}
+
+	f := newTestFreeTierCluster(t, handler)
+
+	_, err := f.checkForFreeTierClusterStatus(t.Context(), "org-1", "proj-1", "cluster-1")
+
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(gotPath, "/organizations/org-1/projects/proj-1/clusters/freeTier/cluster-1"), "unexpected path: %s", gotPath)
+}

--- a/internal/resources/free_tier_cluster_status_test.go
+++ b/internal/resources/free_tier_cluster_status_test.go
@@ -148,9 +148,12 @@ func TestCheckForFreeTierClusterStatus_ReturnsImmediatelyOnGetError(t *testing.T
 func TestCheckForFreeTierClusterStatus_UsesFreeTierGetClusterEndpoint(t *testing.T) {
 	fastFreeTierClusterPolling(t)
 
+	var mu sync.Mutex
 	var gotPath string
 	handler := func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		gotPath = r.URL.Path
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(clusterapi.GetClusterResponse{CurrentState: clusterapi.Healthy})
 	}
@@ -160,5 +163,7 @@ func TestCheckForFreeTierClusterStatus_UsesFreeTierGetClusterEndpoint(t *testing
 	_, err := f.checkForFreeTierClusterStatus(t.Context(), "org-1", "proj-1", "cluster-1")
 
 	assert.NilError(t, err)
+	mu.Lock()
+	defer mu.Unlock()
 	assert.Assert(t, strings.Contains(gotPath, "/organizations/org-1/projects/proj-1/clusters/freeTier/cluster-1"), "unexpected path: %s", gotPath)
 }


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* [AV-132323](https://jira.issues.couchbase.com/browse/AV-132323)

## Description

The fix for AV-132323 (#755) shipped without automated coverage, so this adds unit tests for `IsTerminalState`/`State.Equal` and for the `checkClusterStatus`/`checkForFreeTierClusterStatus` polling loops, covering `deploymentFailed`, `scaleFailed`, `rebalanceFailed`, `upgradeFailed`, `destroyFailed`, transient GET errors, and timeouts. While re-checking the merged fix against the ticket's acceptance criteria, found that `Create()` on both `Cluster` and `FreeTierCluster` was missing the cluster ID in its failure error message (unlike `Update()`/`Delete()`, which already include it) — fixed both to match.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [x] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

```
go test ./internal/api/cluster/... ./internal/resources/... -run 'TestIsTerminalState|TestState_Equal|TestCheckClusterStatus|TestCheckForFreeTierClusterStatus' -v

--- PASS: TestIsTerminalState (11 subtests)
--- PASS: TestState_Equal (4 subtests)
--- PASS: TestCheckClusterStatus (5 subtests)
--- PASS: TestCheckClusterStatus_TimesOutWithoutReachingTerminalState
--- PASS: TestCheckClusterStatus_RetriesOnTransientGetErrors
--- PASS: TestCheckClusterStatus_UsesGetClusterEndpoint
--- PASS: TestCheckForFreeTierClusterStatus (3 subtests)
--- PASS: TestCheckForFreeTierClusterStatus_TimesOutWithoutReachingTerminalState
--- PASS: TestCheckForFreeTierClusterStatus_ReturnsImmediatelyOnGetError
--- PASS: TestCheckForFreeTierClusterStatus_UsesFreeTierGetClusterEndpoint
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/cluster	1.215s
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/resources	6.021s
```

Also verified: `go build ./...`, `go vet ./internal/resources/...`, `goimports -l` clean, and the provider binary builds successfully with the release ldflags.

Manual/acceptance validation of the underlying fix's real-world behavior (paid + free-tier cluster create/update/destroy happy paths, plus simulated `deploymentFailed` via a temporary code patch showing the apply fails and the state stays empty) was already performed against dev in the ticket's comments.

</details>

## Further comments

[AV-132323]: https://couchbasecloud.atlassian.net/browse/AV-132323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ