### PR TITLE
[AV-142489] Add tf-change-review skill

### DIFF
--- a/.claude/skills/tf-change-review/SKILL.md
+++ b/.claude/skills/tf-change-review/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: tf-change-review
+description: Review a change to the Couchbase Capella Terraform provider - a PR number, branch, commit range, or the working-tree diff - for regressions, newly introduced bugs, pre-existing bugs the change exposes, and breaking changes that support and SEs need to relay to customers. Then audit acceptance coverage and add what is missing, draft and file AV bug tickets, and fix what is fixable. Use this whenever the user asks to review a PR or a change, asks whether something causes regressions or breaks anything, asks whether a change is covered by tests, or asks about upgrade impact on existing state - including when they only paste a PR URL or say "check this diff".
+---
+
+# Terraform provider change review
+
+You are reviewing a change to the Couchbase Capella Terraform provider as someone
+who knows both Capella and the Terraform plugin framework well. The value you add
+is not restating the diff: it is working out what the change does to practitioners
+who already have state, configuration and pipelines built on the current provider.
+
+Work through the phases below in order. Each phase feeds the next - you cannot
+judge acceptance coverage before you know what the change actually risks.
+
+## Ground rule: ask rather than assume
+
+The whole point of this review is to be trusted, and a confident wrong answer
+costs more than a question. When something material is genuinely ambiguous, stop
+and ask. Things worth asking about, rather than guessing:
+
+- Which change to review, if the user's reference is ambiguous (a branch that has
+  moved, a PR with several revisions, "my change" with a dirty working tree).
+- The intended semantics when the diff is consistent with more than one intent.
+  A `Set` becoming a `List` might be about ordering, about plan output, or about
+  working around a framework bug - the right review differs.
+- Whether a pre-existing bug you uncover is in scope to fix (see Phase 5).
+- The target release or version number for anything version-stamped.
+- Whether to run anything against a live Capella organisation.
+
+Do not ask about things you can determine yourself from the repository. Read the
+code first; ask about intent and scope.
+
+## Phase 1 - Establish exactly what you are reviewing
+
+Getting this wrong invalidates everything downstream, so spend real effort here.
+
+`gh` is often not installed. Fetch a PR by ref instead:
+
+```bash
+git fetch origin "refs/pull/<N>/head:refs/remotes/pr/<N>"
+git merge-base main pr/<N>
+git diff --stat $(git merge-base main pr/<N>) pr/<N>
+```
+
+Then establish three facts that reviewers routinely get wrong:
+
+**Is the change merged, and is it released?** These are different questions with
+different consequences. A change can be on `main` yet absent from the newest tag,
+which decides whether a breaking-change note belongs in an existing upgrade guide
+or a new one:
+
+```bash
+git describe --tags --abbrev=0
+git show <tag>:<changed-file> | head -40      # what practitioners actually have
+git log --oneline <tag>..main -- <changed-file>
+```
+
+**Is there related work in flight?** Other branches may already fix, extend or
+conflict with the change, and duplicating or contradicting a colleague's work
+wastes everyone's time:
+
+```bash
+git fetch origin -q
+git branch -a --contains <commit>
+git branch -r | grep -i "<ticket-id>"
+git log --all --oneline --grep="<ticket-id>"
+```
+
+If you find a related branch, read its version of the changed code. A refactor
+in flight may carry the same defect, which changes your recommendation from
+"fix here" to "fix here and port to that branch".
+
+**What is in the diff?** Follow the repository's own review workflow in
+`CLAUDE.md` - stage the change, list changed Go files, and never read
+`internal/generated/api/openapi.gen.go`; it will consume the context window for
+no benefit.
+
+## Phase 2 - Analyse for regressions and bugs
+
+Read every changed Go file against its `main` counterpart, then reason about
+consequences rather than syntax. Three questions carry most of the signal:
+
+1. **Where does state come from?** Trace `Create`, `Read` and `Update`. An
+   attribute whose state is echoed back from the plan behaves completely
+   differently from one mapped out of the API response - the first cannot drift
+   from configuration but breaks import, the second can produce a perpetual diff
+   if the API reorders or normalises anything. This single distinction explains
+   most database-credential behaviour in this provider.
+
+2. **Does the declared schema still match every place the code reads it?** A
+   type declared one way and read another compiles and vets cleanly, then fails
+   at runtime. This is the highest-severity class of defect in this codebase.
+
+3. **Is `nil` distinguished from empty at every nesting level?** Terraform treats
+   an absent list and an empty list as different values, and a mapping helper
+   that collapses one into the other produces "Provider produced inconsistent
+   result after apply" - an error that aborts the apply.
+
+When the diff touches a schema file, read
+`references/schema-change-analysis.md`. It covers the specific failure modes of
+type changes (Set/List, nesting, optionality), how to verify model compatibility,
+resource/datasource parity, and how to reproduce an ordering effect cheaply.
+
+Then run the repository's verification loop from `CLAUDE.md`: `goimports -w
+-local github.com/couchbasecloud/terraform-provider-couchbase-capella`, `go vet`,
+and the version-stamped `go build`. Report failures with output rather than
+paraphrasing them.
+
+Distinguish clearly, throughout, between three categories, because the right
+response differs for each:
+
+- **Introduced** - the change causes it. Fix it in this change.
+- **Exposed** - pre-existing, but the change makes it reachable or visible.
+- **Adjacent** - pre-existing and untouched, found while reading. Worth a ticket;
+  usually not worth expanding this change to fix.
+
+## Phase 3 - Breaking changes and upgrade impact
+
+This is the phase most reviews skip, and the one support and SEs actually need.
+
+A change that alters how *existing state* is interpreted breaks practitioners who
+change nothing at all. Acceptance tests are structurally blind to it, because
+`terraform-plugin-testing` builds state from scratch with the provider under test
+on every run, so state written by an older version never exists.
+
+Read `references/upgrade-and-breaking-changes.md` when the change touches schema
+types, state mapping, defaults, or anything a practitioner has already persisted.
+It covers the two-tier upgrade harness in `upgrade_tests/`, how to author a
+fixture that actually proves something, and the traps that produce false passes
+and phantom diffs.
+
+For any breaking change, establish and state four things - a diff alone is not
+enough for someone writing customer comms:
+
+- **Who is affected**, concretely: which resources, and which configuration
+  shapes. "Any credential with more than one access block" is useful;
+  "users of database credentials" is not.
+- **What they see**: the actual plan output, quoted.
+- **Whether it is self-healing** - clears after one apply - or permanent. This is
+  the difference between a release note and an emergency.
+- **Whether it can be migrated away.** A state upgrader receives only prior
+  state, so information the old schema never recorded cannot be recovered. Say
+  so plainly when that is the case, rather than implying a fix is possible.
+
+Then write the customer-facing note using the template in that reference. Keep it
+free of framework vocabulary: the reader is a support engineer, not a provider
+developer.
+
+## Phase 4 - Acceptance coverage
+
+Audit before you write. Read `references/acceptance-coverage.md` - it explains
+how to tell real coverage from tests that only look like coverage, which is the
+common case here and the reason this phase exists.
+
+Enumerate every existing test that touches the changed resource or data source,
+then judge each against the change: would this test have failed if the change
+were reverted or made wrong? A test that passes either way is not coverage, and
+saying so is more useful than counting tests.
+
+Write the missing tests with the `tf-acceptance-test-gen` skill so they match the
+repository's conventions. Always verify they compile:
+
+```bash
+go test -c -o /dev/null ./acceptance_tests
+```
+
+Run them against a live cluster only when the user asks. They provision real
+Capella resources and can take an hour, so surprise runs are unwelcome; say
+plainly which assumptions remain unverified until someone does run them.
+
+For a defect you are documenting but not fixing, a test that asserts the correct
+behaviour and is skipped with a ticket reference is far more valuable than no
+test - it is one line from becoming a regression guard:
+
+```go
+t.Skip("AV-12345: <what is wrong>; unskip once <what must change>")
+```
+
+## Phase 5 - Bug tickets
+
+Draft a ticket for each confirmed finding, show them all to the user, and create
+them in the **AV** project via the Atlassian MCP only after the user approves.
+Filing is outward-facing and lands in someone's triage queue, so a misjudged
+finding has a real cost.
+
+Each draft needs: a summary naming the symptom; affected versions (use the
+merged-versus-released facts from Phase 1); a minimal reproducing configuration;
+the root cause with `file:line`; expected versus actual behaviour, quoting real
+output where you have it; and whether it is introduced, exposed or adjacent.
+
+Verify a finding before drafting a ticket for it. Reproducing it - a scratch
+test, a plan against a fixture, a live run - is worth the effort, both because
+unverified tickets erode trust and because the reproduction usually sharpens the
+root cause. Say explicitly when something is reasoned but unreproduced.
+
+## Phase 6 - Fixes
+
+Present each bug with its proposed fix and let the user decide, one at a time.
+Regressions the change introduced are usually clear-cut; pre-existing bugs expand
+the scope of someone's PR, which is their call and not yours.
+
+Use the `tf-bugfix` skill for approved fixes so root-cause analysis and test
+naming follow the repository's conventions, including the
+`TestAcc<Feature>_AV_XXXXX` test name format.
+
+Keep fixes minimal and structural. When a mapping helper mishandles one branch,
+fix that branch rather than rewriting the helper - a reviewer comparing against
+the reported bug should see the correspondence immediately.
+
+If you experiment on the source to isolate a cause, restore it and prove you did:
+
+```bash
+git diff --quiet <file> && echo "restored"
+```
+
+## Report
+
+Lead with the verdict, then detail. Someone should be able to read the first two
+sections and know whether the change is safe to merge.
+
+```markdown
+## Verdict
+<Ship / ship with notes / do not ship, and the single reason why>
+
+## What the change does
+<2-4 sentences: mechanism, not a diff restatement>
+
+## Regressions and bugs
+<Per finding: introduced | exposed | adjacent; severity; file:line;
+ what breaks and for whom; verified how>
+
+## Breaking changes - for customer, support and SE comms
+<The customer-facing note. Omit this section entirely if there are none.>
+
+## Acceptance coverage
+<What exists, what it actually guards, what does not guard anything and why,
+ what was added>
+
+## Tickets
+<Drafted / created, with keys>
+
+## Fixes
+<Applied, with files; and what was deliberately left alone>
+
+## Unverified
+<Anything reasoned but not reproduced, and what would settle it>
+```
+
+An empty findings section is a good outcome, not a failure - say so directly
+rather than inflating minor observations to fill the template. Equally, do not
+soften a real breaking change: someone downstream is going to have to explain it
+to a customer, and they need it stated plainly.

--- a/.claude/skills/tf-change-review/references/acceptance-coverage.md
+++ b/.claude/skills/tf-change-review/references/acceptance-coverage.md
@@ -1,0 +1,158 @@
+# Auditing and extending acceptance coverage
+
+Read this in the coverage phase. The reason it exists: in this repository it is
+common for tests to *look* like coverage for a change while guarding nothing at
+all. Counting tests is misleading; the useful question is always the same.
+
+> Would this test have failed if the change were reverted, or made wrong?
+
+If the answer is no, the test is not coverage for this change - and reporting
+that honestly is more valuable than a reassuring test count.
+
+## Audit first
+
+Find everything that exercises the changed resource or data source, including
+tests that only use it as a fixture for something else:
+
+```bash
+grep -rln "<resource_type_name>" acceptance_tests/
+grep -rn -A6 "resource \"couchbase-capella_<name>\"" acceptance_tests/
+```
+
+Read the configurations, not just the test names. Then check each against the
+change. Two patterns account for most false coverage:
+
+**The configuration never reaches the changed code.** Attributes that are always
+omitted mean the changed branch is never executed. Before AV-139841, every
+database-credential test used `access = [{ privileges = ["data_writer"] }]` and
+no test anywhere set `resources`, so the entire bucket/scope/collection mapping
+path - the thing the change was about - had no coverage.
+
+Check the *examples* directory too. Deeper shapes often exist there
+(`examples/*/terraform.template.tfvars`), which is easy to mistake for coverage,
+but examples are not executed by CI.
+
+**The assertion cannot distinguish the old behaviour from the new.** See below;
+this one is subtle enough that experienced reviewers miss it.
+
+## Set and List assertions look identical
+
+`terraform-plugin-testing` flattens tuples, lists and sets alike by numeric
+index - one branch handles all three in
+`internal/configs/hcl2shim/flatmap.go`. So `access.0.privileges.0` is a valid
+address whether the attribute is a `Set` or a `List`, and an assertion on it
+passes under both.
+
+That has a consequence worth internalising: **a positional assertion only proves
+ordering if the configured order differs from the canonical order.** If a test
+lists `["default", "metadata"]` or `["_default", "col_a", "col_b"]` - already
+alphabetical - then `buckets.0.name` holds the same value under a Set as under a
+List, and the test cannot detect a reversion.
+
+So when writing ordering tests, choose values whose configured order is
+deliberately *not* the sorted order, and say why in a comment so the next person
+does not "tidy" them.
+
+`randomStringWithPrefix` cannot help here: its suffix is random, so the relative
+order of two generated names is unknown. Generate a shared random suffix with a
+deterministic ordering infix instead:
+
+```go
+// Two names sharing a random suffix but sorting a-before-z, so callers can
+// configure them in a known non-canonical order.
+func orderedFixtureNames(prefix string) (a, z string) {
+    suffix := randomString()
+    return prefix + "a_" + suffix, prefix + "z_" + suffix
+}
+```
+
+For fixture values you do not control - the shared bucket names, say - compare at
+runtime and order them so the first sorts after the second, rather than
+hard-coding an assumption about what they are called.
+
+## Choose assertions that match the declared type
+
+Positional assertions are right for a `List`. For an attribute that is genuinely
+a `Set`, order is not meaningful, so assert membership instead - a positional
+assertion there is a latent flake:
+
+```go
+resource.TestCheckResourceAttr(ref, "access.0.privileges.#", "2"),
+resource.TestCheckTypeSetElemAttr(ref, "access.0.privileges.*", "data_reader"),
+resource.TestCheckTypeSetElemAttr(ref, "access.0.privileges.*", "data_writer"),
+```
+
+Mixed nesting is common in this provider - a `Set` inside a `List` - so check the
+schema for each attribute you assert on rather than applying one style
+throughout.
+
+## Import needs `ImportStateVerify`
+
+`ImportState: true` alone only proves the import ID parses and the import does
+not error. It does not prove the resource round-trips. An import that succeeds
+and silently returns an empty attribute passes such a step.
+
+Only `ImportStateVerify: true` compares state before and after import. Most
+import steps in this repository do not set it, so "import silently loses data" is
+invisible across much of the provider - worth flagging when the change touches an
+attribute that import should carry.
+
+```go
+{
+    ResourceName:            resourceReference,
+    ImportStateIdFunc:       generate<Feature>ImportIdForResource(resourceReference),
+    ImportState:             true,
+    ImportStateVerify:       true,
+    ImportStateVerifyIgnore: []string{"password"}, // never returned by GET
+}
+```
+
+Read the resource's `ImportState` for the composite ID format; several resources
+here take a comma-separated key such as
+`id=...,cluster_id=...,project_id=...,organization_id=...`.
+
+## Steps come with a free idempotency check
+
+Each `TestStep` runs a plan after its apply and fails on a non-empty plan unless
+`ExpectNonEmptyPlan` is set. Every step therefore already asserts idempotency -
+so a perpetual diff is caught without writing anything extra, and a second step
+repeating the same configuration adds little. Spend the extra step on a real
+transition instead: reorder a list, cross a `nil`-to-empty boundary, narrow a
+grant from bucket to scope to collection.
+
+## Assert full state after an update
+
+An update step that checks only the field that changed will not notice that
+updating field A silently reset field B. Assert the whole shape after each
+update; this is where mapping helpers with mirrored gaps get caught.
+
+## Writing the tests
+
+Use the `tf-acceptance-test-gen` skill so structure, naming and helper usage match
+the repository. For tests attached to a specific bug, `tf-bugfix` sets the naming
+convention `TestAcc<Feature>_AV_XXXXX`.
+
+Verify compilation always - it is fast and catches most mistakes:
+
+```bash
+go test -c -o /dev/null ./acceptance_tests
+```
+
+Run against a live cluster only when asked. When you have not run them, list the
+assumptions that remain unverified - whether the API accepts an empty nested
+list, whether it tolerates duplicate entries, what shape a GET actually returns -
+so nobody mistakes "compiles" for "passes".
+
+## Documenting a defect you are not fixing
+
+A test that asserts the correct behaviour and is skipped with a ticket reference
+is one line away from becoming a regression guard, and it keeps the suite green
+meanwhile. The convention here:
+
+```go
+t.Skip("AV-12345: <what is wrong today>; unskip once <what must change>")
+```
+
+Write the assertions for the *fixed* behaviour, not the buggy behaviour. A test
+that pins a bug in place has to be rewritten when the bug is fixed, which is
+exactly when nobody wants to be reinterpreting it.

--- a/.claude/skills/tf-change-review/references/schema-change-analysis.md
+++ b/.claude/skills/tf-change-review/references/schema-change-analysis.md
@@ -1,0 +1,165 @@
+# Analysing a schema change
+
+Read this when a diff touches a `*_schema.go` file, a model struct in
+`internal/schema/`, or the mapping helpers between them. Schema changes are the
+highest-risk category in this provider because they alter how *existing* state is
+interpreted, and because several of their failure modes compile and vet cleanly.
+
+## 1. Does the Go model still match the declared type?
+
+Framework reflection is more permissive than people expect, which is why this is
+worth checking explicitly rather than assuming.
+
+| Model field | `SetNestedAttribute` | `ListNestedAttribute` |
+|---|---|---|
+| `[]Access` (plain slice) | works | works |
+| `types.Set` | works | **breaks** |
+| `types.List` | **breaks** | works |
+
+So a Set to List change is invisible to the compiler when the model uses plain
+slices - which is the common style in `internal/schema/`. A clean `go build` says
+nothing about whether the change is safe.
+
+## 2. Does every read of the attribute agree with the declaration?
+
+This is the failure mode that hurts most, so hunt for it deliberately. If the
+schema declares a `List` while some code path reads the same attribute into a
+`types.Set` (or the reverse), the provider builds and vets cleanly and then fails
+**every plan** with a framework `Value Conversion Error` - including for
+configurations that never touch the changed nesting.
+
+Search every path that reads the attribute, not just CRUD:
+
+```bash
+grep -rn "ValidateConfig\|ModifyPlan\|planmodifier\|types.Set\|types.List" \
+  internal/resources/<resource>.go internal/schema/<model>.go
+```
+
+`ValidateConfig` and `ModifyPlan` are the usual offenders because they are easy
+to forget - they are not part of the Create/Read/Update/Delete path a reviewer
+naturally traces. This is real: AV-139978 was exactly this, an `access` attribute
+declared `ListNestedAttribute` while `ValidateConfig` read it into a `types.Set`.
+
+## 3. Are the resource and data source still consistent?
+
+The same conceptual attribute is often declared twice - once in
+`internal/resources/` and once in `internal/datasources/` - and they drift. Drift
+is not always a bug, but it is always worth reporting, because practitioners
+reasonably expect `privileges` to behave the same in both places and the
+generated docs will contradict each other.
+
+Compare them side by side and check the generated docs agree:
+
+```bash
+grep -n "Attributes List\|Attributes Set\|List of String\|Set of String" \
+  docs/resources/<name>.md docs/data-sources/<name>s.md
+```
+
+## 4. Where does the attribute's state come from?
+
+Trace this before reasoning about diffs - it determines which risks apply at all.
+
+**Echoed from plan/state.** `Read` rebuilds the attribute from prior state rather
+than the API response. Consequences: configuration order is preserved, so no
+API-driven perpetual diff is possible - but `import` cannot populate the
+attribute at all, because an imported resource has no prior state. It lands empty.
+
+**Mapped from the API response.** Consequences: import works, but any server-side
+reordering or normalisation shows up as a permanent diff. Once an attribute is a
+`List`, order is significant, so this becomes a real risk where it was harmless
+under a `Set`.
+
+Changing an attribute from Set to List while `Read` maps from the API is the
+dangerous combination. Verify the API actually preserves order before accepting
+it; do not assume either way.
+
+## 5. Is `nil` distinguished from empty at every level?
+
+Terraform treats an absent list and an empty list as different values. A mapping
+helper that collapses one into the other makes the applied state differ from the
+plan, and Terraform aborts with:
+
+```
+Provider produced inconsistent result after apply
+```
+
+The bug hides in nested guards. This shape looks careful but drops a level:
+
+```go
+if acc.Resources != nil {
+    if acc.Resources.Buckets != nil {          // Resources stays nil when
+        access[i].Resources = &Resources{...}  // Buckets is nil
+    }
+}
+```
+
+Given `resources = {}` in configuration, the plan holds
+`resources = {buckets = null}` while the applied state holds `resources = null`.
+Walk each nesting level and ask what happens when the outer value is present and
+the inner one is absent. Fix by assigning the container first, then filling it:
+
+```go
+if acc.Resources == nil {
+    continue
+}
+access[i].Resources = &Resources{}   // present, even with no buckets
+if acc.Resources.Buckets == nil {
+    continue
+}
+```
+
+Check the request-building helper too. The two directions usually have mirrored
+gaps, and fixing only the state side leaves the API receiving nothing.
+
+## 6. Ordering: what a Set/List change actually does
+
+`cty` stores set elements in canonical order, not configuration order. A `List`
+preserves configuration order. So the same configuration produces different
+state depending on which type the attribute has - and existing state written by
+the old provider disagrees with the new schema's reading of it.
+
+Confirm this cheaply rather than asserting it. A throwaway test in the repo makes
+it concrete in seconds:
+
+```go
+vals := []cty.Value{cty.StringVal("orders"), cty.StringVal("customers")}
+setJSON, _ := ctyjson.Marshal(cty.SetVal(vals), cty.Set(cty.String))
+listJSON, _ := ctyjson.Marshal(cty.ListVal(vals), cty.List(cty.String))
+// set:  ["customers","orders"]   <- reordered
+// list: ["orders","customers"]
+```
+
+Delete the scratch file afterwards.
+
+Two consequences worth reporting separately:
+
+- **Existing state disagrees with configuration** after the upgrade. Covered in
+  `upgrade-and-breaking-changes.md`.
+- **Duplicates are no longer collapsed.** A `Set` deduplicated identical elements
+  silently; a `List` keeps them and sends them to the API. Usually more correct,
+  occasionally a new API error.
+
+## 7. Optionality and validator changes
+
+`Required` becoming `Optional`, or a new `SizeAtLeast`/`ExactlyOneOf`, changes
+which configurations are accepted. Loosening is safe; tightening rejects
+configurations that used to apply, which is a breaking change even though nothing
+about state changed. Check whether any shipped example or acceptance test uses a
+configuration the new validators would now reject.
+
+## Isolating a cause when behaviour is puzzling
+
+Two techniques that save a lot of time:
+
+**Compare against a structurally simpler resource.** If a hand-written fixture
+behaves oddly, build the same fixture for a resource with no nesting (for example
+`couchbase-capella_project`). If that one behaves correctly, the method is sound
+and the cause is in the resource under review; if both misbehave, the fault is in
+your harness. This separates two explanations that otherwise take hours to tease
+apart.
+
+**Do not null a Computed attribute to test whether it matters.** The framework
+marks a null Computed attribute as unknown, which is itself a change. The
+experiment then reports a diff caused by the experiment rather than by the thing
+being tested. Set it to a concrete value in both configuration and state instead,
+or bisect by toggling schema flags and rebuilding.

--- a/.claude/skills/tf-change-review/references/upgrade-and-breaking-changes.md
+++ b/.claude/skills/tf-change-review/references/upgrade-and-breaking-changes.md
@@ -1,0 +1,163 @@
+# Upgrade impact and breaking changes
+
+Read this when a change touches schema types, state mapping, defaults, validators
+or anything else a practitioner has already persisted.
+
+The population at risk is people who upgrade the provider and change *nothing
+else*. They are invisible to acceptance tests, because
+`terraform-plugin-testing` creates state from scratch with the provider under
+test on every run - state written by an older version never exists in that
+harness. `upgrade_tests/` exists to close exactly this gap; read its README for
+the full mechanics.
+
+## Two tiers
+
+**`upgrade_tests/upgrade_test.go`** - offline, a few seconds, no credentials and
+no network. Builds the working tree, serves it through a Terraform filesystem
+mirror as a synthetic version, and runs `terraform plan -refresh=false
+-detailed-exitcode` against a checked-in state fixture. Exit `0` means no
+changes, `2` means a diff. Cheap enough to gate every change, and it is what
+proves an ordering or state-interpretation break.
+
+This works without credentials because the provider's `Configure` only reads
+configuration and environment variables before constructing an HTTP client, so a
+placeholder token reaches the plan phase, and `-refresh=false` skips the only
+step that would call the API.
+
+**`upgrade_tests/upgrade-check.sh`** - end-to-end against a live organisation.
+Installs a released version from the registry, applies, swaps in the working
+tree, re-plans, and on a diff applies once more to report whether the diff is
+self-healing or permanent. This is the only tier that can see an API
+response-shape change or server-side normalisation. Recommend it when the finding
+depends on real API behaviour; do not run it without asking.
+
+```bash
+FROM_VERSION=<last release with the OLD behaviour> \
+TF_VAR_host=... TF_VAR_auth_token=... TF_VAR_organization_id=... \
+TF_VAR_project_id=... TF_VAR_cluster_id=... TF_VAR_bucket_name=... \
+upgrade_tests/upgrade-check.sh
+```
+
+`FROM_VERSION` must be a release that actually has the old behaviour. Confirm
+with `git show <tag>:<file>` rather than assuming the newest tag predates the
+change - a change on `main` is often not in the newest tag.
+
+## Adding a fixture
+
+Add a directory under `upgrade_tests/testdata/` with `main.tf` and
+`terraform.tfstate`, and register it in the `fixtures` table with
+`expectEmptyPlan` and a `reason`. A fixture expecting a diff records a known,
+accepted break; its `reason` has to say why, so the next reader can tell a
+deliberate decision from a bug.
+
+Add both kinds when you can. A fixture in the *new* shape expecting a clean plan
+is the forward-looking guard; a fixture in the *old* shape recording the break is
+the documentation. Together they also prove the harness can distinguish the two -
+a harness that only ever reports diffs is worthless.
+
+The most reliable fixture is a captured one: apply with the released provider,
+copy the resulting `terraform.tfstate`, then edit `terraform_version` down to
+something old, because a state claiming a version newer than the running CLI is
+rejected outright.
+
+### Put every list in non-canonical order
+
+This is the whole point of the fixture and the easiest thing to get wrong.
+Because `cty` stores sets canonically, a fixture whose lists happen to be sorted
+already will produce identical state under both Set and List - so its assertions
+pass either way and it guards nothing. Order elements so configuration order and
+sorted order differ, and say so in a comment.
+
+### `sensitive_attributes` is not optional
+
+Terraform records each schema-sensitive attribute in the instance:
+
+```json
+"sensitive_attributes": [[{ "type": "get_attr", "value": "password" }]]
+```
+
+Omit it and the prior value carries no sensitive mark while the planned value
+does. The values are identical but the marks are not, so Terraform plans an
+in-place update and renders it with **no changed attributes** - a phantom diff
+that looks exactly like a provider bug and will send you hunting in the wrong
+place. Any resource with a `Sensitive` attribute needs this line.
+
+### Do not commit `.terraform/` or `.terraform.lock.hcl`
+
+The lock file records a checksum of the provider binary, and the binary is
+rebuilt on every run, so a committed lock makes `init` fail with "the cached
+package ... does not match any of the checksums recorded in the dependency lock
+file". The driver copies only regular files into a fresh temp directory, which
+keeps this out of the fixtures.
+
+Note also that `.gitignore` excludes `terraform.tfstate` repo-wide, with a
+negation for `upgrade_tests/testdata/**/terraform.tfstate`. A fixture placed
+outside that path is silently untracked - and an untracked fixture means a
+harness that passes locally and is broken for everyone else.
+
+## The `dev_overrides` trap
+
+Most contributors have a `dev_overrides` block in `~/.terraformrc` pointing at a
+local build - it is the normal way to develop against the working tree. It makes
+Terraform run that binary regardless of which version it just downloaded, and
+Terraform reports "Installed v1.9.1" while running your local code.
+
+In an upgrade check this silently turns the released-version phase into a second
+run of the working tree, and the comparison passes for the wrong reason. A false
+pass is worse than a failure because nobody investigates it.
+
+Both tiers set `TF_CLI_CONFIG_FILE` on every invocation, which *replaces* the
+user's config rather than merging with it. If you write any new Terraform-driving
+check, do the same.
+
+`terraform version` will not warn you: it reports the version selected in the
+lock file even while `dev_overrides` substitutes a different binary. The only
+reliable signal is the `Provider development overrides are in effect` warning.
+Treat it as fatal.
+
+## Characterising the break
+
+Four things, because a diff alone is not enough for someone writing customer
+communications:
+
+- **Who is affected**, in configuration terms. "Any credential with more than one
+  access block, or more than one collection listed in a non-alphabetical order"
+  tells a support engineer whether a given customer is at risk. "Users of
+  database credentials" does not.
+- **What they see** - the real plan output, quoted.
+- **Self-healing or permanent.** Apply once and re-plan. If it clears, this is a
+  release note; if it persists, it is an emergency.
+- **Whether it can be migrated away.** A state upgrader receives only prior
+  state. Information the old schema never recorded - such as the order the
+  practitioner wrote elements in, when canonical order overwrote it - cannot be
+  recovered, so no upgrader can fix it. Say that plainly instead of leaving the
+  impression that a migration is merely unimplemented.
+
+## Customer-facing note
+
+Write it for a support engineer, not a provider developer. No framework
+vocabulary - no `cty`, no `SetNestedAttribute`, no "plan merge".
+
+```markdown
+### <Resource>: first plan after upgrading to <version> may show changes
+
+**Who is affected:** <concrete configuration shapes>
+
+**What you see:** on the first `terraform plan` after upgrading, <resource> shows
+an in-place update even though nothing in the configuration changed. <Quote the
+shape of the diff.>
+
+**Why:** <one or two sentences, no framework jargon>
+
+**What to do:** <the action - typically: review the plan, confirm it only
+reorders, and apply once. State that the diff clears after a single apply and
+that no Capella-side change occurs.>
+
+**Is anything at risk?** <Say plainly whether permissions, data or availability
+are affected. If nothing is, say nothing is.>
+```
+
+Version-stamped artefacts need the target release number, which you generally
+cannot infer - ask. Note that upgrade guides in `docs/guides/` appear to be
+produced by `scripts/generate-upgrade-guide.sh`, so check that before
+hand-writing one.


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-142489

## Description

Reviewing a provider change well needs knowledge that currently lives only in people's heads, and the AV-139841 episode showed the cost. That change was reviewed, merged, released in v1.11.0 and reverted in v1.11.1. Along the way it produced a shipped breaking change, a follow-on defect where `ValidateConfig` read `access` into a `types.Set` while the schema declared a `List` (which failed *every* plan with a framework `Value Conversion Error`), and acceptance tests that looked like coverage but could not have detected a reversion.

None of that is visible in a diff. All of it is findable with a repeatable method.

`tf-change-review` takes a PR number, branch, commit range or the working-tree diff and works through six phases: establish exactly what is under review; analyse for regressions and bugs; assess breaking changes and upgrade impact; audit and extend acceptance coverage; draft bug tickets; then fix what is approved. It composes with the existing `tf-acceptance-test-gen` and `tf-bugfix` skills rather than restating them.

Findings are classified as **introduced**, **exposed** or **adjacent**, because the right response differs for each and conflating them is how a PR's scope quietly triples.

`SKILL.md` holds the workflow. Three reference files load only when relevant, so a change touching no schema does not pull in schema-specific material.

Markdown only — no provider code, no build or runtime impact.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [x] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

The skill is documentation, so verification was structural plus a real end-to-end application of the method.

**Structural checks:** YAML frontmatter parses; all three `references/` cross-references from `SKILL.md` resolve; both sibling skills it delegates to (`tf-acceptance-test-gen`, `tf-bugfix`) exist; every repository path it cites exists (`upgrade_tests/`, `CLAUDE.md`, `acceptance_tests/`, `scripts/generate-upgrade-guide.sh`); the skill registers and is invocable as `/tf-change-review`.

**Factual claims re-verified against the pinned dependency**, rather than taken from memory — for example that `terraform-plugin-testing` flattens tuples, lists and sets in a single branch of `internal/configs/hcl2shim/flatmap.go`, which is what makes a positional assertion type-agnostic.

**The method itself was applied end to end before being written down.** Reviewing #749 with it produced AV-142487 (a real defect, reproduced on a live cluster), AV-142488 (the upgrade harness), a confirmed characterisation of the v1.11.0 breaking change, and the finding that two unmerged branches carried the same defect. The skill documents the path that actually worked, including the mistakes — I initially conflated "merged" with "released", which is now a required check in phase 1.

</details>

## Further comments

The references deliberately explain the reasoning rather than just stating rules, so they generalise beyond the cases that produced them. Highlights:

* A positional assertion such as `access.0.privileges.0` passes under both `Set` and `List`, so it proves ordering **only** when the configured order differs from the canonical order. This is why several existing database credential tests cannot detect a `Set`/`List` reversion.
* A schema type declared one way and read another compiles and vets cleanly, then fails at runtime. `ValidateConfig` and `ModifyPlan` are the usual offenders because they sit outside the CRUD path a reviewer naturally traces.
* Whether `Read` echoes prior state or maps from the API response determines whether import breaks or a perpetual diff is possible — one distinction that explains most database credential behaviour.
* Two debugging techniques: compare against a structurally simpler resource to separate a broken harness from a genuinely odd schema, and never null a `Computed` attribute while bisecting, since the framework marks it unknown and the experiment then reports its own diff.

Behaviour was settled before writing: tickets are drafted and shown before being filed in AV; pre-existing bugs are raised individually rather than fixed silently; upgrade fixtures are added whenever state interpretation changes, while the live script is only ever offered; and acceptance tests are always compiled but run against a cluster only on request. A standing instruction to ask rather than assume opens the skill, with guidance on which questions are worth interrupting for.

**Not done:** the skill-creator eval loop, which measures triggering accuracy with paired with-skill and baseline runs, has not been run — the description's trigger quality is reasoned rather than measured. Worth doing if the skill sees real use and under- or over-triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
