### PR TITLE
[AV-128229] Fix disabling App Endpoint CORS when other CORS fields are set

### DIFF
--- a/acceptance_tests/app_endpoint_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_acceptance_test.go
@@ -484,7 +484,6 @@ func TestAccAppEndpointUpdateCorsExpand(t *testing.T) {
 // Once cors is set, the API rejects any PUT that omits the cors body entirely.
 // cors is effectively write-once via Terraform.
 func TestAccAppEndpointUpdateRemoveCors(t *testing.T) {
-	t.Skip("AV-128229 / AV-128217: removing the cors block after it is set should succeed once the bugs are fixed")
 	ensureFixtureCollection(t, globalRemoveCorsEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
@@ -505,13 +504,12 @@ func TestAccAppEndpointUpdateRemoveCors(t *testing.T) {
 	})
 }
 
-// ── U3: cors.disabled false → true — API 409 "CORS cannot be disabled, config not empty" ──
-// The API rejects disabling CORS when other cors fields (origin etc.) are also set.
-func TestAccAppEndpointUpdateCorsDisableToggle(t *testing.T) {
-	t.Skip("AV-128229: toggling cors.disabled=true while other CORS fields are set should succeed once the bug is fixed")
+
+func TestAccAppEndpoint_AV_128229(t *testing.T) {
 	ensureFixtureCollection(t, globalCorsDisableToggleEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
+	resourceReference := "couchbase-capella_app_endpoint." + resourceName
 	epName := randomStringWithPrefix("tf_acc_endpoint_")
 
 	t.Parallel()
@@ -519,11 +517,40 @@ func TestAccAppEndpointUpdateCorsDisableToggle(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: globalProtoV6ProviderFactory,
 		Steps: []resource.TestStep{
+			// Phase 1: CORS enabled with every attribute populated.
 			{
-				Config: testAccAppEndpointCorsOriginOnlyResourceConfig(resourceName, epName, globalCorsDisableToggleEPCollectionName),
+				Config: testAccAppEndpointCorsAllFieldsResourceConfig(resourceName, epName, globalCorsDisableToggleEPCollectionName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAppEndpointComputedAttrs(resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "cors.disabled", "false"),
+					resource.TestCheckResourceAttr(resourceReference, "cors.max_age", "3600"),
+					resource.TestCheckTypeSetElemAttr(resourceReference, "cors.origin.*", "*"),
+				),
 			},
+			// Disabling CORS while origin is still set must fail provider validation rather than
+			// reaching the API and returning a 409.
 			{
-				Config: testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, epName, globalCorsDisableToggleEPCollectionName),
+				Config:      testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, epName, globalCorsDisableToggleEPCollectionName),
+				ExpectError: re.MustCompile(`(?s).*cors\.origin.*when cors\.disabled is true.*`),
+			},
+			// Phase 2: dropping the other CORS attributes disables CORS, and the max_age from
+			// phase 1 is not carried into the update.
+			{
+				Config: testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, epName, globalCorsDisableToggleEPCollectionName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAppEndpointComputedAttrs(resourceReference),
+					resource.TestCheckResourceAttr(resourceReference, "cors.disabled", "true"),
+					resource.TestCheckResourceAttr(resourceReference, "cors.max_age", "0"),
+					resource.TestCheckNoResourceAttr(resourceReference, "cors.origin.#"),
+					resource.TestCheckNoResourceAttr(resourceReference, "cors.login_origin.#"),
+					resource.TestCheckNoResourceAttr(resourceReference, "cors.headers.#"),
+				),
+			},
+			// Re-apply the disabled config; expect no changes (no perpetual drift).
+			{
+				Config:             testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, epName, globalCorsDisableToggleEPCollectionName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -789,7 +816,8 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 }
 
 // testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig creates an endpoint with
-// cors { disabled=true } and no origin field. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin.
+// cors { disabled=true } and no origin field.
+// Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin, TestAccAppEndpoint_AV_128229.
 func testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -1178,8 +1206,9 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	)
 }
 
-// testAccAppEndpointCorsDisabledTrueResourceConfig creates an endpoint with
-// cors.disabled=true. Used by: TestAccAppEndpointUpdateCorsDisableToggle (U3 phase 2, skipped).
+// testAccAppEndpointCorsDisabledTrueResourceConfig creates an endpoint with cors.disabled=true
+// alongside cors.origin, a combination the API rejects.
+// Used by: TestAccAppEndpoint_AV_128229.
 func testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/acceptance_tests/app_endpoint_acceptance_test.go
+++ b/acceptance_tests/app_endpoint_acceptance_test.go
@@ -505,7 +505,7 @@ func TestAccAppEndpointUpdateRemoveCors(t *testing.T) {
 }
 
 
-func TestAccAppEndpoint_AV_128229(t *testing.T) {
+func TestAccAppEndpointUpdateCorsDisableToggle(t *testing.T) {
 	ensureFixtureCollection(t, globalCorsDisableToggleEPCollectionName)
 
 	resourceName := randomStringWithPrefix("tf_acc_app_endpoint_")
@@ -816,8 +816,7 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 }
 
 // testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig creates an endpoint with
-// cors { disabled=true } and no origin field.
-// Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin, TestAccAppEndpoint_AV_128229.
+// cors { disabled=true } and no origin field. Used by: TestAccAppEndpointCorsDisabledFalseNoOrigin.
 func testAccAppEndpointCorsDisabledTrueNoOriginResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -1206,9 +1205,6 @@ resource "couchbase-capella_app_endpoint" "%[2]s" {
 	)
 }
 
-// testAccAppEndpointCorsDisabledTrueResourceConfig creates an endpoint with cors.disabled=true
-// alongside cors.origin, a combination the API rejects.
-// Used by: TestAccAppEndpoint_AV_128229.
 func testAccAppEndpointCorsDisabledTrueResourceConfig(resourceName, endpointName, collectionName string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/internal/resources/app_endpoint.go
+++ b/internal/resources/app_endpoint.go
@@ -57,8 +57,6 @@ func (a *AppEndpoint) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 	resp.Schema = AppEndpointSchema()
 }
 
-// ValidateConfig enforces the CORS rules of the App Endpoint API: origins are required while CORS
-// is enabled, and no other CORS attribute may carry a value once CORS is disabled.
 func (a *AppEndpoint) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var config providerschema.AppEndpoint
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
@@ -126,10 +124,6 @@ func validateDisabledCors(cors *providerschema.AppEndpointCors, resp *resource.V
 	}
 }
 
-// ModifyPlan plans cors.max_age as 0 whenever CORS is disabled. max_age is computed and uses
-// UseStateForUnknown, so an unconfigured max_age would otherwise be planned as the value from
-// before CORS was disabled: the API rejects a disable request that still carries a max age, and
-// reports max_age as 0 once CORS is disabled.
 func (a *AppEndpoint) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	// The plan is null when the resource is being destroyed.
 	if req.Plan.Raw.IsNull() {
@@ -504,9 +498,6 @@ func (a *AppEndpoint) Update(ctx context.Context, req resource.UpdateRequest, re
 	resp.Diagnostics.Append(diags...)
 }
 
-// preserveDisabledCorsAttributes keeps the configured CORS lists in state when CORS is disabled.
-// A disabled App Endpoint reports an empty CORS configuration regardless of what was sent, so
-// reading the remote values back would report a change away from the configuration.
 func preserveDisabledCorsAttributes(config *providerschema.AppEndpoint, state *providerschema.AppEndpoint) {
 	if config.Cors == nil || state.Cors == nil {
 		return

--- a/internal/resources/app_endpoint.go
+++ b/internal/resources/app_endpoint.go
@@ -26,6 +26,7 @@ var (
 	_ resource.Resource                   = &AppEndpoint{}
 	_ resource.ResourceWithConfigure      = &AppEndpoint{}
 	_ resource.ResourceWithImportState    = &AppEndpoint{}
+	_ resource.ResourceWithModifyPlan     = &AppEndpoint{}
 	_ resource.ResourceWithValidateConfig = &AppEndpoint{}
 )
 
@@ -56,7 +57,8 @@ func (a *AppEndpoint) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 	resp.Schema = AppEndpointSchema()
 }
 
-// ValidateConfig enforces that CORS origins are configured unless CORS is explicitly disabled.
+// ValidateConfig enforces the CORS rules of the App Endpoint API: origins are required while CORS
+// is enabled, and no other CORS attribute may carry a value once CORS is disabled.
 func (a *AppEndpoint) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var config providerschema.AppEndpoint
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
@@ -73,7 +75,8 @@ func (a *AppEndpoint) ValidateConfig(ctx context.Context, req resource.ValidateC
 		return
 	}
 
-	if !config.Cors.Disabled.IsNull() && !config.Cors.Disabled.IsUnknown() && config.Cors.Disabled.ValueBool() {
+	if !config.Cors.Disabled.IsNull() && config.Cors.Disabled.ValueBool() {
+		validateDisabledCors(config.Cors, resp)
 		return
 	}
 
@@ -89,6 +92,65 @@ func (a *AppEndpoint) ValidateConfig(ctx context.Context, req resource.ValidateC
 			"Expected cors.origin to be configured with at least 1 value when cors.disabled is not true.",
 		)
 	}
+}
+
+func validateDisabledCors(cors *providerschema.AppEndpointCors, resp *resource.ValidateConfigResponse) {
+	const conflictDetail = "Expected cors.%s to be %s when cors.disabled is true. " +
+		"The App Endpoint API discards the CORS configuration when CORS is disabled and rejects a request that still specifies one."
+
+	for _, attribute := range []struct {
+		name  string
+		value types.Set
+	}{
+		{"origin", cors.Origin},
+		{"login_origin", cors.LoginOrigin},
+		{"headers", cors.Headers},
+	} {
+		if attribute.value.IsNull() || attribute.value.IsUnknown() || len(attribute.value.Elements()) == 0 {
+			continue
+		}
+
+		resp.Diagnostics.AddAttributeError(
+			path.Root("cors").AtName(attribute.name),
+			"Invalid Attribute Combination",
+			fmt.Sprintf(conflictDetail, attribute.name, "empty or unset"),
+		)
+	}
+
+	if !cors.MaxAge.IsNull() && !cors.MaxAge.IsUnknown() && cors.MaxAge.ValueInt64() != 0 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("cors").AtName("max_age"),
+			"Invalid Attribute Combination",
+			fmt.Sprintf(conflictDetail, "max_age", "0 or unset"),
+		)
+	}
+}
+
+// ModifyPlan plans cors.max_age as 0 whenever CORS is disabled. max_age is computed and uses
+// UseStateForUnknown, so an unconfigured max_age would otherwise be planned as the value from
+// before CORS was disabled: the API rejects a disable request that still carries a max age, and
+// reports max_age as 0 once CORS is disabled.
+func (a *AppEndpoint) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// The plan is null when the resource is being destroyed.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan providerschema.AppEndpoint
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() || plan.Cors == nil {
+		return
+	}
+
+	if plan.Cors.Disabled.IsNull() || plan.Cors.Disabled.IsUnknown() || !plan.Cors.Disabled.ValueBool() {
+		return
+	}
+
+	if plan.Cors.MaxAge.Equal(types.Int64Value(0)) {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("cors").AtName("max_age"), types.Int64Value(0))...)
 }
 
 // Create creates a new App Endpoint.
@@ -170,7 +232,7 @@ func (a *AppEndpoint) Create(ctx context.Context, req resource.CreateRequest, re
 	if plan.Cors == nil {
 		state.Cors = nil
 	} else {
-		preserveDisabledCorsOrigin(&plan, state)
+		preserveDisabledCorsAttributes(&plan, state)
 	}
 
 	diags = resp.State.Set(ctx, state)
@@ -360,7 +422,7 @@ func (a *AppEndpoint) Read(ctx context.Context, req resource.ReadRequest, resp *
 	if state.Cors == nil && !isImport {
 		newstate.Cors = nil
 	} else if !isImport {
-		preserveDisabledCorsOrigin(&state, newstate)
+		preserveDisabledCorsAttributes(&state, newstate)
 	}
 
 	diags = resp.State.Set(ctx, newstate)
@@ -436,14 +498,16 @@ func (a *AppEndpoint) Update(ctx context.Context, req resource.UpdateRequest, re
 	if plan.Cors == nil {
 		refreshedState.Cors = nil
 	} else {
-		preserveDisabledCorsOrigin(&plan, refreshedState)
+		preserveDisabledCorsAttributes(&plan, refreshedState)
 	}
 	diags = resp.State.Set(ctx, refreshedState)
 	resp.Diagnostics.Append(diags...)
 }
 
-// preserveDisabledCorsOrigin keeps omitted origin absent from state when CORS is disabled.
-func preserveDisabledCorsOrigin(config *providerschema.AppEndpoint, state *providerschema.AppEndpoint) {
+// preserveDisabledCorsAttributes keeps the configured CORS lists in state when CORS is disabled.
+// A disabled App Endpoint reports an empty CORS configuration regardless of what was sent, so
+// reading the remote values back would report a change away from the configuration.
+func preserveDisabledCorsAttributes(config *providerschema.AppEndpoint, state *providerschema.AppEndpoint) {
 	if config.Cors == nil || state.Cors == nil {
 		return
 	}
@@ -452,9 +516,9 @@ func preserveDisabledCorsOrigin(config *providerschema.AppEndpoint, state *provi
 		return
 	}
 
-	if config.Cors.Origin.IsNull() {
-		state.Cors.Origin = types.SetNull(types.StringType)
-	}
+	state.Cors.Origin = config.Cors.Origin
+	state.Cors.LoginOrigin = config.Cors.LoginOrigin
+	state.Cors.Headers = config.Cors.Headers
 }
 
 // Delete deletes an existing App Endpoint.


### PR DESCRIPTION
## Jira

* [AV-128229](https://jira.issues.couchbase.com/browse/AV-128229)

## Description

Fixes [AV-128229](https://jira.issues.couchbase.com/browse/AV-128229): updating `cors.disabled` from `false` to `true` on `couchbase-capella_app_endpoint` failed with `API 409: "App Endpoint CORS cannot be disabled, config is not empty"`.

**Root Cause**

The API-side rule is `validateCORSConfig` in `couchbase-cloud` (`internal/syncgateways/sg.go`), which rejects `disabled = true` when `origin`, `loginOrigin` or `maxAge` carry values. A disabled App Endpoint is reported back as just `{"disabled": true, "origin": []}`. The constraint is documented in the spec and already surfaced in `docs/resources/app_endpoint.md`: *"When true, no other CORS configuration properties should be provided."*

Two provider gaps let the 409 reach users:

1. **Nothing validated the combination.** `cors.disabled = true` alongside `origin`, `login_origin`, `headers` or `max_age` went straight to the API as an opaque 409.
2. **A correct configuration failed too.** `cors.max_age` is Optional + Computed with `UseStateForUnknown`, so an unset `max_age` was planned as the value from *before* CORS was disabled. Dropping `origin` and setting `cors.disabled = true` still sent `maxAge: 3600` and hit the same 409, with nothing in the configuration to point at.

**Changes**

`internal/resources/app_endpoint.go`:

- **`validateDisabledCors`** — plan-time error naming the offending attribute when it is combined with `cors.disabled = true`. `headers` is included: the API accepts it but discards it, which would otherwise become silent drift.
- **`ModifyPlan`** — plans `cors.max_age` as `0` whenever CORS is disabled, so `UseStateForUnknown` cannot carry a stale max age into the disable request or into state.
- **`preserveDisabledCorsAttributes`** — generalizes the previous origin-only helper to `login_origin` and `headers`, and preserves an explicitly empty set (`origin = []`) rather than only a null one.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [x] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
</details>

## Further comments

[AV-128229]: https://couchbasecloud.atlassian.net/browse/AV-128229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ