### PR TITLE
[AV-142522] Fix access validators left as list after Set/List revert merge

### DIFF
--- a/internal/resources/database_credential_schema.go
+++ b/internal/resources/database_credential_schema.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -79,9 +78,9 @@ func DatabaseCredentialSchema() schema.Schema {
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: accessAttrs,
 		},
-		Validators: []validator.List{
-			listvalidator.ExactlyOneOf(path.MatchRoot("user_roles")),
-			listvalidator.SizeAtLeast(1),
+		Validators: []validator.Set{
+			setvalidator.ExactlyOneOf(path.MatchRoot("user_roles")),
+			setvalidator.SizeAtLeast(1),
 		},
 	})
 


### PR DESCRIPTION
## Jira

* AV-142522

## Description

The feature branch does not compile, so every check fails:

internal/resources/database_credential_schema.go:82:15: cannot use []validator.List{…} as []validator.Set value in struct literal

`access` is a `schema.SetNestedAttribute`, whose `Validators` field is `[]validator.Set`, but it carried `listvalidator` validators.

The mismatch came from the merge of `main` into this branch (d8dd932). AV-139841 (#749) had moved `access`/`buckets`/`scopes`/`collections` to List types; AV-142331 (#772) reverted that on `main`. The merge resolved to `main`'s `SetNestedAttribute` while keeping this branch's `listvalidator.ExactlyOneOf` / `listvalidator.SizeAtLeast` calls — a combination neither side compiled in isolation.

Fix is three lines in `internal/resources/database_credential_schema.go`: swap the validator slice and its two constructors to their `Set` equivalents, and drop the now unused `listvalidator` import. This matches how `Set` attributes are validated elsewhere in the provider (`apikey_schema.go`, `user_schema.go`, `cluster_schema.go`).

Behaviour is unchanged. `setvalidator.ExactlyOneOf` and `setvalidator.SizeAtLeast` are semantically identical to their list counterparts, so the `access` / `user_roles` exactly-one rule and the rejection of `access = []` both still hold. `TestAccDatabaseCredentialEmptyAccess` asserts on `access.*must contain at least 1`, which the set wording still satisfies.

`go build ./...` across the module reported this as the only error.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [x] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments