### PR TITLE
[AV-142288] Make app service on/off idempotent when already in requested state

### DIFF
--- a/acceptance_tests/app_service.go
+++ b/acceptance_tests/app_service.go
@@ -61,6 +61,36 @@ func createAppService(ctx context.Context, client *api.Client) error {
 	return nil
 }
 
+// appServiceCurrentState reads the current state of the shared app service. Unlike
+// appServiceWait it does not block, so tests can assert on the fixture's state up front.
+func appServiceCurrentState(ctx context.Context, client *api.Client) (appservice.State, error) {
+	url := fmt.Sprintf(
+		"%s/v4/organizations/%s/projects/%s/clusters/%s/appservices/%s",
+		globalHost,
+		globalOrgId,
+		globalProjectId,
+		globalClusterId,
+		globalAppServiceId)
+
+	cfg := api.EndpointCfg{
+		Url:           url,
+		Method:        http.MethodGet,
+		SuccessStatus: http.StatusOK,
+	}
+
+	response, err := client.ExecuteWithRetry(ctx, cfg, nil, globalToken, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var appServiceResponse appservice.GetAppServiceResponse
+	if err = json.Unmarshal(response.Body, &appServiceResponse); err != nil {
+		return "", fmt.Errorf("error unmarshalling app service response: %w", err)
+	}
+
+	return appServiceResponse.CurrentState, nil
+}
+
 func appServiceWait(ctx context.Context, client *api.Client, destroy bool) error {
 	const maxWaitTime = 30 * time.Minute
 	const checkInterval = 1 * time.Minute

--- a/acceptance_tests/appservice_onoff_ondemand_acceptance_test.go
+++ b/acceptance_tests/appservice_onoff_ondemand_acceptance_test.go
@@ -1,12 +1,15 @@
 package acceptance_tests
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/appservice"
 )
 
 func TestAccAppServiceOnOffOnDemandResource(t *testing.T) {
@@ -43,9 +46,37 @@ func TestAccAppServiceOnOffOnDemandAlreadyInRequestedState(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		// The fixture app service has to be on already, otherwise the first apply performs a
+		// real activation and never reaches the redundant-request path under test. TestMain
+		// waits for Healthy only when it creates the app service itself; one supplied through
+		// TF_VAR_app_service_id is adopted as-is, so its state is asserted here rather than
+		// assumed. Failing loudly beats passing without covering the fix.
+		PreCheck: func() {
+			currentState, err := appServiceCurrentState(context.Background(), globalClient)
+			if err != nil {
+				t.Fatalf("could not read state of app service %s: %s", globalAppServiceId, err)
+			}
+			if currentState != appservice.Healthy {
+				t.Fatalf(
+					"app service %s must be %q so that requesting state \"on\" is redundant, got %q",
+					globalAppServiceId, appservice.Healthy, currentState,
+				)
+			}
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "app_service_id", globalAppServiceId),
+					resource.TestCheckResourceAttr(resourceReference, "state", "on"),
+				),
+			},
+			// Tainting forces a second Create against the app service, which is still on
+			// because Delete is a no-op for this resource. That exercises the redundant
+			// activation request independently of what the first apply happened to do.
+			{
+				Config: cfg,
+				Taint:  []string{resourceReference},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceReference, "app_service_id", globalAppServiceId),
 					resource.TestCheckResourceAttr(resourceReference, "state", "on"),

--- a/acceptance_tests/appservice_onoff_ondemand_acceptance_test.go
+++ b/acceptance_tests/appservice_onoff_ondemand_acceptance_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-
 func TestAccAppServiceOnOffOnDemandResource(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_app_service_onoff_ondemand_")
 	resourceReference := "couchbase-capella_app_service_onoff_ondemand." + resourceName
@@ -32,6 +31,31 @@ func TestAccAppServiceOnOffOnDemandResource(t *testing.T) {
 				ImportStateIdFunc:                    generateAppServiceOnOffOnDemandImportId(resourceReference),
 				ImportState:                          true,
 				ImportStateVerifyIdentifierAttribute: "app_service_id",
+			},
+		},
+	})
+}
+
+func TestAccAppServiceOnOffOnDemandAlreadyInRequestedState(t *testing.T) {
+	resourceName := randomStringWithPrefix("tf_acc_app_service_onoff_already_on_")
+	resourceReference := "couchbase-capella_app_service_onoff_ondemand." + resourceName
+	cfg := testAccAppServiceOnOffOnDemandResourceConfig(resourceName, globalAppServiceId, "on")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceReference, "app_service_id", globalAppServiceId),
+					resource.TestCheckResourceAttr(resourceReference, "state", "on"),
+				),
+			},
+			// Re-apply the same config; expect no changes (no perpetual drift).
+			{
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/internal/resources/appservice_onoff.go
+++ b/internal/resources/appservice_onoff.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -33,6 +32,13 @@ const errorMessageAfterAppServiceOnOffCreation = "Cluster switch on/off is succe
 	" state of the switched on/off cluster. Please run `terraform plan` after 1-2 minutes to know the" +
 	" current state. Additionally, run `terraform apply --refresh-only` to update" +
 	" the state from remote, unexpected error: "
+
+// Capella rejects an activation state change with a 409 when the app service is not in a
+// state that permits it, which includes it already being in the requested state.
+const (
+	errCodeAppServiceNotOffToBeTurnedOn = 11018
+	errCodeAppServiceNotOnToBeTurnedOff = 11019
+)
 
 // AppServiceOnOffOnDemand is the AppServiceOnOffOnDemand implementation.
 type AppServiceOnOffOnDemand struct {
@@ -160,9 +166,79 @@ func (a *AppServiceOnOffOnDemand) manageAppServiceActivation(ctx context.Context
 		nil,
 	)
 	if err != nil {
+		if a.appServiceAlreadyInState(ctx, err, state, organizationId, projectId, clusterId, appServiceId) {
+			tflog.Info(ctx, "app service is already in the requested activation state, nothing to do", map[string]any{
+				"app_service_id": appServiceId,
+				"state":          state,
+			})
+			return nil
+		}
 		return errors.New(errorMessageWhileAppServiceOnOffCreation + app_service_onoff_api.ParseError(err))
 	}
 	return nil
+}
+
+func (a *AppServiceOnOffOnDemand) appServiceAlreadyInState(ctx context.Context, err error, state, organizationId, projectId, clusterId, appServiceId string) bool {
+	var apiErr *app_service_onoff_api.Error
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	switch {
+	case state == "on" && apiErr.Code == errCodeAppServiceNotOffToBeTurnedOn:
+	case state == "off" && apiErr.Code == errCodeAppServiceNotOnToBeTurnedOff:
+	default:
+		return false
+	}
+
+	currentState, stateErr := a.retrieveAppServiceCurrentState(ctx, organizationId, projectId, clusterId, appServiceId)
+	if stateErr != nil {
+		tflog.Warn(ctx, "could not read app service state to confirm it is already in the requested activation state", map[string]any{
+			"app_service_id": appServiceId,
+			"error":          app_service_onoff_api.ParseError(stateErr),
+		})
+		return false
+	}
+
+	return appServiceStateSatisfies(state, currentState)
+}
+
+// appServiceStateSatisfies reports whether currentState already satisfies the requested on/off
+// state. In-progress transitions count as satisfied so that a state read racing with a
+// concurrent transition does not turn a no-op into an apply failure.
+func appServiceStateSatisfies(state string, currentState apps_service_api.State) bool {
+	switch state {
+	case "on":
+		return currentState == apps_service_api.Healthy || currentState == apps_service_api.TurningOn
+	case "off":
+		return currentState == apps_service_api.TurnedOff || currentState == apps_service_api.TurningOff
+	default:
+		return false
+	}
+}
+
+// retrieveAppServiceCurrentState reads the app service's current state. There is no GET
+// endpoint for app service on/off, so the app service itself is fetched instead.
+func (a *AppServiceOnOffOnDemand) retrieveAppServiceCurrentState(ctx context.Context, organizationId, projectId, clusterId, appServiceId string) (apps_service_api.State, error) {
+	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/appservices/%s", a.HostURL, organizationId, projectId, clusterId, appServiceId)
+	cfg := app_service_onoff_api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
+	response, err := a.ClientV1.ExecuteWithRetry(
+		ctx,
+		cfg,
+		nil,
+		a.Token,
+		nil,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	appServiceResp := apps_service_api.GetAppServiceResponse{}
+	if err := json.Unmarshal(response.Body, &appServiceResp); err != nil {
+		return "", err
+	}
+
+	return appServiceResp.CurrentState, nil
 }
 
 func (a *AppServiceOnOffOnDemand) validateAppServiceOnOffRequest(plan providerschema.AppServiceOnOffOnDemand) error {
@@ -185,29 +261,13 @@ func (a *AppServiceOnOffOnDemand) validateAppServiceOnOffRequest(plan providersc
 }
 
 // retrieveAppServiceOnOff retrieves AppServiceOnOff information from the specified organization and project using the provided cluster ID by Get cluster open-api call.
+//
+// The returned state is the requested one rather than the app service's current state: the
+// current state carries transitional values such as turningOn that the on/off resource does
+// not model, so it is only fetched to confirm the app service still exists.
 func (a *AppServiceOnOffOnDemand) retrieveAppServiceOnOff(ctx context.Context, organizationId, projectId, clusterId, appServiceId, state string) (*providerschema.AppServiceOnOffOnDemand, error) {
-	url := fmt.Sprintf("%s/v4/organizations/%s/projects/%s/clusters/%s/appservices/%s", a.HostURL, organizationId, projectId, clusterId, appServiceId)
-	cfg := app_service_onoff_api.EndpointCfg{Url: url, Method: http.MethodGet, SuccessStatus: http.StatusOK}
-	response, err := a.ClientV1.ExecuteWithRetry(
-		ctx,
-		cfg,
-		nil,
-		a.Token,
-		nil,
-	)
-	if err != nil {
+	if _, err := a.retrieveAppServiceCurrentState(ctx, organizationId, projectId, clusterId, appServiceId); err != nil {
 		return nil, err
-	}
-
-	//There is no GET endpoint so get the app service response and check current state
-	appServiceResp := apps_service_api.GetAppServiceResponse{}
-	err = json.Unmarshal(response.Body, &appServiceResp)
-	if err != nil {
-		return nil, err
-	}
-
-	if validateAppserviceStateIsSameInPlanAndState(state, string(appServiceResp.CurrentState)) {
-		appServiceResp.CurrentState = apps_service_api.State(state)
 	}
 
 	refreshedState := providerschema.AppServiceOnOffOnDemand{
@@ -219,10 +279,6 @@ func (a *AppServiceOnOffOnDemand) retrieveAppServiceOnOff(ctx context.Context, o
 	}
 
 	return &refreshedState, nil
-}
-
-func validateAppserviceStateIsSameInPlanAndState(planAppServiceState, stateAppServiceState string) bool {
-	return strings.EqualFold(planAppServiceState, stateAppServiceState)
 }
 
 // Couchbase Capella's v4 does not support a GET endpoint for app service on/off.

--- a/internal/resources/appservice_onoff_test.go
+++ b/internal/resources/appservice_onoff_test.go
@@ -1,0 +1,36 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/api/appservice"
+)
+
+func Test_appServiceStateSatisfies(t *testing.T) {
+	tests := []struct {
+		name         string
+		state        string
+		currentState appservice.State
+		expected     bool
+	}{
+		{name: "on is satisfied by healthy", state: "on", currentState: appservice.Healthy, expected: true},
+		{name: "on is satisfied by turningOn", state: "on", currentState: appservice.TurningOn, expected: true},
+		{name: "on is not satisfied by turnedOff", state: "on", currentState: appservice.TurnedOff, expected: false},
+		{name: "on is not satisfied by degraded", state: "on", currentState: appservice.Degraded, expected: false},
+		{name: "on is not satisfied by turnOnFailed", state: "on", currentState: appservice.TurnOnFailed, expected: false},
+		{name: "off is satisfied by turnedOff", state: "off", currentState: appservice.TurnedOff, expected: true},
+		{name: "off is satisfied by turningOff", state: "off", currentState: appservice.TurningOff, expected: true},
+		{name: "off is not satisfied by healthy", state: "off", currentState: appservice.Healthy, expected: false},
+		{name: "off is not satisfied by turnOffFailed", state: "off", currentState: appservice.TurnOffFailed, expected: false},
+		{name: "unknown requested state is never satisfied", state: "frozen", currentState: appservice.Healthy, expected: false},
+		{name: "empty current state is never satisfied", state: "on", currentState: "", expected: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, appServiceStateSatisfies(test.state, test.currentState))
+		})
+	}
+}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-142288

## Description

<!-- What does this change do? Why is it needed? -->

Applying `couchbase-capella_app_service_onoff_ondemand` with the activation state the app service is *already* in failed the apply. Capella rejects the redundant transition with a `409`, and `manageAppServiceActivation` surfaced it as a hard error — so the resource was not idempotent, and re-applying an unchanged config was never safe.

This absorbs the two "already in the requested state" codes (`11018` for `on`, `11019` for `off`), the same way `manageClusterActivation` already handles `7010`/`7011` for the cluster resource.

One deliberate difference from the cluster resource: Capella returns `11018` for *every* state that forbids a turn-on, including `degraded`, `turnOnFailed` and `deploying`. A blanket swallow of the code would report a broken app service as a successful apply, so the current state is read back and the error is discarded only when it genuinely satisfies the request — `healthy`/`turningOn` for `on`, `turnedOff`/`turningOff` for `off`. A broken app service still fails the apply.

`retrieveAppServiceOnOff` now shares that state read, which also drops a dead `CurrentState` assignment and its `validateAppserviceStateIsSameInPlanAndState` helper.

**Not a regression.** The activation error handling is unchanged in substance since the resource landed in #181 (later edits were cosmetic: `Client` → `ClientV1` in #404, `fmt.Errorf` → `errors.New` in #423), and the server-side guard predates the resource. What is new is `TestAccAppServiceOnOffOnDemandResource`, added in #740 — the first test to drive `Create` against the shared already-healthy app service, which is what exposed a latent bug. Acceptance tests run only on push-to-`main` and manual dispatch, so #740 merged without a green acceptance run.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [x] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->

New table test `Test_appServiceStateSatisfies` covers both directions, the transitional states, and the failure states that must **not** be absorbed (`degraded`, `turnOnFailed`, `turnOffFailed`):

```
$ go test ./internal/resources/ -run Test_appServiceStateSatisfies -v
=== RUN   Test_appServiceStateSatisfies
--- PASS: Test_appServiceStateSatisfies (0.00s)
    --- PASS: Test_appServiceStateSatisfies/on_is_satisfied_by_healthy (0.00s)
    --- PASS: Test_appServiceStateSatisfies/on_is_satisfied_by_turningOn (0.00s)
    --- PASS: Test_appServiceStateSatisfies/on_is_not_satisfied_by_turnedOff (0.00s)
    --- PASS: Test_appServiceStateSatisfies/on_is_not_satisfied_by_degraded (0.00s)
    --- PASS: Test_appServiceStateSatisfies/on_is_not_satisfied_by_turnOnFailed (0.00s)
    --- PASS: Test_appServiceStateSatisfies/off_is_satisfied_by_turnedOff (0.00s)
    --- PASS: Test_appServiceStateSatisfies/off_is_satisfied_by_turningOff (0.00s)
    --- PASS: Test_appServiceStateSatisfies/off_is_not_satisfied_by_healthy (0.00s)
    --- PASS: Test_appServiceStateSatisfies/off_is_not_satisfied_by_turnOffFailed (0.00s)
    --- PASS: Test_appServiceStateSatisfies/unknown_requested_state_is_never_satisfied (0.00s)
    --- PASS: Test_appServiceStateSatisfies/empty_current_state_is_never_satisfied (0.00s)
PASS
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/resources	3.764s
```

Full package run, plus the repo's standard checks:

```
$ go test ./internal/resources/
ok  	github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/resources	6.848s

$ goimports -w -local github.com/couchbasecloud/terraform-provider-couchbase-capella <changed files>   # clean
$ gofmt -l <changed files>                                                                             # clean
$ go vet ./internal/resources/ ./acceptance_tests/                                                      # clean
$ go build -ldflags "-s -w -X '...ProviderVersion=v1.10.0'" -o ./bin/terraform-provider-couchbase-capella   # ok
```

</details>

## Further comments

`TestAccAppServiceOnOffOnDemandAlreadyInRequestedState` is added in this PR but has **not** been executed — it needs a live Capella org with a healthy app service, and the acceptance suite only runs on push-to-`main` or manual dispatch. It applies `state = "on"` against the already-healthy global app service (the exact case that was failing), then re-plans to assert the plan is empty. The pre-existing `TestAccAppServiceOnOffOnDemandResource` exercises the same path and should go green on the next acceptance run.

Out of scope, flagged for a separate ticket: `Read` echoes the stored `state` back rather than the app service's real state, so an app service turned off outside Terraform still reads as `on`. This PR does not change that behaviour.
