### PR TITLE
[AV-142623] Match the 422 the API returns for a non-existent keyspace

### DIFF
--- a/acceptance_tests/database_role_negative_test.go
+++ b/acceptance_tests/database_role_negative_test.go
@@ -222,15 +222,18 @@ func TestAccDatabaseRoleEmptyPrivileges(t *testing.T) {
 	})
 }
 
-// TestAccDatabaseRoleNonExistentKeyspace covers a role naming a bucket, scope or
-// collection that is not present on the cluster. The V4 API answers each with a 400.
+
 func TestAccDatabaseRoleNonExistentKeyspace(t *testing.T) {
 	testCases := []struct {
 		name      string
 		accessHCL func() string
+		phrase    func() string
 	}{
 		{
 			name: "bucket",
+			phrase: func() string {
+				return "references bucket 'tf_acc_no_such_bucket', which does not exist on the cluster"
+			},
 			accessHCL: func() string {
 				return `[
     {
@@ -248,6 +251,11 @@ func TestAccDatabaseRoleNonExistentKeyspace(t *testing.T) {
 		},
 		{
 			name: "scope",
+			phrase: func() string {
+				return fmt.Sprintf(
+					"references scope 'tf_acc_no_such_scope' in bucket '%s', which does not exist on the cluster",
+					globalBucketName)
+			},
 			accessHCL: func() string {
 				return fmt.Sprintf(`[
     {
@@ -270,6 +278,11 @@ func TestAccDatabaseRoleNonExistentKeyspace(t *testing.T) {
 		},
 		{
 			name: "collection",
+			phrase: func() string {
+				return fmt.Sprintf(
+					"references collection 'tf_acc_no_such_collection' in scope '%s' of bucket '%s', which does not exist on the cluster",
+					globalScopeName, globalBucketName)
+			},
 			accessHCL: func() string {
 				return fmt.Sprintf(`[
     {
@@ -303,7 +316,7 @@ func TestAccDatabaseRoleNonExistentKeyspace(t *testing.T) {
 				Steps: []resource.TestStep{
 					{
 						Config:      testAccDatabaseRoleConfigAccess(resourceName, resourceName, "", tc.accessHCL()),
-						ExpectError: apiErrorPattern("Error creating database role", "Bad Request", "400"),
+						ExpectError: apiErrorPattern("Error creating database role", tc.phrase(), "422"),
 					},
 				},
 			})


### PR DESCRIPTION
## Jira

* [AV-142623](https://couchbasecloud.atlassian.net/browse/AV-142623)

## Description


All three subtests of `TestAccDatabaseRoleNonExistentKeyspace` (bucket, scope, collection) were failing on the assertion, not on provider behaviour.

The test asserted `apiErrorPattern("Error creating database role", "Bad Request", "400")`. Creating a database role that names a bucket, scope or collection absent from the cluster actually answers with a **422** whose message names the level that could not be resolved. Both halves of the expected pattern missed — the response contains neither `Bad Request` nor `"httpStatusCode":400`.

`acceptance_tests/database_role_negative_test.go` — added a `phrase func() string` per test case and switched the assertion to `apiErrorPattern("Error creating database role", tc.phrase(), "422")`.

| case | asserted phrase |
| --- | --- |
| bucket | `references bucket 'tf_acc_no_such_bucket', which does not exist on the cluster` |
| scope | `references scope 'tf_acc_no_such_scope' in bucket '<globalBucketName>', …` |
| collection | `references collection 'tf_acc_no_such_collection' in scope '<globalScopeName>' of bucket '<globalBucketName>', …` |

Per-case phrases rather than one shared 422 pattern: this endpoint answers several unrelated problems with a 422, and — more to the point — a scope typo misreported as a missing *bucket* would still pass a shared pattern. The scope and collection phrases go through `fmt.Sprintf` on the globals so they stay correct when the suite runs against a non-default bucket (`envVars.go` / `bucket.go` overwrite `globalBucketName`).


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments

[AV-142623]: https://couchbasecloud.atlassian.net/browse/AV-142623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ