### PR TITLE
[AV-143040] Fix Azure disk autoexpansion default when unset

### DIFF
--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -710,7 +710,7 @@ func (c *Cluster) morphToApiServiceGroups(plan providerschema.Cluster) ([]cluste
 				}
 			}
 
-			if serviceGroup.Node != nil && !serviceGroup.Node.Disk.Autoexpansion.IsNull() {
+			if serviceGroup.Node != nil && !serviceGroup.Node.Disk.Autoexpansion.IsNull() && !serviceGroup.Node.Disk.Autoexpansion.IsUnknown() {
 				autoexpansion := serviceGroup.Node.Disk.Autoexpansion.ValueBool()
 				diskAzure.Autoexpansion = &autoexpansion
 			}


### PR DESCRIPTION
<!-- REMINDER: All testing and verification for your change should be completed within localdev or a sandbox environment.
ONLY MERGE INTO MAIN IF CHANGES ARE TESTED, VERIFIED AND QUALITY CHECKED THOROUGHLY

Merging to main == merging to PRODUCTION.
-->

## Jira

* AV-143040

## Description

Add an IsUnknown() check alongside the existing IsNull() check in internal/resources/cluster.go before reading Autoexpansion.ValueBool(), so an omitted attribute is left out of the request entirely and  Capella's default applies.
<!-- What does this change do? Why is it needed? -->

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change updates the ci/cd workflow.
- [ ] Documentation fix/enhancement.

## Manual Testing Approach

### How was this change tested and do you have evidence? _**(REQUIRED: Select at least 1)**_

- [X] Manually tested
- [ ] Unit tested
- [ ] Acceptance tested
- [ ] Unable to test / will not test (Please provide comments in section below)

### Testing

<details open>
  <summary>Testing</summary>
  <!-- Provide your testing proof within this collapsible segment-->
Below is the video of apply a terraform file with no specification of auto storage expansion and it is working as expected, i.e the cluster having the auto expansion settings as true.

https://github.com/user-attachments/assets/c28edffb-8da6-4e40-82f1-0acef5ddf6d8


</details>

## Further comments