### PR TITLE
[AV-139981] Stop new credential_type forcing database credential replacement on upgrade

### DIFF
--- a/internal/resources/attributes.go
+++ b/internal/resources/attributes.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"context"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
@@ -32,6 +33,7 @@ const (
 	sensitive                   = "sensitive"
 	requiresReplace             = "requiresReplace"
 	requiresReplaceIfConfigured = "requiresReplaceIfConfigured"
+	requiresReplaceOnChange     = "requiresReplaceOnChange"
 	useStateForUnknown          = "useStateForUnknown"
 	deprecated                  = "deprecated"
 	deprecationMessage          = "Remove this attribute's configuration as it no longer in use and the attribute will be removed in the next major version of the provider."
@@ -67,6 +69,11 @@ func stringAttribute(fields []string, validators ...validator.String) *schema.St
 				stringplanmodifier.RequiresReplaceIfConfigured(),
 			}
 			attribute.PlanModifiers = append(attribute.PlanModifiers, planModifiers...)
+		case requiresReplaceOnChange:
+			var planModifiers = []planmodifier.String{
+				requiresReplaceOnKnownChange(),
+			}
+			attribute.PlanModifiers = append(attribute.PlanModifiers, planModifiers...)
 		case useStateForUnknown:
 			var planModifiers = []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
@@ -77,6 +84,26 @@ func stringAttribute(fields []string, validators ...validator.String) *schema.St
 		}
 	}
 	return &attribute
+}
+
+// requiresReplaceOnKnownChange requests replacement only when a known prior value changes.
+// A null prior state means the attribute was absent from the state file because it was
+// added to the schema after that state was written, so a Default supplying a value is a
+// backfill on provider upgrade rather than a practitioner-driven change. Plain
+// RequiresReplace cannot tell the two apart and destroys every existing resource on the
+// first plan after the upgrade (AV-139981). RequiresReplaceIf's own guards already cover
+// create, destroy and an unchanged value, so only the null prior state has to be excluded
+// here.
+func requiresReplaceOnKnownChange() planmodifier.String {
+	const description = "Replaces the resource when a known prior value changes."
+
+	return stringplanmodifier.RequiresReplaceIf(
+		func(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+			resp.RequiresReplace = !req.StateValue.IsNull()
+		},
+		description,
+		description,
+	)
 }
 
 // stringDefaultAttribute sets the default values for a string field and returns the string attribute.

--- a/internal/resources/attributes.go
+++ b/internal/resources/attributes.go
@@ -88,25 +88,17 @@ func stringDefaultAttribute(defaultValue string, fields ...string) *schema.Strin
 }
 
 // stringDefaultAttributeReplaceOnChange returns a defaulted string attribute that requires
-// replacement only when its value genuinely changes. Use it in place of the requiresReplace
-// field wherever a Default and RequiresReplace are combined.
+// replacement only on a genuine change. Use it wherever a Default and RequiresReplace combine.
 func stringDefaultAttributeReplaceOnChange(defaultValue string, fields ...string) *schema.StringAttribute {
 	attribute := stringDefaultAttribute(defaultValue, fields...)
 	attribute.PlanModifiers = append(attribute.PlanModifiers, requiresReplaceOnKnownChange(defaultValue))
 	return attribute
 }
 
-// requiresReplaceOnKnownChange requests replacement when the planned value differs from the
-// prior one, treating an absent prior value as implicitPriorValue.
-//
-// A state file written before the attribute existed holds no value for it, so it decodes as
-// null and the Default backfills it on the first plan after a provider upgrade. Plain
-// RequiresReplace reads that backfill as a change and destroys every existing resource
-// (AV-139981). Excluding a null prior state outright is not enough: the practitioner may set
-// a different value in the same plan that upgrades the provider, which is a real change and
-// must still replace. Comparing against implicitPriorValue distinguishes the two.
-//
-// RequiresReplaceIf's own guards already cover create, destroy and an unchanged value.
+// requiresReplaceOnKnownChange requires replacement when the planned value differs from the
+// prior one, treating an absent prior value as implicitPriorValue. Plain RequiresReplace
+// instead reads the Default backfilling a state file written before the attribute existed as
+// a change, and destroys every existing resource on the first plan after an upgrade (AV-139981).
 func requiresReplaceOnKnownChange(implicitPriorValue string) planmodifier.String {
 	const description = "Replaces the resource when the value changes, treating an absent prior value as the default."
 

--- a/internal/resources/attributes.go
+++ b/internal/resources/attributes.go
@@ -33,7 +33,6 @@ const (
 	sensitive                   = "sensitive"
 	requiresReplace             = "requiresReplace"
 	requiresReplaceIfConfigured = "requiresReplaceIfConfigured"
-	requiresReplaceOnChange     = "requiresReplaceOnChange"
 	useStateForUnknown          = "useStateForUnknown"
 	deprecated                  = "deprecated"
 	deprecationMessage          = "Remove this attribute's configuration as it no longer in use and the attribute will be removed in the next major version of the provider."
@@ -69,11 +68,6 @@ func stringAttribute(fields []string, validators ...validator.String) *schema.St
 				stringplanmodifier.RequiresReplaceIfConfigured(),
 			}
 			attribute.PlanModifiers = append(attribute.PlanModifiers, planModifiers...)
-		case requiresReplaceOnChange:
-			var planModifiers = []planmodifier.String{
-				requiresReplaceOnKnownChange(),
-			}
-			attribute.PlanModifiers = append(attribute.PlanModifiers, planModifiers...)
 		case useStateForUnknown:
 			var planModifiers = []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
@@ -86,31 +80,47 @@ func stringAttribute(fields []string, validators ...validator.String) *schema.St
 	return &attribute
 }
 
-// requiresReplaceOnKnownChange requests replacement only when a known prior value changes.
-// A null prior state means the attribute was absent from the state file because it was
-// added to the schema after that state was written, so a Default supplying a value is a
-// backfill on provider upgrade rather than a practitioner-driven change. Plain
-// RequiresReplace cannot tell the two apart and destroys every existing resource on the
-// first plan after the upgrade (AV-139981). RequiresReplaceIf's own guards already cover
-// create, destroy and an unchanged value, so only the null prior state has to be excluded
-// here.
-func requiresReplaceOnKnownChange() planmodifier.String {
-	const description = "Replaces the resource when a known prior value changes."
-
-	return stringplanmodifier.RequiresReplaceIf(
-		func(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
-			resp.RequiresReplace = !req.StateValue.IsNull()
-		},
-		description,
-		description,
-	)
-}
-
 // stringDefaultAttribute sets the default values for a string field and returns the string attribute.
 func stringDefaultAttribute(defaultValue string, fields ...string) *schema.StringAttribute {
 	attribute := stringAttribute(fields)
 	attribute.Default = stringdefault.StaticString(defaultValue)
 	return attribute
+}
+
+// stringDefaultAttributeReplaceOnChange returns a defaulted string attribute that requires
+// replacement only when its value genuinely changes. Use it in place of the requiresReplace
+// field wherever a Default and RequiresReplace are combined.
+func stringDefaultAttributeReplaceOnChange(defaultValue string, fields ...string) *schema.StringAttribute {
+	attribute := stringDefaultAttribute(defaultValue, fields...)
+	attribute.PlanModifiers = append(attribute.PlanModifiers, requiresReplaceOnKnownChange(defaultValue))
+	return attribute
+}
+
+// requiresReplaceOnKnownChange requests replacement when the planned value differs from the
+// prior one, treating an absent prior value as implicitPriorValue.
+//
+// A state file written before the attribute existed holds no value for it, so it decodes as
+// null and the Default backfills it on the first plan after a provider upgrade. Plain
+// RequiresReplace reads that backfill as a change and destroys every existing resource
+// (AV-139981). Excluding a null prior state outright is not enough: the practitioner may set
+// a different value in the same plan that upgrades the provider, which is a real change and
+// must still replace. Comparing against implicitPriorValue distinguishes the two.
+//
+// RequiresReplaceIf's own guards already cover create, destroy and an unchanged value.
+func requiresReplaceOnKnownChange(implicitPriorValue string) planmodifier.String {
+	const description = "Replaces the resource when the value changes, treating an absent prior value as the default."
+
+	return stringplanmodifier.RequiresReplaceIf(
+		func(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+			priorValue := req.StateValue
+			if priorValue.IsNull() {
+				priorValue = types.StringValue(implicitPriorValue)
+			}
+			resp.RequiresReplace = !req.PlanValue.Equal(priorValue)
+		},
+		description,
+		description,
+	)
 }
 
 // requiredUUIDStringAttribute is intended for adding a required string attribute with requires replace set for hierarchical Capella resource UUIDs

--- a/internal/resources/database_credential_schema.go
+++ b/internal/resources/database_credential_schema.go
@@ -30,7 +30,7 @@ func DatabaseCredentialSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "name", databaseCredentialBuilder, stringAttribute([]string{required, requiresReplace}))
 	capellaschema.AddAttr(attrs, "password", databaseCredentialBuilder, stringAttribute([]string{optional, computed, sensitive, useStateForUnknown}))
 
-	credentialTypeAttr := stringDefaultAttribute(credentialTypeBasic, optional, computed, requiresReplace)
+	credentialTypeAttr := stringDefaultAttribute(credentialTypeBasic, optional, computed, requiresReplaceOnChange)
 	// The OneOf validator is attached manually because the published OpenAPI spec
 	// does not yet include credentialType; it can be removed once the spec is
 	// published and `make gen-enums` regenerates the enum table.

--- a/internal/resources/database_credential_schema.go
+++ b/internal/resources/database_credential_schema.go
@@ -30,7 +30,7 @@ func DatabaseCredentialSchema() schema.Schema {
 	capellaschema.AddAttr(attrs, "name", databaseCredentialBuilder, stringAttribute([]string{required, requiresReplace}))
 	capellaschema.AddAttr(attrs, "password", databaseCredentialBuilder, stringAttribute([]string{optional, computed, sensitive, useStateForUnknown}))
 
-	credentialTypeAttr := stringDefaultAttribute(credentialTypeBasic, optional, computed, requiresReplaceOnChange)
+	credentialTypeAttr := stringDefaultAttributeReplaceOnChange(credentialTypeBasic, optional, computed)
 	// The OneOf validator is attached manually because the published OpenAPI spec
 	// does not yet include credentialType; it can be removed once the spec is
 	// published and `make gen-enums` regenerates the enum table.

--- a/internal/resources/database_credential_test.go
+++ b/internal/resources/database_credential_test.go
@@ -220,6 +220,11 @@ func assertNoDiags(t *testing.T, diags diag.Diagnostics) {
 // then plans "basic" against that null. Under a plain RequiresReplace this destroyed and
 // recreated every existing credential on the first plan after the upgrade, regenerating
 // the auto-generated passwords applications were holding (AV-139981).
+//
+// A null prior state is not on its own proof of a backfill, so the legacy cases below pin
+// both readings of one: the practitioner may convert the credential in the same plan that
+// upgrades the provider, and may equally pin the default explicitly. Only the planned value
+// separates them.
 func TestDatabaseCredentialTypeReplacement(t *testing.T) {
 	ctx := context.Background()
 	credentialSchema := DatabaseCredentialSchema()
@@ -255,6 +260,26 @@ func TestDatabaseCredentialTypeReplacement(t *testing.T) {
 			state:       &upgraded,
 			plan:        &basic,
 			configValue: types.StringNull(),
+			wantReplace: false,
+		},
+		{
+			// Converting in the same plan that upgrades the provider. The prior state is
+			// null exactly as in the backfill above, but the V4 API cannot promote a basic
+			// credential, so this must still replace.
+			name:        "legacy state converted to advanced replaces",
+			state:       &upgraded,
+			plan:        &advanced,
+			configValue: types.StringValue(credentialTypeAdvanced),
+			wantReplace: true,
+		},
+		{
+			// The mirror image: pinning the default explicitly while upgrading is not a
+			// change, so keying off "was it configured" instead of the planned value would
+			// destroy the credential here.
+			name:        "legacy state pinned to the default does not replace",
+			state:       &upgraded,
+			plan:        &basic,
+			configValue: types.StringValue(credentialTypeBasic),
 			wantReplace: false,
 		},
 		{

--- a/internal/resources/database_credential_test.go
+++ b/internal/resources/database_credential_test.go
@@ -212,19 +212,10 @@ func assertNoDiags(t *testing.T, diags diag.Diagnostics) {
 	}
 }
 
-// TestDatabaseCredentialTypeReplacement covers when a credential_type diff is allowed to
-// destroy and recreate the credential. The V4 API cannot convert a credential between
-// basic and advanced, so a practitioner-driven type change must still replace. An
-// attribute merely absent from an older state file must not: credential_type was added by
-// AV-124932, so every state a released provider wrote decodes it as null and the Default
-// then plans "basic" against that null. Under a plain RequiresReplace this destroyed and
-// recreated every existing credential on the first plan after the upgrade, regenerating
-// the auto-generated passwords applications were holding (AV-139981).
-//
-// A null prior state is not on its own proof of a backfill, so the legacy cases below pin
-// both readings of one: the practitioner may convert the credential in the same plan that
-// upgrades the provider, and may equally pin the default explicitly. Only the planned value
-// separates them.
+// TestDatabaseCredentialTypeReplacement pins when a credential_type diff replaces the
+// credential. The V4 API cannot convert between basic and advanced, so a real change must
+// replace, but the Default backfilling a state written before the attribute existed must not
+// (AV-139981). Only the planned value separates the two on a null prior state.
 func TestDatabaseCredentialTypeReplacement(t *testing.T) {
 	ctx := context.Background()
 	credentialSchema := DatabaseCredentialSchema()
@@ -240,22 +231,19 @@ func TestDatabaseCredentialTypeReplacement(t *testing.T) {
 	basic := managedCredentialState(credentialTypeBasic, nil, basicAccess)
 	advanced := managedCredentialState(credentialTypeAdvanced, advancedRoles, nil)
 
-	// The regression fixture: a basic credential as a released provider stored it, with no
-	// credential_type key at all. The planned value is the Default backfilling it.
+	// A basic credential as a released provider stored it: no credential_type key.
 	upgraded := managedCredentialState(credentialTypeBasic, nil, basicAccess)
 	upgraded.CredentialType = types.StringNull()
 
 	tests := []struct {
 		name string
-		// A nil state is a create and a nil plan is a destroy, both of which the framework
-		// signals with a null raw value rather than a null attribute.
+		// nil state means create, nil plan means destroy: both are a null raw value.
 		state       *providerschema.DatabaseCredential
 		plan        *providerschema.DatabaseCredential
 		configValue types.String
 		wantReplace bool
 	}{
 		{
-			// The regression. Nothing in the configuration changed.
 			name:        "upgrade backfills a state written before the attribute existed",
 			state:       &upgraded,
 			plan:        &basic,
@@ -263,9 +251,7 @@ func TestDatabaseCredentialTypeReplacement(t *testing.T) {
 			wantReplace: false,
 		},
 		{
-			// Converting in the same plan that upgrades the provider. The prior state is
-			// null exactly as in the backfill above, but the V4 API cannot promote a basic
-			// credential, so this must still replace.
+			// Prior state is null as in the backfill above, but this is a real change.
 			name:        "legacy state converted to advanced replaces",
 			state:       &upgraded,
 			plan:        &advanced,
@@ -273,9 +259,7 @@ func TestDatabaseCredentialTypeReplacement(t *testing.T) {
 			wantReplace: true,
 		},
 		{
-			// The mirror image: pinning the default explicitly while upgrading is not a
-			// change, so keying off "was it configured" instead of the planned value would
-			// destroy the credential here.
+			// Pinning the default while upgrading is not a change.
 			name:        "legacy state pinned to the default does not replace",
 			state:       &upgraded,
 			plan:        &basic,
@@ -297,8 +281,7 @@ func TestDatabaseCredentialTypeReplacement(t *testing.T) {
 			wantReplace: true,
 		},
 		{
-			// Dropping credential_type from an advanced credential's configuration falls
-			// back to the Default, which is still a real type change.
+			// A dropped credential_type falls back to the Default, still a real change.
 			name:        "advanced to basic replaces",
 			state:       &advanced,
 			plan:        &basic,
@@ -332,8 +315,7 @@ func TestDatabaseCredentialTypeReplacement(t *testing.T) {
 				ConfigValue: tc.configValue,
 			}
 
-			// Each modifier sees the plan value the previous one produced, matching
-			// fwserver.AttributeModifyPlan.
+			// Each modifier sees the previous one's plan value, as fwserver does.
 			var gotReplace bool
 			for _, modifier := range attribute.PlanModifiers {
 				resp := planmodifier.StringResponse{PlanValue: req.PlanValue}
@@ -348,11 +330,9 @@ func TestDatabaseCredentialTypeReplacement(t *testing.T) {
 	}
 }
 
-// credentialRawValue renders v as the whole-resource value the framework puts in a plan
-// modifier request. RequiresReplaceIf consults req.State.Raw and req.Plan.Raw before it
-// looks at any attribute value, so a request carrying only StateValue and PlanValue would
-// take the create branch and pass no matter what the modifier does. A nil v is that null
-// raw value: no prior state on create, no planned state on destroy.
+// credentialRawValue renders v as the whole-resource value a plan modifier request carries.
+// RequiresReplaceIf checks State.Raw and Plan.Raw before any attribute value, so a request
+// without them passes vacuously. A nil v is that null raw: create has no state, destroy no plan.
 func credentialRawValue(t *testing.T, ctx context.Context, s schema.Schema, v *providerschema.DatabaseCredential) tftypes.Value {
 	t.Helper()
 

--- a/internal/resources/database_credential_test.go
+++ b/internal/resources/database_credential_test.go
@@ -7,9 +7,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"gotest.tools/assert"
 
 	providerschema "github.com/couchbasecloud/terraform-provider-couchbase-capella/internal/schema"
@@ -206,4 +210,139 @@ func assertNoDiags(t *testing.T, diags diag.Diagnostics) {
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags.Errors())
 	}
+}
+
+// TestDatabaseCredentialTypeReplacement covers when a credential_type diff is allowed to
+// destroy and recreate the credential. The V4 API cannot convert a credential between
+// basic and advanced, so a practitioner-driven type change must still replace. An
+// attribute merely absent from an older state file must not: credential_type was added by
+// AV-124932, so every state a released provider wrote decodes it as null and the Default
+// then plans "basic" against that null. Under a plain RequiresReplace this destroyed and
+// recreated every existing credential on the first plan after the upgrade, regenerating
+// the auto-generated passwords applications were holding (AV-139981).
+func TestDatabaseCredentialTypeReplacement(t *testing.T) {
+	ctx := context.Background()
+	credentialSchema := DatabaseCredentialSchema()
+
+	attribute, ok := credentialSchema.Attributes["credential_type"].(*schema.StringAttribute)
+	if !ok {
+		t.Fatalf("credential_type is %T, want *schema.StringAttribute", credentialSchema.Attributes["credential_type"])
+	}
+
+	basicAccess := []providerschema.Access{{Privileges: []types.String{types.StringValue("read")}}}
+	advancedRoles := []types.String{types.StringValue(testUserRole)}
+
+	basic := managedCredentialState(credentialTypeBasic, nil, basicAccess)
+	advanced := managedCredentialState(credentialTypeAdvanced, advancedRoles, nil)
+
+	// The regression fixture: a basic credential as a released provider stored it, with no
+	// credential_type key at all. The planned value is the Default backfilling it.
+	upgraded := managedCredentialState(credentialTypeBasic, nil, basicAccess)
+	upgraded.CredentialType = types.StringNull()
+
+	tests := []struct {
+		name string
+		// A nil state is a create and a nil plan is a destroy, both of which the framework
+		// signals with a null raw value rather than a null attribute.
+		state       *providerschema.DatabaseCredential
+		plan        *providerschema.DatabaseCredential
+		configValue types.String
+		wantReplace bool
+	}{
+		{
+			// The regression. Nothing in the configuration changed.
+			name:        "upgrade backfills a state written before the attribute existed",
+			state:       &upgraded,
+			plan:        &basic,
+			configValue: types.StringNull(),
+			wantReplace: false,
+		},
+		{
+			name:        "an unchanged credential type is left alone",
+			state:       &basic,
+			plan:        &basic,
+			configValue: types.StringNull(),
+			wantReplace: false,
+		},
+		{
+			name:        "basic to advanced replaces",
+			state:       &basic,
+			plan:        &advanced,
+			configValue: types.StringValue(credentialTypeAdvanced),
+			wantReplace: true,
+		},
+		{
+			// Dropping credential_type from an advanced credential's configuration falls
+			// back to the Default, which is still a real type change.
+			name:        "advanced to basic replaces",
+			state:       &advanced,
+			plan:        &basic,
+			configValue: types.StringNull(),
+			wantReplace: true,
+		},
+		{
+			name:        "create does not replace",
+			state:       nil,
+			plan:        &basic,
+			configValue: types.StringNull(),
+			wantReplace: false,
+		},
+		{
+			name:        "destroy does not replace",
+			state:       &basic,
+			plan:        nil,
+			configValue: types.StringNull(),
+			wantReplace: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := planmodifier.StringRequest{
+				Path:        path.Root("credential_type"),
+				State:       tfsdk.State{Schema: credentialSchema, Raw: credentialRawValue(t, ctx, credentialSchema, tc.state)},
+				StateValue:  credentialTypeOf(tc.state),
+				Plan:        tfsdk.Plan{Schema: credentialSchema, Raw: credentialRawValue(t, ctx, credentialSchema, tc.plan)},
+				PlanValue:   credentialTypeOf(tc.plan),
+				ConfigValue: tc.configValue,
+			}
+
+			// Each modifier sees the plan value the previous one produced, matching
+			// fwserver.AttributeModifyPlan.
+			var gotReplace bool
+			for _, modifier := range attribute.PlanModifiers {
+				resp := planmodifier.StringResponse{PlanValue: req.PlanValue}
+				modifier.PlanModifyString(ctx, req, &resp)
+				req.PlanValue = resp.PlanValue
+				gotReplace = gotReplace || resp.RequiresReplace
+			}
+
+			assert.Equal(t, gotReplace, tc.wantReplace,
+				"credential_type replacement decision for %q", tc.name)
+		})
+	}
+}
+
+// credentialRawValue renders v as the whole-resource value the framework puts in a plan
+// modifier request. RequiresReplaceIf consults req.State.Raw and req.Plan.Raw before it
+// looks at any attribute value, so a request carrying only StateValue and PlanValue would
+// take the create branch and pass no matter what the modifier does. A nil v is that null
+// raw value: no prior state on create, no planned state on destroy.
+func credentialRawValue(t *testing.T, ctx context.Context, s schema.Schema, v *providerschema.DatabaseCredential) tftypes.Value {
+	t.Helper()
+
+	if v == nil {
+		return tftypes.NewValue(s.Type().TerraformType(ctx), nil)
+	}
+
+	state := tfsdk.State{Schema: s}
+	assertNoDiags(t, state.Set(ctx, *v))
+	return state.Raw
+}
+
+func credentialTypeOf(v *providerschema.DatabaseCredential) types.String {
+	if v == nil {
+		return types.StringNull()
+	}
+	return v.CredentialType
 }


### PR DESCRIPTION
## Jira

* AV-139981

## Description

`credential_type`, added to `couchbase-capella_database_credential` , is declared `Optional + Computed` with `Default("basic")` **and** `RequiresReplace`. Existing state has no `credential_type`, so the first `terraform plan` after upgrading destroys and recreates **every** database credential with no configuration change by the practitioner.

caught pre-merge — not present in any released version.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments