### PR TITLE
[AV-142969] Fix three failing acceptance tests

### DIFF
--- a/acceptance_tests/cluster_acceptance_test.go
+++ b/acceptance_tests/cluster_acceptance_test.go
@@ -1037,6 +1037,14 @@ data "http" "cluster_info" {
   request_headers = {
     Authorization = "Bearer ${var.auth_token}"
   }
+
+  # Without this block the provider gives up after a single attempt, so a
+  # transient 429 or 5xx from the Capella API fails the whole test step.
+  retry {
+    attempts     = 5
+    min_delay_ms = 2000
+    max_delay_ms = 10000
+  }
 }
 
 resource "couchbase-capella_cluster" "%[4]s" {

--- a/acceptance_tests/eventing_function_acceptance_test.go
+++ b/acceptance_tests/eventing_function_acceptance_test.go
@@ -1986,9 +1986,7 @@ func TestAccEventingFunctionResourceUpdateKeyspacesUndeployed(t *testing.T) {
 	})
 }
 
-// TestAccEventingFunctionResourceRemoveDescription (TC-UP-Optional-Omit): clearing a set description should empty it on read; the fix lives in branch AV-136448-desc, so this is skipped until that merges.
 func TestAccEventingFunctionResourceRemoveDescription(t *testing.T) {
-
 	funcName := randomStringWithPrefix("tf_acc_evt_rm_desc_fn_")
 	funcReference := "couchbase-capella_eventing_function." + funcName
 
@@ -2001,7 +1999,7 @@ func TestAccEventingFunctionResourceRemoveDescription(t *testing.T) {
 			},
 			{
 				Config: testAccEventingFunctionResourceConfigMaybeDescription(funcName, "", "undeployed"),
-				Check:  resource.TestCheckResourceAttr(funcReference, "description", ""),
+				Check:  resource.TestCheckNoResourceAttr(funcReference, "description"),
 			},
 		},
 	})

--- a/acceptance_tests/user_acceptance_test.go
+++ b/acceptance_tests/user_acceptance_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccUserResource(t *testing.T) {
 	resourceName := randomStringWithPrefix("tf_acc_user_")
+	username := resourceName
 	resourceReference := "couchbase-capella_user." + resourceName
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -18,10 +19,10 @@ func TestAccUserResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read
 			{
-				Config: testAccUserResourceConfig(resourceName, "terraform_acceptance_test1"),
+				Config: testAccUserResourceConfig(resourceName, username),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceReference, "name", "terraform_acceptance_test1"),
-					resource.TestCheckResourceAttr(resourceReference, "email", "terraform_acceptance_test1@couchbase.com"),
+					resource.TestCheckResourceAttr(resourceReference, "name", username),
+					resource.TestCheckResourceAttr(resourceReference, "email", username+"@couchbase.com"),
 					resource.TestCheckResourceAttr(resourceReference, "organization_roles.0", "organizationOwner"),
 				),
 			},
@@ -34,10 +35,10 @@ func TestAccUserResource(t *testing.T) {
 			},
 			// Update and Read
 			{
-				Config: testAccUserResourceConfigUpdate(resourceName, "terraform_acceptance_test1"),
+				Config: testAccUserResourceConfigUpdate(resourceName, username),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceReference, "name", "terraform_acceptance_test1"),
-					resource.TestCheckResourceAttr(resourceReference, "email", "terraform_acceptance_test1@couchbase.com"),
+					resource.TestCheckResourceAttr(resourceReference, "name", username),
+					resource.TestCheckResourceAttr(resourceReference, "email", username+"@couchbase.com"),
 					resource.TestCheckResourceAttr(resourceReference, "organization_roles.0", "organizationMember"),
 					resource.TestCheckResourceAttr(resourceReference, "resources.0.type", "project"),
 					resource.TestCheckResourceAttr(resourceReference, "resources.0.roles.0", "projectViewer"),


### PR DESCRIPTION
## Jira

* [AV-142969](https://couchbasecloud.atlassian.net/browse/AV-142969)

## Description

Fixes three acceptance test failures. All three are defects in the tests, not in the provider.

**1. `TestAccUserResource` invited a hardcoded email** (failing since build #1663)

The test randomised the Terraform resource name but passed a literal username into the config, and `testAccUserResourceConfig` derives the email from that argument (`username+"@couchbase.com"`). Every run therefore invited the same user, `terraform_acceptance_test1@couchbase.com`, so once a run left that invite behind — an aborted CI job, a failed destroy — every later run got `code 8010 / 422 — This email has already been registered`. The error was misleading because the resource address in it *is* unique; only the email was not.

Fixed by using `resourceName` as the username, as the sibling `TestAccUserResourceWithProjectRoles` already does.

**2. `TestAccClusterResourceWithOnlyReqFieldAWS` gave up on the first retryable status**

The step reads the cluster `Etag` header through `data "http" "cluster_info"` to feed `if_match`. The block declared no `retry`, so `RetryMax` was 0.

`go-retryablehttp` omits the trailing `: <cause>` from its give-up error when the request completed but `CheckRetry` rejected the response *status* ([client.go:837-842](https://github.com/hashicorp/go-retryablehttp/blob/v0.7.8/client.go#L837-L842)). The failure showed that form, so this was not a transport, DNS, TLS or auth problem — Capella answered with a 429 or a 5xx other than 501. The block is read four times per run (plan, apply, post-apply plan, post-apply refresh plan) and the test is parallel against a shared sandbox org, so a 429 is the likely status.

Fixed by adding a `retry` block (5 attempts, 2s–10s backoff).

**3. `TestAccEventingFunctionResourceRemoveDescription` asserted the wrong absence**

`testAccEventingFunctionResourceConfigMaybeDescription` omits the `description` line from the generated HCL entirely when passed `""`, so after the removal step the attribute is absent from state rather than set to `""`. Fixed by asserting `TestCheckNoResourceAttr`, and dropped a stale comment claiming the test was skipped pending branch `AV-136448-desc` (no matching `t.Skip` existed).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [ ] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [x] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>

Static checks only — `gofmt -l` clean on all three files, `go vet ./acceptance_tests/` clean.

The acceptance tests themselves have **not** been run against a sandbox from this branch; no Capella credentials were available in the authoring environment. They need a run before merge:

```
TF_ACC=1 go test ./acceptance_tests/ -run 'TestAccUserResource$|TestAccClusterResourceWithOnlyReqFieldAWS|TestAccEventingFunctionResourceRemoveDescription' -timeout 2h
```

</details>

## Further comments


🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AV-142969]: https://couchbasecloud.atlassian.net/browse/AV-142969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ